### PR TITLE
Use Memory Optimized Instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,6 @@ jobs:
             pulumi config set --path unchained:common.eks.autoscaling.maxInstances 3
             pulumi config set --path unchained:common.eks.instanceTypes[0] r5.4xlarge
             pulumi config set --path unchained:common.eks.instanceTypes[1] r5b.4xlarge
-            pulumi config set --path unchained:common.eks.instanceTypes[2] r6gd.4xlarge
             pulumi config set --path unchained:common.eks.logging.enabled true
             pulumi config set --path unchained:common.eks.logging.persistentVolume true
             pulumi config set --path unchained:common.eks.logging.pvSize 50Gi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,9 @@ jobs:
             pulumi config set --path unchained:common.eks.autoscaling.minInstances 2
             pulumi config set --path unchained:common.eks.autoscaling.maxInstances 3
             pulumi config set --path unchained:common.eks.instanceTypes[0] r5.4xlarge
-            pulumi config set --path unchained:common.eks.instanceTypes[1] r5b.4xlarge
+            pulumi config set --path unchained:common.eks.instanceTypes[1] r5a.4xlarge
+            pulumi config set --path unchained:common.eks.instanceTypes[2] r5b.4xlarge
+            pulumi config set --path unchained:common.eks.instanceTypes[3] r5n.4xlarge
             pulumi config set --path unchained:common.eks.logging.enabled true
             pulumi config set --path unchained:common.eks.logging.persistentVolume true
             pulumi config set --path unchained:common.eks.logging.pvSize 50Gi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,9 +203,9 @@ jobs:
             pulumi config set --path unchained:common.eks.autoscaling.enabled true
             pulumi config set --path unchained:common.eks.autoscaling.minInstances 2
             pulumi config set --path unchained:common.eks.autoscaling.maxInstances 3
-            pulumi config set --path unchained:common.eks.instanceTypes[0] m5.4xlarge
-            pulumi config set --path unchained:common.eks.instanceTypes[1] m5a.4xlarge
-            pulumi config set --path unchained:common.eks.instanceTypes[2] m5ad.4xlarge
+            pulumi config set --path unchained:common.eks.instanceTypes[0] r5.4xlarge
+            pulumi config set --path unchained:common.eks.instanceTypes[1] r5b.4xlarge
+            pulumi config set --path unchained:common.eks.instanceTypes[2] r6gd.4xlarge
             pulumi config set --path unchained:common.eks.logging.enabled true
             pulumi config set --path unchained:common.eks.logging.persistentVolume true
             pulumi config set --path unchained:common.eks.logging.pvSize 50Gi


### PR DESCRIPTION
Our current instance types running in unchained, along with their discounted hourly rate, and the % chance of interruption

m5.4xlarge -- $.29 -- >20%
m5a.4xlarge -- $.43 -- >20%
m5ad.4xlarge -- $.49 -- 5-10%

Lately, we've only been scheduled m5ad.4xlarge, but even those are being removed what seems like 6-7 times per day.

I propose we use memory-optimized instances, there's way more of them, and all three will be cheaper than what we're currently running. 

r5.4xlarge -- $.32 -- 10-15%
r5a.4xlarge -- $.36 -- 5-10%
r5b.4xlarge -- $.27 -- <5%
r5n.4xlarge -- $.27 -- 5-10%