### PR TITLE
use traefik to load balance multiple coinstacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,6 @@ Traefik routes requests based on host name. which includes the coinstack name. F
 #### **Prerequisites**
 
 - Install [docker-compose](https://docs.docker.com/compose/install/)
-- To start up the reverse proxy and hot reloading for files run from the root of the project
-  ```sh
-  docker-compose up
-  ```
 - Copy sample env file:
   ```sh
   cp coinstacks/ethereum/sample.env coinstacks/ethereum/.env
@@ -108,10 +104,15 @@ Traefik routes requests based on host name. which includes the coinstack name. F
 
 #### **Running**
 
+- To start up the reverse proxy and hot reloading for files run from the root of the project
+  ```sh
+  docker-compose up
+  ```
+
 - To spin up a coinstack:
-  - API only (watcher service is for hot reloading):
+  - API only:
     ```sh
-    cd coinstacks/ethereum && docker-compose up api watcher
+    cd coinstacks/ethereum && docker-compose up api
     ```
   - API + Ingester (more resource intensive):
     ```sh

--- a/README.md
+++ b/README.md
@@ -78,12 +78,16 @@ Unchained is a multi-blockchain backend interface with three main goals:
   yarn && yarn build
   ```
 
-## Ports
+## Local Networking 
 
-- API: `31300`
-- MongoDB: `27017`
-- RabbitMQ: `30672`
-- RabbitMQ Admin: `31672`
+We use traefik as a reverse-proxy to expose all of our docker containers. Traefik is exposed at port `80`. Traefik Dashboard is exposed at port `8080`
+
+Traefik routes requests based on host name. which includes the coinstack name. For Example:
+- `api.bitcoin.localhost`
+- `mongo.bitcoin.localhost`
+- `rabbit-admin.bitcoin.localhost`
+
+
 
 ## Docker-Compose Local Dev Instructions
 
@@ -92,6 +96,10 @@ Unchained is a multi-blockchain backend interface with three main goals:
 #### **Prerequisites**
 
 - Install [docker-compose](https://docs.docker.com/compose/install/)
+- To start up the reverse proxy and hot reloading for files run from the root of the project
+  ```sh
+  docker-compose up
+  ```
 - Copy sample env file:
   ```sh
   cp coinstacks/ethereum/sample.env coinstacks/ethereum/.env
@@ -103,19 +111,16 @@ Unchained is a multi-blockchain backend interface with three main goals:
 - To spin up a coinstack:
   - API only (watcher service is for hot reloading):
     ```sh
-    COINSTACK=ethereum docker-compose up api watcher
+    cd coinstacks/ethereum && docker-compose up api watcher
     ```
   - API + Ingester (more resource intensive):
     ```sh
-    COINSTACK=ethereum docker-compose up
+    cd coinstacks/ethereum && docker-compose up
     ```
 - To completely tear down the coinstack (including docker volumes):
   ```sh
-  COINSTACK=ethereum docker-compose down -v
+  cd coinstacks/ethereum && docker-compose down -v
   ```
-
-Toubleshooting:
-    the api claims to be running on listening at http://localhost:3000; however in docker compose its actually running on http://localhost:31300
 
 ## Kubernetes Local Dev Instructions
 

--- a/coinstacks/bitcoin/api/src/app.ts
+++ b/coinstacks/bitcoin/api/src/app.ts
@@ -35,7 +35,7 @@ app.use('/docs', swaggerUi.serve, swaggerUi.setup(undefined, options))
 RegisterRoutes(app)
 
 // redirect any unmatched routes to docs
-app.get('*', async (_, res) => {
+app.get('/', async (_, res) => {
   res.redirect('/docs')
 })
 

--- a/coinstacks/bitcoin/docker-compose.yml
+++ b/coinstacks/bitcoin/docker-compose.yml
@@ -1,0 +1,165 @@
+version: '3.6'
+
+services:
+  api:
+    labels:
+      - 'traefik.http.routers.bitcoin-api.rule=Host(`api.bitcoin.localhost`)'
+      - 'traefik.http.services.bitcoin-api.loadbalancer.server.port=3000'
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/api
+    command: yarn nodemon
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+  mongo:
+    labels:
+      - 'traefik.http.routers.bitcoin-mongo.rule=Host(`mongo.bitcoin.localhost`)'
+      - 'traefik.http.services.bitcoin-mongo.loadbalancer.server.port=27017'
+    image: mongo:4.2.8
+    logging:
+      driver: none
+    volumes:
+      - mongodb:/data/db
+  rabbitmq:
+    labels:
+      - 'traefik.http.routers.bitcoin-rabbit.rule=Host(`rabbit-admin.bitcoin.localhost`)'
+      - 'traefik.http.services.bitcoin-rabbit.loadbalancer.server.port=15672'
+      - "traefik.docker.network=bitcoin_default"
+    image: rabbitmq:3-management
+    environment:
+      RABBITMQ_DEFAULT_VHOST: /
+    logging:
+      driver: none
+  rabbitmq-declare-topology:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://rabbitmq:5672 -timeout 5m -wait-retry-interval 10s sh -c "yarn tsc && node dist/topology.js"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+  socket-new-block:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/sockets/newBlock.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  socket-new-transaction:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/sockets/newTransaction.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-newBlock:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/newBlock.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-block:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/block.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-txid:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/txid.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-tx:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/tx.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-address:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/address.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-registry:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/bitcoin/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/registry.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+
+volumes:
+  mongodb:

--- a/coinstacks/bitcoin/docker-compose.yml
+++ b/coinstacks/bitcoin/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     command: yarn nodemon
     volumes:
       - ../..:/app
-    depends_on:
-      - unchained-local
   mongo:
     labels:
       - 'traefik.http.routers.bitcoin-mongo.rule=Host(`mongo.bitcoin.localhost`)'
@@ -45,7 +43,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
   socket-new-block:
     image: unchained-local
@@ -58,7 +55,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   socket-new-transaction:
@@ -72,7 +68,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-newBlock:
@@ -86,7 +81,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-block:
@@ -100,7 +94,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-txid:
@@ -114,7 +107,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-tx:
@@ -128,7 +120,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-address:
@@ -142,7 +133,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-registry:
@@ -156,7 +146,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
 

--- a/coinstacks/bitcoin/docker-compose.yml
+++ b/coinstacks/bitcoin/docker-compose.yml
@@ -29,7 +29,6 @@ services:
     labels:
       - 'traefik.http.routers.bitcoin-rabbit.rule=Host(`rabbit-admin.bitcoin.localhost`)'
       - 'traefik.http.services.bitcoin-rabbit.loadbalancer.server.port=15672'
-      - "traefik.docker.network=bitcoin_default"
     image: rabbitmq:3-management
     environment:
       RABBITMQ_DEFAULT_VHOST: /

--- a/coinstacks/ethereum/api/src/app.ts
+++ b/coinstacks/ethereum/api/src/app.ts
@@ -31,7 +31,7 @@ app.use('/docs', swaggerUi.serve, swaggerUi.setup(undefined, options))
 RegisterRoutes(app)
 
 // redirect any unmatched routes to docs
-app.get('*', async (_, res) => {
+app.get('/', async (_, res) => {
   res.redirect('/docs')
 })
 

--- a/coinstacks/ethereum/docker-compose.yml
+++ b/coinstacks/ethereum/docker-compose.yml
@@ -1,0 +1,167 @@
+version: '3.6'
+
+services:
+  api:
+    labels:
+      - 'traefik.http.routers.ethereum-api.rule=Host(`api.ethereum.localhost`)'
+      - 'traefik.http.services.ethereum-api.loadbalancer.server.port=3000'
+      - "traefik.docker.network=ethereum_default"
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/api
+    command: yarn nodemon
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+  mongo:
+    labels:
+      - 'traefik.http.routers.ethereum-mongo.rule=Host(`mongo.ethereum.localhost`)'
+      - 'traefik.http.services.ethereum-mongo.loadbalancer.server.port=27017'
+      - "traefik.docker.network=ethereum_default"
+    image: mongo:4.2.8
+    logging:
+      driver: none
+    volumes:
+      - mongodb:/data/db
+  rabbitmq:
+    labels:
+      - 'traefik.http.routers.ethereum-rabbit.rule=Host(`rabbit-admin.ethereum.localhost`)'
+      - 'traefik.http.services.ethereum-rabbit.loadbalancer.server.port=15672'
+      - "traefik.docker.network=ethereum_default"
+    image: rabbitmq:3-management
+    environment:
+      RABBITMQ_DEFAULT_VHOST: /
+    logging:
+      driver: none
+  rabbitmq-declare-topology:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://rabbitmq:5672 -timeout 5m -wait-retry-interval 10s sh -c "yarn tsc && node dist/topology.js"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+  socket-new-block:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/sockets/newBlock.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  socket-new-transaction:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/sockets/newTransaction.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-newBlock:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/newBlock.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-block:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/block.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-txid:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/txid.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-tx:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/tx.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-address:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/address.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+  worker-registry:
+    image: unchained-local
+    env_file: .env
+    environment:
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      MONGO_URL: mongodb://mongo:27017
+    working_dir: /app/coinstacks/ethereum/ingester
+    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/registry.ts"
+    volumes:
+      - ../..:/app
+    depends_on:
+      - unchained-local
+      - rabbitmq
+      - mongo
+
+volumes:
+  mongodb:

--- a/coinstacks/ethereum/docker-compose.yml
+++ b/coinstacks/ethereum/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     labels:
       - 'traefik.http.routers.ethereum-api.rule=Host(`api.ethereum.localhost`)'
       - 'traefik.http.services.ethereum-api.loadbalancer.server.port=3000'
-      - "traefik.docker.network=ethereum_default"
     image: unchained-local
     env_file: .env
     environment:
@@ -21,7 +20,6 @@ services:
     labels:
       - 'traefik.http.routers.ethereum-mongo.rule=Host(`mongo.ethereum.localhost`)'
       - 'traefik.http.services.ethereum-mongo.loadbalancer.server.port=27017'
-      - "traefik.docker.network=ethereum_default"
     image: mongo:4.2.8
     logging:
       driver: none
@@ -31,7 +29,6 @@ services:
     labels:
       - 'traefik.http.routers.ethereum-rabbit.rule=Host(`rabbit-admin.ethereum.localhost`)'
       - 'traefik.http.services.ethereum-rabbit.loadbalancer.server.port=15672'
-      - "traefik.docker.network=ethereum_default"
     image: rabbitmq:3-management
     environment:
       RABBITMQ_DEFAULT_VHOST: /

--- a/coinstacks/ethereum/docker-compose.yml
+++ b/coinstacks/ethereum/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     command: yarn nodemon
     volumes:
       - ../..:/app
-    depends_on:
-      - unchained-local
   mongo:
     labels:
       - 'traefik.http.routers.ethereum-mongo.rule=Host(`mongo.ethereum.localhost`)'
@@ -45,7 +43,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
   socket-new-block:
     image: unchained-local
@@ -58,7 +55,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   socket-new-transaction:
@@ -72,7 +68,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-newBlock:
@@ -86,7 +81,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-block:
@@ -100,7 +94,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-txid:
@@ -114,7 +107,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-tx:
@@ -128,7 +120,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-address:
@@ -142,7 +133,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
   worker-registry:
@@ -156,7 +146,6 @@ services:
     volumes:
       - ../..:/app
     depends_on:
-      - unchained-local
       - rabbitmq
       - mongo
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,173 +1,39 @@
 version: '3.6'
 
 services:
-  api:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/api
-    command: yarn nodemon
-    ports:
-      - 31300:3000
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-  mongo:
-    image: mongo:4.2.8
-    logging:
-      driver: none
-    ports:
-      - 27017:27017
-    volumes:
-      - mongodb:/data/db
-  rabbitmq:
-    image: rabbitmq:3-management
-    environment:
-      RABBITMQ_DEFAULT_VHOST: /
-    logging:
-      driver: none
-    ports:
-      - 30672:5672
-      - 31672:15672
-  rabbitmq-declare-topology:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://rabbitmq:5672 -timeout 5m -wait-retry-interval 10s sh -c "yarn tsc && node dist/topology.js"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-  socket-new-block:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/sockets/newBlock.ts"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-      - mongo
-  socket-new-transaction:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/sockets/newTransaction.ts"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-      - mongo
   unchained-local:
     image: unchained-local
     build:
       context: .
       dockerfile: Dockerfile.local
+
   watcher:
     image: unchained-local
     working_dir: /app
     command: sh -c "yarn lerna run watch --scope @shapeshiftoss/* --parallel"
     volumes:
       - .:/app
-  worker-newBlock:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/newBlock.ts"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-      - mongo
-  worker-block:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/block.ts"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-      - mongo
-  worker-txid:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/txid.ts"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-      - mongo
-  worker-tx:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/tx.ts"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-      - mongo
-  worker-address:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/address.ts"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-      - mongo
-  worker-registry:
-    image: unchained-local
-    env_file: ./coinstacks/${COINSTACK}/.env
-    environment:
-      BROKER_URL: amqp://guest:guest@rabbitmq:5672
-      MONGO_URL: mongodb://mongo:27017
-    working_dir: /app/coinstacks/${COINSTACK}/ingester
-    command: dockerize -wait tcp://mongo:27017 -wait http://guest:guest@rabbitmq:15672/api/exchanges/%2f/exchange.coinstack -timeout 5m -wait-retry-interval 10s sh -c "yarn ts-node-dev --watch ../../../packages/*/dist/tsconfig.tsbuildinfo,../../common/ingester/dist/tsconfig.tsbuildinfo --respawn --transpile-only src/workers/registry.ts"
-    volumes:
-      - .:/app
-    depends_on:
-      - unchained-local
-      - rabbitmq
-      - mongo
 
-volumes:
-  mongodb:
+  reverse-proxy:
+    # The official v2 Traefik docker image
+    image: traefik:v2.5
+    # Enables the web UI and tells Traefik to listen to docker
+    command: --api.insecure=true --providers.docker
+    networks:
+      - bitcoin_default
+      - ethereum_default
+    ports:
+      # The HTTP port
+      - '80:80'
+      # The Web UI (enabled by --api.insecure=true)
+      - '8080:8080'
+    volumes:
+      # So that Traefik can listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock
+
+networks:
+   bitcoin_default:
+    name: bitcoin_default
+   ethereum_default:
+    name: ethereum_default
+

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "husky": "^7.0.0",
+    "husky": "^7.0.2",
     "jest": "^27.2.5",
     "nodemon": "^2.0.6",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:coverage": "jest --coverage",
     "version:major": "lerna version major --force-publish --no-push",
     "version:minor": "lerna version minor --force-publish --no-push",
-    "version:patch": "lerna version patch --force-publish --no-push"
+    "version:patch": "lerna version patch --force-publish --no-push",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@pulumi/kubernetes": "3.6.3",
@@ -37,7 +38,7 @@
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "husky": "^7.0.2",
+    "husky": "^7.0.0",
     "jest": "^27.2.5",
     "nodemon": "^2.0.6",
     "prettier": "^2.2.1",


### PR DESCRIPTION
It has become apparent that we need to be able to run multiple coinstacks locally. At first this would have required exposing each service at different ports.

So I decided to use a reverse proxy to handle all traffic to all container. Now the only ports exposed are port `80` for the reverse proxy and port `8080` for the proxies dashboard. all routing to coinstacks can be done via localhost now. For example

`api.bitcoin.localhost/docs`
`rabbit-admin.ethereum.localhost`
`mongo.bitcoin.localhost`

This should simplify networking locally.

To use this now simply run `docker-compose up` in the root of the project. Then run `docker-compose up` in the coinstacks you want to run.