### PR TITLE
Ingester Autoscaling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,11 @@ aliases:
     api-cpu-limit: "500m"
     api-cpu-threshold: 30
     api-memory-limit: "2Gi"
-    ingester-replicas: 3
-    ingester-cpu-limit: "1"
+    ingester-autoscaling: true
+    ingester-replicas: 2
+    ingester-max-replicas: 4
+    ingester-cpu-threshold: 20
+    ingester-cpu-limit: "500m"
     ingester-memory-limit: "3Gi"
     rpc-url: http://user:password@bitcoin-indexer-svc.unchained.svc.cluster.local:8332
 
@@ -88,8 +91,11 @@ aliases:
     api-cpu-limit: "500m"
     api-cpu-threshold: 30
     api-memory-limit: "2Gi"
-    ingester-replicas: 3
-    ingester-cpu-limit: "1"
+    ingester-autoscaling: true
+    ingester-replicas: 2
+    ingester-max-replicas: 4
+    ingester-cpu-threshold: 20
+    ingester-cpu-limit: "500m"
     ingester-memory-limit: "3Gi"
     rpc-url: http://ethereum-indexer-svc.unchained.svc.cluster.local:8332
 
@@ -122,8 +128,11 @@ aliases:
     api-cpu-threshold: 30
     api-cpu-limit: "500m"
     api-memory-limit: "2Gi"
+    ingester-autoscaling: true
     ingester-replicas: 2
-    ingester-cpu-limit: "1"
+    ingester-max-replicas: 4
+    ingester-cpu-threshold: 20
+    ingester-cpu-limit: "500m"
     ingester-memory-limit: "3Gi"
     rpc-url: http://ethereum-ropsten-indexer-svc.unchained.svc.cluster.local:8332
 
@@ -396,11 +405,17 @@ jobs:
         type: string
       api-replicas:
         type: integer
+      ingester-autoscaling:
+        type: boolean
       ingester-cpu-limit:
         type: string
+      ingester-cpu-threshold:
+        type: integer
       ingester-memory-limit:
         type: string
       ingester-replicas:
+        type: integer
+      ingester-max-replicas:
         type: integer
     steps:
       - setup_remote_docker:
@@ -449,6 +464,9 @@ jobs:
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.daemon.cpuLimit << parameters.daemon-cpu-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.daemon.memoryLimit << parameters.daemon-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.daemon.storageSize << parameters.daemon-storage-size >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.ingester.autoscaling.enabled << parameters.ingester-autoscaling >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.ingester.autoscaling.cpuThreshold << parameters.ingester-cpu-threshold >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.ingester.autoscaling.maxReplicas << parameters.ingester-max-replicas >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.cpuLimit << parameters.ingester-cpu-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.memoryLimit << parameters.ingester-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.replicas << parameters.ingester-replicas >>
@@ -540,8 +558,11 @@ workflows:
           api-cpu-limit: "300m"
           api-cpu-threshold: 30
           api-memory-limit: "1Gi"
-          ingester-replicas: 2
+          ingester-autoscaling: true
+          ingester-replicas: 1
+          ingester-max-replcas: 2
           ingester-cpu-limit: "500m"
+          ingester-cpu-threshold: 20
           ingester-memory-limit: "2Gi"
           requires:
             - deploy common unchained dependencies
@@ -566,8 +587,11 @@ workflows:
           api-cpu-limit: "300m"
           api-cpu-threshold: 30
           api-memory-limit: "1Gi"
-          ingester-replicas: 2
+          ingester-autoscaling: true
+          ingester-replicas: 1
+          ingester-max-replcas: 2
           ingester-cpu-limit: "500m"
+          ingester-cpu-threshold: 20
           ingester-memory-limit: "2Gi"
           requires:
             - deploy common unchained dependencies
@@ -593,8 +617,11 @@ workflows:
           api-cpu-limit: "300m"
           api-cpu-threshold: 30
           api-memory-limit: "1Gi"
-          ingester-replicas: 2
+          ingester-autoscaling: true
+          ingester-replicas: 1
+          ingester-max-replcas: 2
           ingester-cpu-limit: "500m"
+          ingester-cpu-threshold: 20
           ingester-memory-limit: "2Gi"
           requires:
             - deploy common unchained dependencies

--- a/node/coinstacks/bitcoin/pulumi/Pulumi.sample.yaml
+++ b/node/coinstacks/bitcoin/pulumi/Pulumi.sample.yaml
@@ -29,11 +29,17 @@ config:
       replicas: 1
 
     ## ingester - if specified all ingestion workers will be deployed
+    ## All ingesters use 1 replica with the exception of tx and address workers, which are configured for high availability
+    ## If autoscaling is enabled, horizontal pod autoscalers will be deployed to high availability workers
     ingester:
       enableDatadogLogs: false
+      autoscaling:
+        enabled: false
+        cpuThreshold: 30
+        maxReplicas: 2
       cpuLimit: '300m'
       memoryLimit: '512Mi'
-      replicas: 1 ## Current HA ingester workers are tx and address, all other workers will be single instance
+      replicas: 1
 
     ## mongo - if specified a mongo database will be deployed
     mongo:

--- a/node/coinstacks/bitcoin/pulumi/config.ts
+++ b/node/coinstacks/bitcoin/pulumi/config.ts
@@ -95,6 +95,9 @@ export const getConfig = async (): Promise<BitcoinConfig> => {
   }
 
   if (config.ingester) {
+    if (!config.ingester.autoscaling.enabled) missingRequiredConfig.push('ingester.autoscaling.enabled')
+    if (!config.ingester.autoscaling.maxReplicas) missingRequiredConfig.push('ingester.autoscaling.maxReplicas')
+    if (!config.ingester.autoscaling.cpuThreshold) missingRequiredConfig.push('ingester.autoscaling.cpuThreshold')
     if (!config.ingester.cpuLimit) missingRequiredConfig.push('ingester.cpuLimit')
     if (!config.ingester.memoryLimit) missingRequiredConfig.push('ingester.memoryLimit')
     if (!config.ingester.replicas) missingRequiredConfig.push('ingester.replicas')

--- a/node/coinstacks/common/pulumi/src/ingester.ts
+++ b/node/coinstacks/common/pulumi/src/ingester.ts
@@ -9,6 +9,7 @@ import { Input, output, Resource } from '@pulumi/pulumi'
 import { buildAndPushImage, Config, hasTag, getBaseHash } from './index'
 
 export interface IngesterConfig {
+  autoscaling: { enabled: boolean; cpuThreshold: number; maxReplicas: number }
   cpuLimit: string
   memoryLimit: string
   replicas: number
@@ -157,12 +158,14 @@ export async function deployIngester(
     name: string
     path: string
     replicas: 0 | 1
+    autoscaling: boolean
   }
 
   type Worker = {
     name: string
     path: string
     replicas: number
+    autoscaling: boolean
   }
 
   type Workers = Array<Socket | Worker>
@@ -170,19 +173,19 @@ export async function deployIngester(
   const socket = (s: Socket): Socket => s
   const worker = (w: Worker): Worker => w
 
-  // All ingester workers are single instance except tx and address workers
+  // We have hard-coded high availability workers here, need to break this into configuration
   const workers: Workers = [
-    socket({ name: 'socket-new-transaction', path: 'sockets/newTransaction', replicas: 1 }),
-    socket({ name: 'socket-new-block', path: 'sockets/newBlock', replicas: 1 }),
-    worker({ name: 'worker-new-block', path: 'workers/newBlock', replicas: 1 }),
-    worker({ name: 'worker-block', path: 'workers/block', replicas: 1 }),
-    worker({ name: 'worker-txid', path: 'workers/txid', replicas: 1 }),
-    worker({ name: 'worker-tx', path: 'workers/tx', replicas: config.ingester.replicas }),
-    worker({ name: 'worker-address', path: 'workers/address', replicas: config.ingester.replicas }),
-    worker({ name: 'worker-registry', path: 'workers/registry', replicas: 1 }),
+    socket({ name: 'socket-new-transaction', path: 'sockets/newTransaction', replicas: 1, autoscaling: false }),
+    socket({ name: 'socket-new-block', path: 'sockets/newBlock', replicas: 1, autoscaling: false  }),
+    worker({ name: 'worker-new-block', path: 'workers/newBlock', replicas: 1, autoscaling: false }),
+    worker({ name: 'worker-block', path: 'workers/block', replicas: 1, autoscaling: false }),
+    worker({ name: 'worker-txid', path: 'workers/txid', replicas: 1, autoscaling: false }),
+    worker({ name: 'worker-tx', path: 'workers/tx', replicas: config.ingester.replicas, autoscaling: true }),
+    worker({ name: 'worker-address', path: 'workers/address', replicas: config.ingester.replicas, autoscaling: true }),
+    worker({ name: 'worker-registry', path: 'workers/registry', replicas: 1, autoscaling: false }),
   ]
 
-  const { enableDatadogLogs, cpuLimit, memoryLimit } = config.ingester
+  const { enableDatadogLogs, cpuLimit, memoryLimit, autoscaling  } = config.ingester
 
   return workers.map((worker) => {
     const datadogAnnotation = enableDatadogLogs
@@ -243,6 +246,28 @@ export async function deployIngester(
         ],
         volumes: volumes,
       },
+    }
+
+    if (worker.autoscaling && autoscaling.enabled) {
+      new k8s.autoscaling.v1.HorizontalPodAutoscaler(
+        `${name}-${worker.name}`,
+        {
+          metadata: {
+            namespace: namespace,
+          },
+          spec: {
+            minReplicas: worker.replicas,
+            maxReplicas: autoscaling.maxReplicas,
+            scaleTargetRef: {
+              apiVersion: 'apps/v1',
+              kind: 'Deployment',
+              name: `${name}-${worker.name}`
+            },
+            targetCPUUtilizationPercentage: autoscaling.cpuThreshold
+          }
+        },
+        { provider, dependsOn: deployDependencies }
+      )
     }
 
     return new k8s.apps.v1.Deployment(

--- a/node/coinstacks/ethereum/pulumi/Pulumi.sample.yaml
+++ b/node/coinstacks/ethereum/pulumi/Pulumi.sample.yaml
@@ -30,11 +30,17 @@ config:
 
 
     ## ingester - if specified all ingestion workers will be deployed
+    ## All ingesters use 1 replica with the exception of tx and address workers, which are configured for high availability
+    ## If autoscaling is enabled, horizontal pod autoscalers will be deployed alongside high availability worker deployments
     ingester:
+      enableDatadogLogs: false
+      autoscaling:
+        enabled: false
+        cpuThreshold: 30
+        maxReplicas: 2
       cpuLimit: '300m'
       memoryLimit: '512Mi'
-      replicas: 1 ## Current HA ingester workers are tx and address, all other workers will be single instance
-      enableDatadogLogs: false
+      replicas: 1
 
     ## mongo - if specified a mongo database will be deployed
     mongo:

--- a/node/coinstacks/ethereum/pulumi/config.ts
+++ b/node/coinstacks/ethereum/pulumi/config.ts
@@ -95,6 +95,9 @@ export const getConfig = async (): Promise<EthereumConfig> => {
   }
 
   if (config.ingester) {
+    if (!config.ingester.autoscaling.enabled) missingRequiredConfig.push('ingester.autoscaling.enabled')
+    if (!config.ingester.autoscaling.maxReplicas) missingRequiredConfig.push('ingester.autoscaling.maxReplicas')
+    if (!config.ingester.autoscaling.cpuThreshold) missingRequiredConfig.push('ingester.autoscaling.cpuThreshold')
     if (!config.ingester.cpuLimit) missingRequiredConfig.push('ingester.cpuLimit')
     if (!config.ingester.memoryLimit) missingRequiredConfig.push('ingester.memoryLimit')
     if (!config.ingester.replicas) missingRequiredConfig.push('ingester.replicas')


### PR DESCRIPTION
This PR adds the ability to deploy horizontal pod autoscalers alongside specific ingester worker deployments. Currently these workers are `tx` and `address`. 

This PR also reduces the CPU requested per worker, and reduces the replica count in dev from 2-->1 with autoscaling configured to scale up if needed.