### PR TITLE
use root address if there is no nextAddressIndex

### DIFF
--- a/coinstacks/bitcoin/api/src/controller.ts
+++ b/coinstacks/bitcoin/api/src/controller.ts
@@ -83,8 +83,8 @@ export class Bitcoin extends Controller implements BaseAPI, BitcoinAPI {
       return {
         pubkey: data.address,
         balance: data.balance,
-        nextReceiveAddressIndex: nextAddressIndexes[0] || 0,
-        nextChangeAddressIndex: nextAddressIndexes[1] || 0,
+        nextReceiveAddressIndex: nextAddressIndexes[0] ?? 0,
+        nextChangeAddressIndex: nextAddressIndexes[1] ?? 0,
       }
     } catch (err) {
       throw new ApiError(err.response.statusText, err.response.status, JSON.stringify(err.response.data))

--- a/coinstacks/bitcoin/api/src/controller.ts
+++ b/coinstacks/bitcoin/api/src/controller.ts
@@ -83,8 +83,8 @@ export class Bitcoin extends Controller implements BaseAPI, BitcoinAPI {
       return {
         pubkey: data.address,
         balance: data.balance,
-        nextReceiveAddressIndex: nextAddressIndexes[0],
-        nextChangeAddressIndex: nextAddressIndexes[1],
+        nextReceiveAddressIndex: nextAddressIndexes[0] || 0,
+        nextChangeAddressIndex: nextAddressIndexes[1] || 0,
       }
     } catch (err) {
       throw new ApiError(err.response.statusText, err.response.status, JSON.stringify(err.response.data))


### PR DESCRIPTION
If an xpub does not have any tx history, it will not have a `tokens` object in the response of `getXPub`, which means that we need to use 0 for the `nextReceiveAddressIndex` rather than undefined.