### PR TITLE
Implement websocket heartbeat

### DIFF
--- a/coinstacks/common/api/src/websocket.ts
+++ b/coinstacks/common/api/src/websocket.ts
@@ -46,25 +46,42 @@ export class ConnectionHandler {
   private readonly routes: Record<Topics, Methods>
   private readonly unchainedExchange: Exchange
 
+  private isAlive: boolean
   private queue?: Queue
 
-  constructor(coinstack: string, websocket: WebSocket) {
+  private constructor(coinstack: string, websocket: WebSocket) {
     this.coinstack = coinstack
     this.id = v4()
+    this.isAlive = true
     this.rabbit = new Connection(BROKER_URL)
     this.unchainedExchange = this.rabbit.declareExchange('exchange.unchained', '', { noCreate: true })
-    this.websocket = websocket
     this.routes = {
       txs: {
         subscribe: (data: TxsTopicData) => this.handleSubscribeTxs(data),
       },
     }
+
+    const interval = setInterval(() => {
+      console.log('isAlive', this.isAlive)
+      if (!this.isAlive) return this.websocket.terminate()
+
+      this.isAlive = false
+      this.websocket.ping()
+    }, 10000)
+
+    this.websocket = websocket
+    this.websocket.onmessage = (event) => this.onMessage(event)
+    this.websocket.onerror = () => this.onClose(interval)
+    this.websocket.onclose = () => this.onClose(interval)
+    this.websocket.on('pong', () => this.heartbeat())
   }
 
-  start(): void {
-    this.websocket.onmessage = (event) => this.onMessage(event)
-    this.websocket.onclose = () => this.onClose()
-    this.websocket.onerror = () => this.onClose()
+  static start(coinstack: string, websocket: WebSocket): void {
+    new ConnectionHandler(coinstack, websocket)
+  }
+
+  private heartbeat(): void {
+    this.isAlive = true
   }
 
   private sendError(message: string): void {
@@ -87,10 +104,12 @@ export class ConnectionHandler {
     }
   }
 
-  private async onClose() {
+  private async onClose(interval: NodeJS.Timeout) {
     const msg: RegistryMessage = { action: 'unregister', client_id: this.id, registration: {} }
     this.unchainedExchange.send(new Message(msg), `${this.coinstack}.registry`)
+
     await this.queue?.delete()
+    clearInterval(interval)
   }
 
   private async handleSubscribeTxs(data: TxsTopicData) {
@@ -132,9 +151,10 @@ export class ConnectionHandler {
 
     const onMessage = (message: Message) => {
       const content = message.getContent()
-      // TODO: requeue on error callback
-      this.websocket.send(JSON.stringify(content))
-      message.ack()
+      this.websocket.send(JSON.stringify(content), (err) => {
+        // TODO: test error case and determine correct handling
+        err ? message.nack(false, true) : message.ack()
+      })
     }
 
     this.queue.activateConsumer(onMessage)

--- a/coinstacks/ethereum/api/src/app.ts
+++ b/coinstacks/ethereum/api/src/app.ts
@@ -47,6 +47,4 @@ const server = app.listen(port, () => logger.info('server listening...'))
 
 const wsServer = new Server({ server })
 
-wsServer.on('connection', (connection) => {
-  new ConnectionHandler('ethereum', connection).start()
-})
+wsServer.on('connection', (connection) => ConnectionHandler.start('ethereum', connection))

--- a/coinstacks/ethereum/api/src/websocket.ts
+++ b/coinstacks/ethereum/api/src/websocket.ts
@@ -4,17 +4,22 @@ import { SequencedETHParseTx } from '@shapeshiftoss/ethereum-ingester'
 
 export { SequencedETHParseTx, ErrorResponse, RequestPayload, TxsTopicData }
 
+export interface Connection {
+  ws: WebSocket
+  pingTimeout?: NodeJS.Timeout
+}
+
 export class Client {
   private readonly url: string
-  private readonly websockets: Record<Topics, WebSocket | undefined>
+  private readonly connections: Record<Topics, Connection | undefined>
   private readonly sequencedData: Record<Topics, Array<boolean> | undefined>
   private readonly opts?: WebSocket.ClientOptions
 
   constructor(url: string, opts?: WebSocket.ClientOptions) {
     this.url = url
-    this.opts = opts
+    this.opts = { ...opts, sessionTimeout: 10000 }
 
-    this.websockets = {
+    this.connections = {
       txs: undefined,
     }
 
@@ -23,21 +28,35 @@ export class Client {
     }
   }
 
+  private heartbeat(topic: Topics): void {
+    const connection = this.connections[topic]
+    if (!connection) return
+
+    connection.pingTimeout && clearTimeout(connection.pingTimeout)
+    connection.pingTimeout = setTimeout(() => connection?.ws.terminate(), 10000 + 1000)
+  }
+
+  private onOpen(topic: Topics, resolve: (value: unknown) => void): void {
+    this.heartbeat(topic)
+    resolve(true)
+  }
+
   // TODO: add onError callback for any error cases
   // TODO: add batch key
   async subscribeTxs(
     data: TxsTopicData,
     onMessage: (message: SequencedETHParseTx | ErrorResponse) => void
   ): Promise<void> {
-    if (this.websockets.txs) return
+    if (this.connections.txs) return
 
     const ws = new WebSocket(this.url, this.opts)
 
-    ws.onerror = (event) => console.log('error', event)
+    this.connections.txs = { ws }
 
-    this.websockets.txs = ws
+    await new Promise((resolve) => (ws.onopen = () => this.onOpen('txs', resolve)))
 
-    await new Promise((resolve) => (ws.onopen = () => resolve(true)))
+    ws.onclose = () => this.connections.txs?.pingTimeout && clearTimeout(this.connections.txs.pingTimeout)
+    ws.on('ping', () => this.heartbeat('txs'))
 
     const payload: RequestPayload = { method: 'subscribe', topic: 'txs', data }
 
@@ -67,13 +86,13 @@ export class Client {
 
   unsubscribeTxs(): void {
     this.sequencedData.txs = undefined
-    this.websockets.txs?.send(
+    this.connections.txs?.ws.send(
       JSON.stringify({ method: 'unsubscribe', topic: 'txs', data: undefined } as RequestPayload)
     )
   }
 
   close(topic: Topics): void {
     this.sequencedData[topic] = undefined
-    this.websockets[topic]?.close()
+    this.connections[topic]?.ws.close()
   }
 }


### PR DESCRIPTION
Followed recommended pattern here: https://github.com/websockets/ws#how-to-detect-and-close-broken-connections

Works well enough for now, but not a big fan of the magic number and + 1000 dependency. Might circle back and just add a ping handler to the server side connection handler and have the client hit that directly on whatever interval it sees fit.

Also updated the ConnectionHandler to a static start function which looked a bit nicer to me