### PR TITLE
Volume Rightsizing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,11 @@ aliases:
     mongo-cpu-limit: 512m
     mongo-memory-limit: 512Mi
     mongo-replicas: 3
-    mongo-storage-size: 100Gi
+    mongo-storage-size: 10Gi
     mongo-url: mongodb://bitcoin-mongodb-0.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017,bitcoin-mongodb-1.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017,bitcoin-mongodb-2.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
     rabbit-cpu-limit: "2"
     rabbit-memory-limit: "8Gi"
-    rabbit-storage-size: "100Gi"
+    rabbit-storage-size: "10Gi"
     indexer-cpu-limit: "4"
     indexer-memory-limit: 24Gi
     indexer-replicas: 3
@@ -70,11 +70,11 @@ aliases:
     mongo-cpu-limit: 512m
     mongo-memory-limit: 512Mi
     mongo-replicas: 3
-    mongo-storage-size: 100Gi
+    mongo-storage-size: 10Gi
     mongo-url: mongodb://ethereum-mongodb-0.ethereum-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-mongodb-1.ethereum-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-mongodb-2.ethereum-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
     rabbit-cpu-limit: "2"
     rabbit-memory-limit: "8Gi"
-    rabbit-storage-size: "100Gi"
+    rabbit-storage-size: "10Gi"
     indexer-cpu-limit: "4"
     indexer-memory-limit: 12Gi
     indexer-replicas: 3
@@ -107,11 +107,11 @@ aliases:
     mongo-cpu-limit: 512m
     mongo-memory-limit: 512Mi
     mongo-replicas: 3
-    mongo-storage-size: 100Gi
+    mongo-storage-size: 10Gi
     mongo-url: mongodb://ethereum-ropsten-mongodb-0.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-ropsten-mongodb-1.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-ropsten-mongodb-2.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
     rabbit-cpu-limit: "1"
     rabbit-memory-limit: "4Gi"
-    rabbit-storage-size: "100Gi"
+    rabbit-storage-size: "10Gi"
     indexer-cpu-limit: "4"
     indexer-memory-limit: 12Gi
     indexer-replicas: 2


### PR DESCRIPTION
Decrease EBS volume size of RabbitMQ and MongoDB persistent volumes.