### PR TITLE
Return both confirmed and unconfirmed utxos

### DIFF
--- a/coinstacks/bitcoin/api/src/controller.ts
+++ b/coinstacks/bitcoin/api/src/controller.ts
@@ -204,7 +204,7 @@ export class Bitcoin extends Controller implements BaseAPI, BitcoinAPI {
   @Get('account/{pubkey}/utxos')
   async getUtxos(@Path() pubkey: string): Promise<Array<Utxo>> {
     try {
-      const data = await blockbook.getUtxo(pubkey, true)
+      const data = await blockbook.getUtxo(pubkey)
       return data
     } catch (err) {
       throw new ApiError(err.response, err.response.status, JSON.stringify(err.response.data))


### PR DESCRIPTION
This will now take into consideration uncomfirmed transactions to avoid constructing double spend transactions on accident. If a utxo is still pending to be received, it will be listed and have `confirmations: 0` so the client can decide if they would like to construct a transaction with a pending utxo or not.