### PR TITLE
fix: check readyState in unsubscribeTxs

### DIFF
--- a/node/packages/client/src/bitcoin/websocket.ts
+++ b/node/packages/client/src/bitcoin/websocket.ts
@@ -156,6 +156,9 @@ export class Client {
    * @param data.addresses list of addresses to unsubscribe from
    */
   unsubscribeTxs(subscriptionId?: string, data?: TxsTopicData): void {
+    if (this.connections.txs?.ws.readyState === WebSocket.CONNECTING) {
+      return
+    }
     if (!subscriptionId) this.txs = {}
     if (subscriptionId && !data?.addresses.length) delete this.txs[subscriptionId]
 

--- a/node/packages/client/src/bitcoin/websocket.ts
+++ b/node/packages/client/src/bitcoin/websocket.ts
@@ -156,9 +156,7 @@ export class Client {
    * @param data.addresses list of addresses to unsubscribe from
    */
   unsubscribeTxs(subscriptionId?: string, data?: TxsTopicData): void {
-    if (this.connections.txs?.ws.readyState === WebSocket.CONNECTING) {
-      return
-    }
+    if (this.connections.txs?.ws.readyState !== WebSocket.OPEN) return
     if (!subscriptionId) this.txs = {}
     if (subscriptionId && !data?.addresses.length) delete this.txs[subscriptionId]
 

--- a/node/packages/client/src/ethereum/websocket.ts
+++ b/node/packages/client/src/ethereum/websocket.ts
@@ -157,9 +157,7 @@ export class Client {
    * @param data.addresses list of addresses to unsubscribe from
    */
   unsubscribeTxs(subscriptionId?: string, data?: TxsTopicData): void {
-    if (this.connections.txs?.ws.readyState === WebSocket.CONNECTING) {
-      return
-    }
+    if (this.connections.txs?.ws.readyState !== WebSocket.OPEN) return
     if (!subscriptionId) this.txs = {}
     if (subscriptionId && !data?.addresses.length) delete this.txs[subscriptionId]
 

--- a/node/packages/client/src/ethereum/websocket.ts
+++ b/node/packages/client/src/ethereum/websocket.ts
@@ -157,6 +157,9 @@ export class Client {
    * @param data.addresses list of addresses to unsubscribe from
    */
   unsubscribeTxs(subscriptionId?: string, data?: TxsTopicData): void {
+    if (this.connections.txs?.ws.readyState === WebSocket.CONNECTING) {
+      return
+    }
     if (!subscriptionId) this.txs = {}
     if (subscriptionId && !data?.addresses.length) delete this.txs[subscriptionId]
 


### PR DESCRIPTION
## Description

@soptq has [made a PR ](https://github.com/shapeshift/web/pull/1010)to add programmatic login to Cypress.

It now connects to a wallet and starts running tests fast enough that we can end up in a state where we attempt to call `unsubscribeTxs`, and thus, `this.connections.txs?.ws.send(...)`, before we actually have a connected WebSocket.

This causes an exception in Cypress, and stops the tests.

This PR adds a check to ensure we do not attempt to send a payload via a WebSocket connection that is still `CONNECTING`.