### PR TITLE
Traefik Autoscaling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,11 @@ jobs:
             pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[1] r5a.4xlarge
             pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[2] r5b.4xlarge
             pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[3] r5n.4xlarge
+            pulumi config set --path unchained:common.eks.traefik.autoscaling.enabled true
+            pulumi config set --path unchained:common.eks.traefik.autoscaling.cpuThreshold 30
+            pulumi config set --path unchained:common.eks.traefik.autoscaling.maxReplicas 10
+            pulumi config set --path unchained:common.eks.traefik.replicas 3
+            pulumi config set --path unchained:common.eks.traefik.resources.cpu 300m
             pulumi config set --path unchained:common.eks.traefik.replicas 7
             pulumi config set --path unchained:common.eks.traefik.resources.cpu 500m
             pulumi config set --path unchained:common.eks.traefik.resources.memory 512Mi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,8 +277,6 @@ jobs:
             pulumi config set --path unchained:common.eks.traefik.autoscaling.maxReplicas 10
             pulumi config set --path unchained:common.eks.traefik.replicas 3
             pulumi config set --path unchained:common.eks.traefik.resources.cpu 300m
-            pulumi config set --path unchained:common.eks.traefik.replicas 7
-            pulumi config set --path unchained:common.eks.traefik.resources.cpu 500m
             pulumi config set --path unchained:common.eks.traefik.resources.memory 512Mi
             pulumi config set --path unchained:common.eks.traefik.whitelist[0] 173.245.48.0/20
             pulumi config set --path unchained:common.eks.traefik.whitelist[1] 103.21.244.0/22

--- a/node/pulumi/Pulumi.sample.yaml
+++ b/node/pulumi/Pulumi.sample.yaml
@@ -67,6 +67,11 @@ config:
 
     # # traefik - additional ingress controller configuration
     #   traefik:
+    #     # autoscaling - if enabled, a horizontal pod autoscaler will be deployed
+    #     autoscaling:
+    #       enabled: false
+    #       cpuThreshold: 30
+    #       maxReplicas: 5
     #     replicas: 3
     #     resources:
     #       cpu: '300m'

--- a/node/pulumi/package.json
+++ b/node/pulumi/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
-    "@shapeshiftoss/cluster-launcher": "0.7.1",
+    "@shapeshiftoss/cluster-launcher": "0.7.2",
     "@types/folder-hash": "^4.0.0",
     "folder-hash": "^4.0.0"
   }


### PR DESCRIPTION
This PR leverages new functionality in [cluster launcher](https://github.com/shapeshift/cluster-launcher/pull/14) that will allow for a horizontal pod autoscaler to be deployed alongside the traefik deployment.

Horizonal pod autoscaling will allow us to ask for less CPU per pod (`500m` --> `300m`) and use less replicas (`7` --> `3`). If the aggregate CPU utilization across all pods exceeds 30%, a new replica will be added to the deployment. With the ability to scale up to 10 replicas.