### PR TITLE
RabbitMQ Memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
     mongo-storage-size: 100Gi
     mongo-url: mongodb://bitcoin-mongodb-0.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017,bitcoin-mongodb-1.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017,bitcoin-mongodb-2.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
     rabbit-cpu-limit: '1'
-    rabbit-memory-limit: '2Gi'
+    rabbit-memory-limit: '4Gi'
     rabbit-storage-size: '100Gi'
     rabbit-replicas: 3
     indexer-cpu-limit: '4'
@@ -65,7 +65,7 @@ aliases:
     mongo-storage-size: 100Gi
     mongo-url: mongodb://ethereum-mongodb-0.ethereum-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-mongodb-1.ethereum-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-mongodb-2.ethereum-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
     rabbit-cpu-limit: '1'
-    rabbit-memory-limit: '2Gi'
+    rabbit-memory-limit: '4Gi'
     rabbit-storage-size: '100Gi'
     rabbit-replicas: 3
     indexer-cpu-limit: '4'
@@ -91,7 +91,7 @@ aliases:
     mongo-storage-size: 100Gi
     mongo-url: mongodb://ethereum-ropsten-mongodb-0.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-ropsten-mongodb-1.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-ropsten-mongodb-2.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
     rabbit-cpu-limit: '1'
-    rabbit-memory-limit: '2Gi'
+    rabbit-memory-limit: '4Gi'
     rabbit-storage-size: '100Gi'
     rabbit-replicas: 3
     indexer-cpu-limit: '4'
@@ -238,7 +238,7 @@ jobs:
     executor: pulumi
     environment:
       DOCKER_BUILDKIT: 1
-      LOG_LEVEL: info
+      LOG_LEVEL: debug
       MIDGARD_URL: https://midgard.thorchain.info
       MONGO_DBNAME: coinstack
     parameters:


### PR DESCRIPTION
We have been experiencing issues with ingesters communicating with RabbitMQ, memory alerts have been found.  

-Double RabbitMQ memory
-Increase logging verbosity on coinstacks