### PR TITLE
AWS CI Credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,8 +252,8 @@ commands:
           command: |
             mkdir ~/.aws
             echo [default] >> ~/.aws/credentials
-            echo aws_access_key_id = $AWS_ACCESS_KEY_ID >> ~/.aws/credentials
-            echo aws_secret_access_key = $AWS_SECRET_ACCESS_KEY >> ~/.aws/credentials
+            echo aws_access_key_id = $SHAPESHIFT_AWS_ACCESS_KEY_ID >> ~/.aws/credentials
+            echo aws_secret_access_key = $SHAPESHIFT_AWS_SECRET_ACCESS_KEY >> ~/.aws/credentials
 
 jobs:
   deploy-dependencies:


### PR DESCRIPTION
We're in the process of configuring CI to deploy to two clusters simultaneously. Because `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are CI environment variables they are placed in the CI environment at the start of every workflow. Due to this the credentials placed in `~/.aws/credentials` aren't read by the AWS CLI in favor of using the default environment variables. 

Refer to the shapeshift specific credentials so that we can remove the defaults. 