### PR TITLE
Traefik observability

### DIFF
--- a/node/monitoring/loki.ts
+++ b/node/monitoring/loki.ts
@@ -86,7 +86,7 @@ export class Deployment extends pulumi.ComponentResource {
         values: {
           podAnnotations: {
             'prometheus.io/scrape': 'true',
-            'prometheus.io/port': '3101'
+            'prometheus.io/port': '3101',
           },
           config: {
             lokiAddress: `http://${name}-loki:3100/loki/api/v1/push`,
@@ -120,14 +120,14 @@ export class Deployment extends pulumi.ComponentResource {
                     selector: '{app="traefik"}|="/ping"',
                     action: 'drop',
                     drop_counter_reason: 'traefik_ping',
-                  }
+                  },
                 },
                 {
                   match: {
                     selector: '{app="traefik"}|="/metrics"',
                     action: 'drop',
                     drop_counter_reason: 'traefik_metrics',
-                  }
+                  },
                 },
                 {
                   match: {
@@ -143,9 +143,9 @@ export class Deployment extends pulumi.ComponentResource {
                             RequestHost: 'RequestHost',
                             RequestMethod: 'RequestMethod',
                             RequestPath: 'RequestPath',
-                            RequestProtocol: 'RequestProtocol'
-                          }
-                        }
+                            RequestProtocol: 'RequestProtocol',
+                          },
+                        },
                       },
                       {
                         labels: {
@@ -153,21 +153,22 @@ export class Deployment extends pulumi.ComponentResource {
                           DownstreamStatus: 'DownstreamStatus',
                           RequestHost: 'RequestHost',
                           RequestMethod: 'RequestMethod',
-                        }
+                        },
                       },
                       {
                         template: {
                           source: 'output_msg',
-                          template: '{{ .ClientHost }} - {{ .RequestMethod }} {{ .RequestPath }} {{ .RequestProtocol }} {{ .DownstreamStatus }} {{ .OriginContentSize }} {{ .Duration }}'
-                        }
+                          template:
+                            '{{ .ClientHost }} - {{ .RequestMethod }} {{ .RequestPath }} {{ .RequestProtocol }} {{ .DownstreamStatus }} {{ .OriginContentSize }} {{ .Duration }}',
+                        },
                       },
                       {
                         output: {
-                          source: 'output_msg'
-                        }
-                      }
-                    ]
-                  }
+                          source: 'output_msg',
+                        },
+                      },
+                    ],
+                  },
                 },
               ],
             },

--- a/node/monitoring/loki.ts
+++ b/node/monitoring/loki.ts
@@ -84,6 +84,10 @@ export class Deployment extends pulumi.ComponentResource {
         namespace: args.namespace,
         version: '3.8.2',
         values: {
+          podAnnotations: {
+            'prometheus.io/scrape': 'true',
+            'prometheus.io/port': '3101'
+          },
           config: {
             lokiAddress: `http://${name}-loki:3100/loki/api/v1/push`,
             snippets: {
@@ -110,6 +114,60 @@ export class Deployment extends pulumi.ComponentResource {
                       },
                     ],
                   },
+                },
+                {
+                  match: {
+                    selector: '{app="traefik"}|="/ping"',
+                    action: 'drop',
+                    drop_counter_reason: 'traefik_ping',
+                  }
+                },
+                {
+                  match: {
+                    selector: '{app="traefik"}|="/metrics"',
+                    action: 'drop',
+                    drop_counter_reason: 'traefik_metrics',
+                  }
+                },
+                {
+                  match: {
+                    selector: '{app="traefik"}|~"ClientHost"',
+                    stages: [
+                      {
+                        json: {
+                          expressions: {
+                            ClientHost: 'ClientHost',
+                            DownstreamStatus: 'DownstreamStatus',
+                            Duration: 'Duration',
+                            OriginContentSize: 'OriginContentSize',
+                            RequestHost: 'RequestHost',
+                            RequestMethod: 'RequestMethod',
+                            RequestPath: 'RequestPath',
+                            RequestProtocol: 'RequestProtocol'
+                          }
+                        }
+                      },
+                      {
+                        labels: {
+                          ClientHost: 'ClientHost',
+                          DownstreamStatus: 'DownstreamStatus',
+                          RequestHost: 'RequestHost',
+                          RequestMethod: 'RequestMethod',
+                        }
+                      },
+                      {
+                        template: {
+                          source: 'output_msg',
+                          template: '{{ .ClientHost }} - {{ .RequestMethod }} {{ .RequestPath }} {{ .RequestProtocol }} {{ .DownstreamStatus }} {{ .OriginContentSize }} {{ .Duration }}'
+                        }
+                      },
+                      {
+                        output: {
+                          source: 'output_msg'
+                        }
+                      }
+                    ]
+                  }
                 },
               ],
             },

--- a/node/pulumi/package.json
+++ b/node/pulumi/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
-    "@shapeshiftoss/cluster-launcher": "0.6.9",
+    "@shapeshiftoss/cluster-launcher": "0.7.0",
     "@types/folder-hash": "^4.0.0",
     "folder-hash": "^4.0.0"
   }

--- a/node/pulumi/package.json
+++ b/node/pulumi/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
-    "@shapeshiftoss/cluster-launcher": "0.7.0",
+    "@shapeshiftoss/cluster-launcher": "0.7.1",
     "@types/folder-hash": "^4.0.0",
     "folder-hash": "^4.0.0"
   }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2172,10 +2172,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-1.6.1.tgz#d9a7928543349536f4cdaf4455de0f6966eed0f4"
   integrity sha512-T7LPjZO9YLuTfVPg2bBbqJH5mSWbcGrcmTJYd41QBRkS1XlAhI63gscENkPo2WeNunrEJFLHITiwk/ddlkme8A==
 
-"@shapeshiftoss/cluster-launcher@0.6.9":
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/cluster-launcher/-/cluster-launcher-0.6.9.tgz#eaa72968dc18121600cf49dcb28f5131e06b7512"
-  integrity sha512-blq7+DiPdbdluWuyJ+9HxyKuRbhBZ+lgH3rng3kRYWmiZiJkBziBot39NPgLsKVcPPwuLrEUSSziuMHuGf9JWQ==
+"@shapeshiftoss/cluster-launcher@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/cluster-launcher/-/cluster-launcher-0.7.1.tgz#75cdd21fb70e10adbbed716236f388deb09739ca"
+  integrity sha512-EfYUzz5hh++/zngkH1WFwYs8ZRMWh46LnDgZ6S3cXlud9xS6W0xFnt3NSFjx6cn+c7hkXV0xmV8Yuup5JFxoVg==
   dependencies:
     "@pulumi/aws" "4.17.0"
     "@pulumi/awsx" "0.31.0"


### PR DESCRIPTION
Configure Loki/Promtail with custom pipelines for Traefik log messages. This will enhance our ability to see what requests are hitting the cluster. 

Update Traefik helm chart to latest version in cluster launcher.
https://github.com/shapeshift/cluster-launcher/pull/13