### PR TITLE
Identify tokens by chain_network_contract

### DIFF
--- a/coinstacks/bitcoin/ingester/src/parseTx/index.ts
+++ b/coinstacks/bitcoin/ingester/src/parseTx/index.ts
@@ -3,11 +3,14 @@ import { Tx, Vin, Vout } from '@shapeshiftoss/blockbook'
 import { TxTransfer, Token } from '@shapeshiftoss/common-ingester'
 import { BTCParseTx } from '../types'
 
+const NODE_ENV = process.env.NODE_ENV
 const COINSTACK = process.env.COINSTACK
-const NETWORK = 'MAINNET' //process.env.NETWORK
+const NETWORK = process.env.NETWORK
 
-if (!COINSTACK) throw new Error('COINSTACK env var not set')
-if (!NETWORK) throw new Error('NETWORK env var not set')
+if (NODE_ENV !== 'test') {
+  if (!COINSTACK) throw new Error('COINSTACK env var not set')
+  if (!NETWORK) throw new Error('NETWORK env var not set')
+}
 
 const nativeToken = `${COINSTACK}_${NETWORK}`
 

--- a/coinstacks/bitcoin/ingester/src/parseTx/index.ts
+++ b/coinstacks/bitcoin/ingester/src/parseTx/index.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { Tx, Vin, Vout } from '@shapeshiftoss/blockbook'
-import { TxTransfer, Token, TxFee } from '@shapeshiftoss/common-ingester'
+import { TxTransfer, Token } from '@shapeshiftoss/common-ingester'
 import { BTCParseTx } from '../types'
 
 const NODE_ENV = process.env.NODE_ENV
@@ -39,12 +39,12 @@ export const parseTx = async (tx: Tx, address: string): Promise<BTCParseTx> => {
       // send amount
       const sendValue = new BigNumber(vin.value ?? 0)
       if (!sendValue.isNaN() && sendValue.gt(0)) {
-        pTx.send['BTC'] = aggregateTransfer(pTx.send['BTC'], sendValue.toString(10))
+        pTx.send[nativeAssetId] = aggregateTransfer(pTx.send[nativeAssetId], sendValue.toString(10))
 
         // network fee (only for sends)
         const fees = new BigNumber(tx.fees ?? 0)
         if (!fees.isNaN() && fees.gt(0)) {
-          pTx.fee = { symbol: 'BTC', value: fees.toString(10) }
+          pTx.fee = { assetId: nativeAssetId, value: fees.toString(10) }
         }
       }
     }
@@ -55,7 +55,7 @@ export const parseTx = async (tx: Tx, address: string): Promise<BTCParseTx> => {
       // receive amount
       const receiveValue = new BigNumber(vout.value ?? 0)
       if (!receiveValue.isNaN() && receiveValue.gt(0)) {
-        pTx.receive['BTC'] = aggregateTransfer(pTx.receive['BTC'], receiveValue.toString(10))
+        pTx.receive[nativeAssetId] = aggregateTransfer(pTx.receive[nativeAssetId], receiveValue.toString(10))
       }
     }
   })

--- a/coinstacks/bitcoin/ingester/src/parseTx/index.ts
+++ b/coinstacks/bitcoin/ingester/src/parseTx/index.ts
@@ -3,6 +3,14 @@ import { Tx, Vin, Vout } from '@shapeshiftoss/blockbook'
 import { TxTransfer, Token } from '@shapeshiftoss/common-ingester'
 import { BTCParseTx } from '../types'
 
+const COINSTACK = process.env.COINSTACK
+const NETWORK = 'MAINNET' //process.env.NETWORK
+
+if (!COINSTACK) throw new Error('COINSTACK env var not set')
+if (!NETWORK) throw new Error('NETWORK env var not set')
+
+const nativeToken = `${COINSTACK}_${NETWORK}`
+
 // keep track of all individual tx components and add up the total value transferred
 const aggregateTransfer = (transfer: TxTransfer, value: string, token?: Token): TxTransfer => {
   if (transfer) {
@@ -28,12 +36,12 @@ export const parseTx = async (tx: Tx, address: string): Promise<BTCParseTx> => {
     if (vin.isAddress === true && vin.addresses?.includes(pTx.address)) {
       const sendValue = new BigNumber(vin.value ?? 0)
       if (!sendValue.isNaN() && sendValue.gt(0)) {
-        pTx.send['BTC'] = aggregateTransfer(pTx.send['BTC'], vin.value ?? '0')
+        pTx.send[nativeToken] = aggregateTransfer(pTx.send[nativeToken], vin.value ?? '0')
 
         // network fee (only for sends)
         const fees = new BigNumber(tx.fees ?? 0)
         if (tx.fees && !fees.isNaN() && fees.gt(0)) {
-          pTx.fee = { symbol: 'BTC', value: tx.fees }
+          pTx.fee = { assetId: nativeToken, value: tx.fees }
         }
       }
     }
@@ -44,7 +52,7 @@ export const parseTx = async (tx: Tx, address: string): Promise<BTCParseTx> => {
     if (vout.isAddress === true && vout.addresses?.includes(pTx.address)) {
       const receiveValue = new BigNumber(vout.value ?? 0)
       if (!receiveValue.isNaN() && receiveValue.gt(0)) {
-        pTx.receive['BTC'] = aggregateTransfer(pTx.receive['BTC'], vout.value ?? '0')
+        pTx.receive[nativeToken] = aggregateTransfer(pTx.receive[nativeToken], vout.value ?? '0')
       }
     }
   })

--- a/coinstacks/bitcoin/ingester/src/parseTx/index.ts
+++ b/coinstacks/bitcoin/ingester/src/parseTx/index.ts
@@ -4,12 +4,15 @@ import { TxTransfer, Token } from '@shapeshiftoss/common-ingester'
 import { BTCParseTx } from '../types'
 
 const NODE_ENV = process.env.NODE_ENV
-const COINSTACK = process.env.COINSTACK
-const NETWORK = process.env.NETWORK
+let COINSTACK = process.env.COINSTACK
+let NETWORK = process.env.NETWORK
 
 if (NODE_ENV !== 'test') {
   if (!COINSTACK) throw new Error('COINSTACK env var not set')
   if (!NETWORK) throw new Error('NETWORK env var not set')
+} else {
+  COINSTACK = 'ethereum'
+  NETWORK = 'MAINNET'
 }
 
 const nativeAssetId = `${COINSTACK}_${NETWORK}`

--- a/coinstacks/common/ingester/src/types.ts
+++ b/coinstacks/common/ingester/src/types.ts
@@ -95,6 +95,7 @@ export interface Token {
   contract: string
   decimals: number
   name: string
+  symbol: string
 }
 
 // Contains data about a dex trade

--- a/coinstacks/common/ingester/src/types.ts
+++ b/coinstacks/common/ingester/src/types.ts
@@ -118,7 +118,7 @@ export type TransactionType = 'receive' | 'send' | 'fee'
 
 // Contains data about the transaction fee
 export interface TxFee {
-  symbol: string
+  assetId: string
   value: string
 }
 

--- a/coinstacks/ethereum/ingester/src/__tests__/parseTx.test.ts
+++ b/coinstacks/ethereum/ingester/src/__tests__/parseTx.test.ts
@@ -21,6 +21,10 @@ import foxExit from './__mocks__/foxExit'
 
 jest.mock('@shapeshiftoss/thorchain')
 
+const COINSTACK = 'ethereum'
+const NETWORK = 'MAINNET'
+const nativeToken = `${COINSTACK}_${NETWORK}`
+
 describe('parseTx', () => {
   describe('multiSig', () => {
     it('should be able to parse eth multi sig send', async () => {
@@ -32,7 +36,7 @@ describe('parseTx', () => {
         address: address,
         send: {},
         receive: {
-          ETH: {
+          [nativeToken]: {
             totalValue: '1201235000000000000',
             components: [{ value: '1201235000000000000' }],
           },
@@ -64,11 +68,11 @@ describe('parseTx', () => {
         ...tx,
         address: address,
         fee: {
-          symbol: 'ETH',
+          assetId: nativeToken,
           value: '1700235000000000',
         },
         send: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '295040000000000000',
             components: [{ value: '295040000000000000' }],
           },
@@ -99,17 +103,18 @@ describe('parseTx', () => {
         contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         decimals: 6,
         name: 'USD Coin',
+        symbol: 'USDC',
       }
-
+      const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
-          symbol: 'ETH',
+          assetId: nativeToken,
           value: '4700280000000000',
         },
         send: {
-          USDC: {
+          [usdcAssetId]: {
             totalValue: '16598881497',
             components: [{ value: '16598881497' }],
             token: usdcToken,
@@ -147,7 +152,7 @@ describe('parseTx', () => {
         address: address,
         send: {},
         receive: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '1579727090000000000',
             components: [{ value: '1579727090000000000' }],
           },
@@ -181,14 +186,15 @@ describe('parseTx', () => {
         contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         decimals: 6,
         name: 'USD Coin',
+        symbol: 'USDC',
       }
-
+      const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
       const expected: ParseTx = {
         ...tx,
         address: address,
         send: {},
         receive: {
-          USDC: {
+          [usdcAssetId]: {
             totalValue: '47596471640',
             components: [{ value: '47596471640' }],
             token: usdcToken,
@@ -224,7 +230,7 @@ describe('parseTx', () => {
         address: address,
         send: {},
         receive: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '6412730000000000',
             components: [{ value: '6412730000000000' }],
           },
@@ -255,24 +261,27 @@ describe('parseTx', () => {
         contract: '0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B',
         decimals: 18,
         name: 'Tribe',
+        symbol: 'TRIBE',
       }
+
+      const assetId = `${COINSTACK}_${NETWORK}_${tribeToken.contract}`
 
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '8308480000000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          TRIBE: {
+          [assetId]: {
             totalValue: '1000000000000000000000',
             components: [{ value: '1000000000000000000000' }],
             token: tribeToken,
           },
         },
         receive: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '541566754246167133',
             components: [{ value: '541566754246167133' }],
           },
@@ -301,23 +310,25 @@ describe('parseTx', () => {
         contract: '0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0',
         decimals: 18,
         name: 'Matic Token',
+        symbol: 'MATIC',
       }
 
+      const assetId = `${COINSTACK}_${NETWORK}_${maticToken.contract}`
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '19815285000000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '10000000000000000000',
             components: [{ value: '10000000000000000000' }],
           },
         },
         receive: {
-          MATIC: {
+          [assetId]: {
             totalValue: '50000000000000000000000',
             components: [{ value: '50000000000000000000000' }],
             token: maticToken,
@@ -347,29 +358,34 @@ describe('parseTx', () => {
         contract: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
         decimals: 6,
         name: 'Tether USD',
+        symbol: 'USDT',
       }
+      const usdtAssetId = `${COINSTACK}_${NETWORK}_${usdtToken.contract}`
+
       const kishuToken = {
         contract: '0xA2b4C0Af19cC16a6CfAcCe81F192B024d625817D',
         decimals: 9,
         name: 'Kishu Inu',
+        symbol: 'KISHU',
       }
+      const kishuAssetId = `${COINSTACK}_${NETWORK}_${kishuToken.contract}`
 
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '78183644000000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          USDT: {
+          [usdtAssetId]: {
             totalValue: '45000000000',
             components: [{ value: '45000000000' }],
             token: usdtToken,
           },
         },
         receive: {
-          KISHU: {
+          [kishuAssetId]: {
             totalValue: '9248567698016204727450',
             components: [{ value: '9248567698016204727450' }],
             token: kishuToken,
@@ -399,29 +415,33 @@ describe('parseTx', () => {
         contract: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
         decimals: 18,
         name: 'Uniswap',
+        symbol: 'UNI',
       }
+      const uniAssetId = `${COINSTACK}_${NETWORK}_${uniToken.contract}`
       const bondToken = {
         contract: '0x0391D2021f89DC339F60Fff84546EA23E337750f',
         decimals: 18,
         name: 'BarnBridge Governance Token',
+        symbol: 'BOND',
       }
+      const bondAssetId = `${COINSTACK}_${NETWORK}_${bondToken.contract}`
 
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '18399681000000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          BOND: {
+          [bondAssetId]: {
             totalValue: '100000000000000000000',
             components: [{ value: '53910224825217010944' }, { value: '46089775174782989056' }],
             token: bondToken,
           },
         },
         receive: {
-          UNI: {
+          [uniAssetId]: {
             totalValue: '104088257588936074249',
             components: [{ value: '56639587020747520629' }, { value: '47448670568188553620' }],
             token: uniToken,
@@ -445,13 +465,13 @@ describe('parseTx', () => {
         ...txMempool,
         address: address,
         send: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
         },
         receive: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -472,16 +492,16 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '399000000000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
         },
         receive: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -500,20 +520,22 @@ describe('parseTx', () => {
         contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         decimals: 6,
         name: 'USD Coin',
+        symbol: 'USDC',
       }
+      const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
 
       const expected: ParseTx = {
         ...txMempool,
         address: address,
         send: {
-          USDC: {
+          [usdcAssetId]: {
             totalValue: '1502080',
             components: [{ value: '1502080' }],
             token: usdcToken,
           },
         },
         receive: {
-          USDC: {
+          [usdcAssetId]: {
             totalValue: '1502080',
             components: [{ value: '1502080' }],
             token: usdcToken,
@@ -533,24 +555,26 @@ describe('parseTx', () => {
         contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         decimals: 6,
         name: 'USD Coin',
+        symbol: 'USDC',
       }
+      const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
 
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '1011738000000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          USDC: {
+          [usdcAssetId]: {
             totalValue: '1502080',
             components: [{ value: '1502080' }],
             token: usdcToken,
           },
         },
         receive: {
-          USDC: {
+          [usdcAssetId]: {
             totalValue: '1502080',
             components: [{ value: '1502080' }],
             token: usdcToken,
@@ -574,7 +598,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '1447243200000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {},
         receive: {},
@@ -589,22 +613,26 @@ describe('parseTx', () => {
       const { txMempool } = uniAddLiquidity
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
 
+      const foxToken = {
+        contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
+        decimals: 18,
+        name: 'FOX',
+        symbol: 'FOX',
+      }
+      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
+
       const expected: ParseTx = {
         ...txMempool,
         address: address,
         send: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '42673718176645189',
             components: [{ value: '42673718176645189' }],
           },
-          FOX: {
+          [foxAssetId]: {
             totalValue: '100000000000000000000',
             components: [{ value: '100000000000000000000' }],
-            token: {
-              contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
-              decimals: 18,
-              name: 'FOX',
-            },
+            token: foxToken,
           },
         },
         receive: {},
@@ -622,33 +650,38 @@ describe('parseTx', () => {
         contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
         decimals: 18,
         name: 'FOX',
+        symbol: 'FOX',
       }
+      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
+
       const uniV2Token = {
         contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
         decimals: 18,
         name: 'Uniswap V2',
+        symbol: 'UNI-V2',
       }
+      const uniV2AssetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
 
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '26926494400000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '42673718176645189',
             components: [{ value: '42673718176645189' }],
           },
-          FOX: {
+          [foxAssetId]: {
             totalValue: '100000000000000000000',
             components: [{ value: '100000000000000000000' }],
             token: foxToken,
           },
         },
         receive: {
-          'UNI-V2': {
+          [uniV2AssetId]: {
             totalValue: '1888842410762840601',
             components: [{ value: '1888842410762840601' }],
             token: uniV2Token,
@@ -668,13 +701,15 @@ describe('parseTx', () => {
         contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
         decimals: 18,
         name: 'Uniswap V2',
+        symbol: 'UNI-V2',
       }
+      const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
 
       const expected: ParseTx = {
         ...txMempool,
         address: address,
         send: {
-          'UNI-V2': {
+          [uniV2assetId]: {
             totalValue: '298717642142382954',
             components: [{ value: '298717642142382954' }],
             token: uniV2Token,
@@ -684,7 +719,6 @@ describe('parseTx', () => {
       }
 
       const actual = await parseTx(txMempool, address)
-
       expect(expected).toEqual(actual)
     })
 
@@ -695,33 +729,38 @@ describe('parseTx', () => {
         contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
         decimals: 18,
         name: 'FOX',
+        symbol: 'FOX',
       }
+      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
+
       const uniV2Token = {
         contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
         decimals: 18,
         name: 'Uniswap V2',
+        symbol: 'UNI-V2',
       }
+      const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
 
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '4082585000000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          'UNI-V2': {
+          [uniV2assetId]: {
             totalValue: '298717642142382954',
             components: [{ value: '298717642142382954' }],
             token: uniV2Token,
           },
         },
         receive: {
-          ETH: {
+          [`${nativeToken}`]: {
             totalValue: '6761476182340434',
             components: [{ value: '6761476182340434' }],
           },
-          FOX: {
+          [foxAssetId]: {
             totalValue: '15785079906515930982',
             components: [{ value: '15785079906515930982' }],
             token: foxToken,
@@ -743,18 +782,19 @@ describe('parseTx', () => {
         contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
         decimals: 18,
         name: 'FOX',
+        symbol: 'FOX',
       }
-
+      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '2559843000000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {},
         receive: {
-          FOX: {
+          [foxAssetId]: {
             totalValue: '1500000000000000000000',
             components: [{ value: '1500000000000000000000' }],
             token: foxToken,
@@ -791,17 +831,18 @@ describe('parseTx', () => {
         contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
         decimals: 18,
         name: 'Uniswap V2',
+        symbol: 'UNI-V2',
       }
-
+      const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '4650509500000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {
-          'UNI-V2': {
+          [uniV2assetId]: {
             totalValue: '99572547380794318',
             components: [{ value: '99572547380794318' }],
             token: uniV2Token,
@@ -838,28 +879,33 @@ describe('parseTx', () => {
         contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
         decimals: 18,
         name: 'FOX',
+        symbol: 'FOX',
       }
+      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
+
       const uniV2Token = {
         contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
         decimals: 18,
         name: 'Uniswap V2',
+        symbol: 'UNI-V2',
       }
+      const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
 
       const expected: ParseTx = {
         ...tx,
         address: address,
         fee: {
           value: '6136186875000000',
-          symbol: 'ETH',
+          assetId: nativeToken,
         },
         send: {},
         receive: {
-          FOX: {
+          [foxAssetId]: {
             totalValue: '317669338073988',
             components: [{ value: '317669338073988' }],
             token: foxToken,
           },
-          'UNI-V2': {
+          [uniV2assetId]: {
             totalValue: '531053586030903030',
             components: [{ value: '531053586030903030' }],
             token: uniV2Token,

--- a/coinstacks/ethereum/ingester/src/__tests__/parseTx.test.ts
+++ b/coinstacks/ethereum/ingester/src/__tests__/parseTx.test.ts
@@ -23,7 +23,7 @@ jest.mock('@shapeshiftoss/thorchain')
 
 const COINSTACK = 'ethereum'
 const NETWORK = 'MAINNET'
-const nativeToken = `${COINSTACK}_${NETWORK}`
+const nativeAssetId = `${COINSTACK}_${NETWORK}`
 
 const uniV2Token = {
   contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
@@ -60,7 +60,7 @@ describe('parseTx', () => {
         address: address,
         send: {},
         receive: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '1201235000000000000',
             components: [{ value: '1201235000000000000' }],
           },
@@ -92,11 +92,11 @@ describe('parseTx', () => {
         ...tx,
         address: address,
         fee: {
-          assetId: nativeToken,
+          assetId: nativeAssetId,
           value: '1700235000000000',
         },
         send: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '295040000000000000',
             components: [{ value: '295040000000000000' }],
           },
@@ -128,7 +128,7 @@ describe('parseTx', () => {
         ...tx,
         address: address,
         fee: {
-          assetId: nativeToken,
+          assetId: nativeAssetId,
           value: '4700280000000000',
         },
         send: {
@@ -170,7 +170,7 @@ describe('parseTx', () => {
         address: address,
         send: {},
         receive: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '1579727090000000000',
             components: [{ value: '1579727090000000000' }],
           },
@@ -242,7 +242,7 @@ describe('parseTx', () => {
         address: address,
         send: {},
         receive: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '6412730000000000',
             components: [{ value: '6412730000000000' }],
           },
@@ -283,7 +283,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '8308480000000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
           [tribeAssetId]: {
@@ -293,7 +293,7 @@ describe('parseTx', () => {
           },
         },
         receive: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '541566754246167133',
             components: [{ value: '541566754246167133' }],
           },
@@ -331,10 +331,10 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '19815285000000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '10000000000000000000',
             components: [{ value: '10000000000000000000' }],
           },
@@ -387,7 +387,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '78183644000000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
           [usdtAssetId]: {
@@ -443,7 +443,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '18399681000000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
           [bondAssetId]: {
@@ -477,13 +477,13 @@ describe('parseTx', () => {
         ...txMempool,
         address: address,
         send: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
         },
         receive: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -504,16 +504,16 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '399000000000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
         },
         receive: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -562,7 +562,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '1011738000000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
           [usdcAssetId]: {
@@ -596,7 +596,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '1447243200000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {},
         receive: {},
@@ -615,7 +615,7 @@ describe('parseTx', () => {
         ...txMempool,
         address: address,
         send: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '42673718176645189',
             components: [{ value: '42673718176645189' }],
           },
@@ -642,10 +642,10 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '26926494400000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '42673718176645189',
             components: [{ value: '42673718176645189' }],
           },
@@ -699,7 +699,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '4082585000000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
           [uniV2assetId]: {
@@ -709,7 +709,7 @@ describe('parseTx', () => {
           },
         },
         receive: {
-          [nativeToken]: {
+          [nativeAssetId]: {
             totalValue: '6761476182340434',
             components: [{ value: '6761476182340434' }],
           },
@@ -737,7 +737,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '2559843000000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {},
         receive: {
@@ -779,7 +779,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '4650509500000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {
           [uniV2assetId]: {
@@ -820,7 +820,7 @@ describe('parseTx', () => {
         address: address,
         fee: {
           value: '6136186875000000',
-          assetId: nativeToken,
+          assetId: nativeAssetId,
         },
         send: {},
         receive: {

--- a/coinstacks/ethereum/ingester/src/__tests__/parseTx.test.ts
+++ b/coinstacks/ethereum/ingester/src/__tests__/parseTx.test.ts
@@ -25,6 +25,30 @@ const COINSTACK = 'ethereum'
 const NETWORK = 'MAINNET'
 const nativeToken = `${COINSTACK}_${NETWORK}`
 
+const uniV2Token = {
+  contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
+  decimals: 18,
+  name: 'Uniswap V2',
+  symbol: 'UNI-V2',
+}
+const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
+
+const usdcToken = {
+  contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  decimals: 6,
+  name: 'USD Coin',
+  symbol: 'USDC',
+}
+const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
+
+const foxToken = {
+  contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
+  decimals: 18,
+  name: 'FOX',
+  symbol: 'FOX',
+}
+const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
+
 describe('parseTx', () => {
   describe('multiSig', () => {
     it('should be able to parse eth multi sig send', async () => {
@@ -72,7 +96,7 @@ describe('parseTx', () => {
           value: '1700235000000000',
         },
         send: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '295040000000000000',
             components: [{ value: '295040000000000000' }],
           },
@@ -99,13 +123,7 @@ describe('parseTx', () => {
         sellAsset: 'USDC',
         sellAmount: '16598881497',
       }
-      const usdcToken = {
-        contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        decimals: 6,
-        name: 'USD Coin',
-        symbol: 'USDC',
-      }
-      const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
+
       const expected: ParseTx = {
         ...tx,
         address: address,
@@ -152,7 +170,7 @@ describe('parseTx', () => {
         address: address,
         send: {},
         receive: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '1579727090000000000',
             components: [{ value: '1579727090000000000' }],
           },
@@ -182,13 +200,7 @@ describe('parseTx', () => {
         sellAmount: '510423341825',
         sellNetwork: 'THOR',
       }
-      const usdcToken = {
-        contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        decimals: 6,
-        name: 'USD Coin',
-        symbol: 'USDC',
-      }
-      const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
+
       const expected: ParseTx = {
         ...tx,
         address: address,
@@ -230,7 +242,7 @@ describe('parseTx', () => {
         address: address,
         send: {},
         receive: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '6412730000000000',
             components: [{ value: '6412730000000000' }],
           },
@@ -264,7 +276,7 @@ describe('parseTx', () => {
         symbol: 'TRIBE',
       }
 
-      const assetId = `${COINSTACK}_${NETWORK}_${tribeToken.contract}`
+      const tribeAssetId = `${COINSTACK}_${NETWORK}_${tribeToken.contract}`
 
       const expected: ParseTx = {
         ...tx,
@@ -274,14 +286,14 @@ describe('parseTx', () => {
           assetId: nativeToken,
         },
         send: {
-          [assetId]: {
+          [tribeAssetId]: {
             totalValue: '1000000000000000000000',
             components: [{ value: '1000000000000000000000' }],
             token: tribeToken,
           },
         },
         receive: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '541566754246167133',
             components: [{ value: '541566754246167133' }],
           },
@@ -313,7 +325,7 @@ describe('parseTx', () => {
         symbol: 'MATIC',
       }
 
-      const assetId = `${COINSTACK}_${NETWORK}_${maticToken.contract}`
+      const maticAssetId = `${COINSTACK}_${NETWORK}_${maticToken.contract}`
       const expected: ParseTx = {
         ...tx,
         address: address,
@@ -322,13 +334,13 @@ describe('parseTx', () => {
           assetId: nativeToken,
         },
         send: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '10000000000000000000',
             components: [{ value: '10000000000000000000' }],
           },
         },
         receive: {
-          [assetId]: {
+          [maticAssetId]: {
             totalValue: '50000000000000000000000',
             components: [{ value: '50000000000000000000000' }],
             token: maticToken,
@@ -465,13 +477,13 @@ describe('parseTx', () => {
         ...txMempool,
         address: address,
         send: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
         },
         receive: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -495,13 +507,13 @@ describe('parseTx', () => {
           assetId: nativeToken,
         },
         send: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
         },
         receive: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -516,13 +528,6 @@ describe('parseTx', () => {
     it('should be able to parse token mempool', async () => {
       const { txMempool } = tokenSelfSend
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
-      const usdcToken = {
-        contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        decimals: 6,
-        name: 'USD Coin',
-        symbol: 'USDC',
-      }
-      const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
 
       const expected: ParseTx = {
         ...txMempool,
@@ -551,13 +556,6 @@ describe('parseTx', () => {
     it('should be able to parse token', async () => {
       const { tx } = tokenSelfSend
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
-      const usdcToken = {
-        contract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        decimals: 6,
-        name: 'USD Coin',
-        symbol: 'USDC',
-      }
-      const usdcAssetId = `${COINSTACK}_${NETWORK}_${usdcToken.contract}`
 
       const expected: ParseTx = {
         ...tx,
@@ -613,19 +611,11 @@ describe('parseTx', () => {
       const { txMempool } = uniAddLiquidity
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
 
-      const foxToken = {
-        contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
-        decimals: 18,
-        name: 'FOX',
-        symbol: 'FOX',
-      }
-      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
-
       const expected: ParseTx = {
         ...txMempool,
         address: address,
         send: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '42673718176645189',
             components: [{ value: '42673718176645189' }],
           },
@@ -646,21 +636,6 @@ describe('parseTx', () => {
     it('should be able to parse add liquidity', async () => {
       const { tx } = uniAddLiquidity
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
-      const foxToken = {
-        contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
-        decimals: 18,
-        name: 'FOX',
-        symbol: 'FOX',
-      }
-      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
-
-      const uniV2Token = {
-        contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
-        decimals: 18,
-        name: 'Uniswap V2',
-        symbol: 'UNI-V2',
-      }
-      const uniV2AssetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
 
       const expected: ParseTx = {
         ...tx,
@@ -670,7 +645,7 @@ describe('parseTx', () => {
           assetId: nativeToken,
         },
         send: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '42673718176645189',
             components: [{ value: '42673718176645189' }],
           },
@@ -681,7 +656,7 @@ describe('parseTx', () => {
           },
         },
         receive: {
-          [uniV2AssetId]: {
+          [uniV2assetId]: {
             totalValue: '1888842410762840601',
             components: [{ value: '1888842410762840601' }],
             token: uniV2Token,
@@ -697,13 +672,6 @@ describe('parseTx', () => {
     it('should be able to parse remove liquidity mempool', async () => {
       const { txMempool } = uniRemoveLiquidity
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
-      const uniV2Token = {
-        contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
-        decimals: 18,
-        name: 'Uniswap V2',
-        symbol: 'UNI-V2',
-      }
-      const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
 
       const expected: ParseTx = {
         ...txMempool,
@@ -725,21 +693,6 @@ describe('parseTx', () => {
     it('should be able to parse remove liquidity', async () => {
       const { tx, internalTxs } = uniRemoveLiquidity
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
-      const foxToken = {
-        contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
-        decimals: 18,
-        name: 'FOX',
-        symbol: 'FOX',
-      }
-      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
-
-      const uniV2Token = {
-        contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
-        decimals: 18,
-        name: 'Uniswap V2',
-        symbol: 'UNI-V2',
-      }
-      const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
 
       const expected: ParseTx = {
         ...tx,
@@ -756,7 +709,7 @@ describe('parseTx', () => {
           },
         },
         receive: {
-          [`${nativeToken}`]: {
+          [nativeToken]: {
             totalValue: '6761476182340434',
             components: [{ value: '6761476182340434' }],
           },
@@ -778,13 +731,7 @@ describe('parseTx', () => {
     it('should be able to parse claim', async () => {
       const { tx } = foxClaim
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
-      const foxToken = {
-        contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
-        decimals: 18,
-        name: 'FOX',
-        symbol: 'FOX',
-      }
-      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
+
       const expected: ParseTx = {
         ...tx,
         address: address,
@@ -827,13 +774,6 @@ describe('parseTx', () => {
     it('should be able to parse stake', async () => {
       const { tx } = foxStake
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
-      const uniV2Token = {
-        contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
-        decimals: 18,
-        name: 'Uniswap V2',
-        symbol: 'UNI-V2',
-      }
-      const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
       const expected: ParseTx = {
         ...tx,
         address: address,
@@ -875,22 +815,6 @@ describe('parseTx', () => {
     it('should be able to parse exit', async () => {
       const { tx } = foxExit
       const address = '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C'
-      const foxToken = {
-        contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
-        decimals: 18,
-        name: 'FOX',
-        symbol: 'FOX',
-      }
-      const foxAssetId = `${COINSTACK}_${NETWORK}_${foxToken.contract}`
-
-      const uniV2Token = {
-        contract: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
-        decimals: 18,
-        name: 'Uniswap V2',
-        symbol: 'UNI-V2',
-      }
-      const uniV2assetId = `${COINSTACK}_${NETWORK}_${uniV2Token.contract}`
-
       const expected: ParseTx = {
         ...tx,
         address: address,

--- a/coinstacks/ethereum/ingester/src/parseTx/index.ts
+++ b/coinstacks/ethereum/ingester/src/parseTx/index.ts
@@ -9,12 +9,15 @@ import * as multiSig from './multiSig'
 import * as uniV2 from './uniV2'
 
 const NODE_ENV = process.env.NODE_ENV
-const COINSTACK = process.env.COINSTACK
-const NETWORK = process.env.NETWORK
+let COINSTACK = process.env.COINSTACK
+let NETWORK = process.env.NETWORK
 
 if (NODE_ENV !== 'test') {
   if (!COINSTACK) throw new Error('COINSTACK env var not set')
   if (!NETWORK) throw new Error('NETWORK env var not set')
+} else {
+  COINSTACK = 'ethereum'
+  NETWORK = 'MAINNET'
 }
 
 const nativeToken = `${COINSTACK}_${NETWORK}`
@@ -94,7 +97,7 @@ export const parseTx = async (tx: Tx, address: string, internalTxs?: Array<Inter
   }
 
   tx.tokenTransfers?.forEach((transfer) => {
-    const assetId = `${COINSTACK}.${NETWORK}.${transfer.token}`
+    const assetId = `${COINSTACK}_${NETWORK}_${transfer.token}`
 
     // FTX Token (FTT) name and symbol was set backwards on the ERC20 contract
     if (transfer.token == '0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9') {

--- a/coinstacks/ethereum/ingester/src/parseTx/index.ts
+++ b/coinstacks/ethereum/ingester/src/parseTx/index.ts
@@ -8,11 +8,13 @@ import * as thor from './thor'
 import * as multiSig from './multiSig'
 import * as uniV2 from './uniV2'
 
-// todo - these should be global configs
-const chain = 'ethereum'
-const network = 'MAINNET'
-const tokenId = ''
-const nativeToken = `${chain}_${network}_${tokenId}`
+const COINSTACK = process.env.COINSTACK
+const NETWORK = 'MAINNET' //process.env.COINSTACK
+
+if (!COINSTACK) throw new Error('COINSTACK env var not set')
+if (!NETWORK) throw new Error('COINSTACK env var not set')
+
+const nativeToken = `${COINSTACK}_${NETWORK}`
 
 export const getInternalAddress = (inputData: string): string | undefined => {
   switch (getSigHash(inputData)) {

--- a/coinstacks/ethereum/ingester/src/parseTx/index.ts
+++ b/coinstacks/ethereum/ingester/src/parseTx/index.ts
@@ -78,13 +78,13 @@ export const parseTx = async (tx: Tx, address: string, internalTxs?: Array<Inter
     // send amount
     const sendValue = new BigNumber(tx.value)
     if (!sendValue.isNaN() && sendValue.gt(0)) {
-      pTx.send['ETH'] = aggregateTransfer(pTx.send['ETH'], sendValue.toString(10))
+      pTx.send[nativeAssetId] = aggregateTransfer(pTx.send[nativeAssetId], sendValue.toString(10))
     }
 
     // network fee
     const fees = new BigNumber(tx.fees ?? 0)
     if (!fees.isNaN() && fees.gt(0)) {
-      pTx.fee = { symbol: 'ETH', value: fees.toString(10) }
+      pTx.fee = { assetId: nativeAssetId, value: fees.toString(10) }
     }
   }
 
@@ -92,7 +92,7 @@ export const parseTx = async (tx: Tx, address: string, internalTxs?: Array<Inter
     // receive amount
     const receiveValue = new BigNumber(tx.value)
     if (!receiveValue.isNaN() && receiveValue.gt(0)) {
-      pTx.receive['ETH'] = aggregateTransfer(pTx.receive['ETH'], receiveValue.toString(10))
+      pTx.receive[nativeAssetId] = aggregateTransfer(pTx.receive[nativeAssetId], receiveValue.toString(10))
     }
   }
 

--- a/coinstacks/ethereum/ingester/src/parseTx/index.ts
+++ b/coinstacks/ethereum/ingester/src/parseTx/index.ts
@@ -8,11 +8,14 @@ import * as thor from './thor'
 import * as multiSig from './multiSig'
 import * as uniV2 from './uniV2'
 
+const NODE_ENV = process.env.NODE_ENV
 const COINSTACK = process.env.COINSTACK
-const NETWORK = 'MAINNET' //process.env.NETWORK
+const NETWORK = process.env.NETWORK
 
-if (!COINSTACK) throw new Error('COINSTACK env var not set')
-if (!NETWORK) throw new Error('NETWORK env var not set')
+if (NODE_ENV !== 'test') {
+  if (!COINSTACK) throw new Error('COINSTACK env var not set')
+  if (!NETWORK) throw new Error('NETWORK env var not set')
+}
 
 const nativeToken = `${COINSTACK}_${NETWORK}`
 

--- a/coinstacks/ethereum/ingester/src/parseTx/index.ts
+++ b/coinstacks/ethereum/ingester/src/parseTx/index.ts
@@ -20,7 +20,7 @@ if (NODE_ENV !== 'test') {
   NETWORK = 'MAINNET'
 }
 
-const nativeToken = `${COINSTACK}_${NETWORK}`
+const nativeAssetId = `${COINSTACK}_${NETWORK}`
 
 export const getInternalAddress = (inputData: string): string | undefined => {
   switch (getSigHash(inputData)) {
@@ -78,13 +78,13 @@ export const parseTx = async (tx: Tx, address: string, internalTxs?: Array<Inter
     // eth send amount
     const sendValue = new BigNumber(tx.value)
     if (!sendValue.isNaN() && sendValue.gt(0)) {
-      pTx.send[nativeToken] = aggregateTransfer(pTx.send[nativeToken], tx.value)
+      pTx.send[nativeAssetId] = aggregateTransfer(pTx.send[nativeAssetId], tx.value)
     }
 
     // eth network fee
     const fees = new BigNumber(tx.fees ?? 0)
     if (tx.fees && !fees.isNaN() && fees.gt(0)) {
-      pTx.fee = { assetId: nativeToken, value: tx.fees }
+      pTx.fee = { assetId: nativeAssetId, value: tx.fees }
     }
   }
 
@@ -92,7 +92,7 @@ export const parseTx = async (tx: Tx, address: string, internalTxs?: Array<Inter
     // eth receive amount
     const receiveValue = new BigNumber(tx.value)
     if (!receiveValue.isNaN() && receiveValue.gt(0)) {
-      pTx.receive[nativeToken] = aggregateTransfer(pTx.receive[nativeToken], tx.value)
+      pTx.receive[nativeAssetId] = aggregateTransfer(pTx.receive[nativeAssetId], tx.value)
     }
   }
 
@@ -126,12 +126,12 @@ export const parseTx = async (tx: Tx, address: string, internalTxs?: Array<Inter
   internalTxs?.forEach((internalTx) => {
     // internal eth send
     if (address === internalTx.from) {
-      pTx.send[nativeToken] = aggregateTransfer(pTx.send[nativeToken], internalTx.value)
+      pTx.send[nativeAssetId] = aggregateTransfer(pTx.send[nativeAssetId], internalTx.value)
     }
 
     // internal eth receive
     if (address === internalTx.to) {
-      pTx.receive[nativeToken] = aggregateTransfer(pTx.receive[nativeToken], internalTx.value)
+      pTx.receive[nativeAssetId] = aggregateTransfer(pTx.receive[nativeAssetId], internalTx.value)
     }
   })
 

--- a/coinstacks/ethereum/ingester/src/parseTx/index.ts
+++ b/coinstacks/ethereum/ingester/src/parseTx/index.ts
@@ -9,10 +9,10 @@ import * as multiSig from './multiSig'
 import * as uniV2 from './uniV2'
 
 const COINSTACK = process.env.COINSTACK
-const NETWORK = 'MAINNET' //process.env.COINSTACK
+const NETWORK = 'MAINNET' //process.env.NETWORK
 
 if (!COINSTACK) throw new Error('COINSTACK env var not set')
-if (!NETWORK) throw new Error('COINSTACK env var not set')
+if (!NETWORK) throw new Error('NETWORK env var not set')
 
 const nativeToken = `${COINSTACK}_${NETWORK}`
 
@@ -78,7 +78,7 @@ export const parseTx = async (tx: Tx, address: string, internalTxs?: Array<Inter
     // eth network fee
     const fees = new BigNumber(tx.fees ?? 0)
     if (tx.fees && !fees.isNaN() && fees.gt(0)) {
-      pTx.fee = { asset: nativeToken, value: tx.fees }
+      pTx.fee = { assetId: nativeToken, value: tx.fees }
     }
   }
 
@@ -90,8 +90,8 @@ export const parseTx = async (tx: Tx, address: string, internalTxs?: Array<Inter
     }
   }
 
-  tx.tokenTransfers?.forEach((transfer: TxTransfer) => {
-    const assetId = `${chain}.${network}.${transfer.token}`
+  tx.tokenTransfers?.forEach((transfer) => {
+    const assetId = `${COINSTACK}.${NETWORK}.${transfer.token}`
 
     // FTX Token (FTT) name and symbol was set backwards on the ERC20 contract
     if (transfer.token == '0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9') {

--- a/coinstacks/ethereum/ingester/src/parseTx/uniV2.ts
+++ b/coinstacks/ethereum/ingester/src/parseTx/uniV2.ts
@@ -48,7 +48,7 @@ export const parse = async (tx: Tx): Promise<ParseTxUnique | undefined> => {
         [symbol]: {
           totalValue: value,
           components: [{ value }],
-          token: { contract: tokenAddress, decimals, name },
+          token: { contract: tokenAddress, decimals, name, symbol },
         },
       }
 
@@ -69,7 +69,7 @@ export const parse = async (tx: Tx): Promise<ParseTxUnique | undefined> => {
         [symbol]: {
           totalValue: value,
           components: [{ value }],
-          token: { contract: lpTokenAddress, decimals, name },
+          token: { contract: lpTokenAddress, decimals, name, symbol },
         },
       }
 

--- a/coinstacks/ethereum/ingester/src/parseTx/uniV2.ts
+++ b/coinstacks/ethereum/ingester/src/parseTx/uniV2.ts
@@ -7,9 +7,16 @@ import { getSigHash } from './utils'
 
 const NODE_ENV = process.env.NODE_ENV
 const RPC_URL = process.env.RPC_URL as string
+let COINSTACK = process.env.COINSTACK
+let NETWORK = process.env.NETWORK
 
 if (NODE_ENV !== 'test') {
   if (!RPC_URL) throw new Error('RPC_URL env var not set')
+  if (!COINSTACK) throw new Error('COINSTACK env var not set')
+  if (!NETWORK) throw new Error('NETWORK env var not set')
+} else {
+  COINSTACK = 'ethereum'
+  NETWORK = 'MAINNET'
 }
 
 const provider = new ethers.providers.JsonRpcProvider(RPC_URL)
@@ -43,9 +50,10 @@ export const parse = async (tx: Tx): Promise<ParseTxUnique | undefined> => {
       const name = await contract.name()
       const symbol = await contract.symbol()
       const value = result.amountTokenDesired.toString()
+      const assetId = `${COINSTACK}_${NETWORK}_${tokenAddress}`
 
       const send: TxTransfers = {
-        [symbol]: {
+        [assetId]: {
           totalValue: value,
           components: [{ value }],
           token: { contract: tokenAddress, decimals, name, symbol },
@@ -64,9 +72,10 @@ export const parse = async (tx: Tx): Promise<ParseTxUnique | undefined> => {
       const name = await contract.name()
       const symbol = await contract.symbol()
       const value = result.liquidity.toString()
+      const assetId = `${COINSTACK}_${NETWORK}_${lpTokenAddress}`
 
       const send: TxTransfers = {
-        [symbol]: {
+        [assetId]: {
           totalValue: value,
           components: [{ value }],
           token: { contract: lpTokenAddress, decimals, name, symbol },

--- a/coinstacks/ethereum/ingester/src/workers/address.ts
+++ b/coinstacks/ethereum/ingester/src/workers/address.ts
@@ -11,7 +11,7 @@ if (!INDEXER_URL) throw new Error('INDEXER_URL env var not set')
 const blockbook = new Blockbook(INDEXER_URL)
 
 const onMessage = (worker: Worker) => async (message: Message) => {
-  const { address, txid, internalTxs, document }: ETHSyncTx = message.getContent()
+  const { address, txid, internalTxs, document }: ETHSyncTx = message.getContent() // todo - fix
   const retryKey = `${address}:${txid}`
 
   try {
@@ -20,6 +20,7 @@ const onMessage = (worker: Worker) => async (message: Message) => {
 
     const pTx = await parseTx(tx, address, internalTxs)
     logger.info(`publishing tx: ${txid} for registered address: ${address} to client: ${document.client_id}`)
+    console.log(JSON.stringify(pTx, null, '\t'))
 
     worker.sendMessage(new Message({ ...pTx, document } as ETHParseTx), document.client_id)
     worker.ackMessage(message, retryKey)

--- a/coinstacks/ethereum/ingester/src/workers/address.ts
+++ b/coinstacks/ethereum/ingester/src/workers/address.ts
@@ -11,7 +11,7 @@ if (!INDEXER_URL) throw new Error('INDEXER_URL env var not set')
 const blockbook = new Blockbook(INDEXER_URL)
 
 const onMessage = (worker: Worker) => async (message: Message) => {
-  const { address, txid, internalTxs, document }: ETHSyncTx = message.getContent() // todo - fix
+  const { address, txid, internalTxs, document }: ETHSyncTx = message.getContent()
   const retryKey = `${address}:${txid}`
 
   try {

--- a/coinstacks/ethereum/ingester/src/workers/address.ts
+++ b/coinstacks/ethereum/ingester/src/workers/address.ts
@@ -20,7 +20,7 @@ const onMessage = (worker: Worker) => async (message: Message) => {
 
     const pTx = await parseTx(tx, address, internalTxs)
     logger.info(`publishing tx: ${txid} for registered address: ${address} to client: ${document.client_id}`)
-    console.log(JSON.stringify(pTx, null, '\t'))
+    //console.log(JSON.stringify(pTx, null, '\t'))
 
     worker.sendMessage(new Message({ ...pTx, document } as ETHParseTx), document.client_id)
     worker.ackMessage(message, retryKey)


### PR DESCRIPTION
Uses standard defined in @shapeshiftoss/asset-service to identify assets by `{chain}_{network}_{tokenId}` where tokenId is either contract address or empty string '' if its the native asset.

Questions:
1. Should we use this same asset notation for the API endpoints?
2. How to get the network name (such as ETH mainnet vs testnet)?
3. Should we use CAIP standard? https://github.com/ChainAgnostic/CAIPs

Here are examples of parsed transaction of a USDT send on ethereum mainnet:

IS:

```
"receive": {},
"send": {
  "ethereum_MAINNET_0xdAC17F958D2ee523a2206206994597C13D831ec7": {
    "totalValue": "1846150000",
    "components": [
      {
	"value": "1846150000"
      }
    ],
    "token": {
      "contract": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
      "decimals": 6,
      "name": "Tether USD",
      "symbol": "USDT"
    }
  }
},
"fee": {
  "asset": "ethereum_MAINNET",
  "value": "3498430018696984"
}
```

WAS:

```
"receive": {},
"send": {
  "USDT": {
    "totalValue": "500000000",
    "components": [
      {
        "value": "500000000"
      }
    ],
    "token": {
      "contract": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
      "decimals": 6,
      "name": "Tether USD"
    }
  }
},
"fee": {
  "symbol": "ETH",
  "value": "3242529567992343"
}
```



