### PR TITLE
Use version tags to avoid imagePullPolicy Always

### DIFF
--- a/packages/blockbook/pulumi/package.json
+++ b/packages/blockbook/pulumi/package.json
@@ -7,5 +7,9 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist node_modules"
+  },
+  "dependencies": {
+    "@types/folder-hash": "^4.0.0",
+    "folder-hash": "^4.0.0"
   }
 }


### PR DESCRIPTION
Crash looping pods resulted in blowing out dockerhub image pull limit with default `Always` pull policy on `:latest` tags.

Using `:latest` tag is also less secure for running production services