### PR TITLE
Add EKS Helm Repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ commands:
             mv linux-amd64/helm /usr/local/bin/helm
             helm repo add bitnami https://charts.bitnami.com/bitnami
             helm repo add traefik https://helm.traefik.io/traefik
+            helm repo add eks https://aws.github.io/eks-charts
       - run:
           name: install pulumi plugin resources
           command: |


### PR DESCRIPTION
Add EKS helm repo during CI so that we can use AWS node termination handler helm chart. 