### PR TITLE
Estimate gas feature for Cosmos 

### DIFF
--- a/go/coinstacks/cosmos/api/api.go
+++ b/go/coinstacks/cosmos/api/api.go
@@ -61,9 +61,9 @@ func Start(httpClient *cosmos.HTTPClient, grpcClient *cosmos.GRPCClient, errChan
 	v1Account.HandleFunc("/{pubkey}", a.Account).Methods("GET")
 	v1Account.HandleFunc("/{pubkey}/txs", a.TxHistory).Methods("GET")
 
-	v1gas := v1.PathPrefix("/gas").Subrouter()
+	v1gas := v1.PathPrefix("/gas/estimate").Subrouter()
 	v1gas.Use(validateRawTx)
-	v1gas.HandleFunc("/estimate", a.GasEstimation).Methods("GET")
+	v1gas.HandleFunc("/{txbytes}", a.GasEstimation).Methods("GET")
 
 	// docs redirect paths
 	r.HandleFunc("/", docsRedirect).Methods("GET")
@@ -203,13 +203,13 @@ func (a *API) SendTx(w http.ResponseWriter, r *http.Request) {
 //   422: ValidationError
 //   500: InternalServerError
 func (a *API) GasEstimation(w http.ResponseWriter, r *http.Request) {
-	body := &api.TxBody{}
-	err := json.NewDecoder(r.Body).Decode(body)
-	if err != nil {
-		handleError(w, http.StatusBadRequest, "invalid query parameter")
+	rawTx, ok := mux.Vars(r)["txbytes"]
+	if !ok || rawTx == "" {
+		handleError(w, http.StatusBadRequest, "raw transaction hash required")
 		return
 	}
-	gasUsed, err := a.handler.GetGasEstimation(body.Hex)
+
+	gasUsed, err := a.handler.GetGasEstimation(rawTx)
 	if err != nil {
 		handleError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/go/coinstacks/cosmos/api/api.go
+++ b/go/coinstacks/cosmos/api/api.go
@@ -57,7 +57,6 @@ func Start(httpClient *cosmos.HTTPClient, grpcClient *cosmos.GRPCClient, errChan
 	v1.HandleFunc("/send", a.SendTx).Methods("POST")
 
 	v1gas := v1.PathPrefix("/gas").Subrouter()
-	//v1gas.Use(validateRawTx)
 	v1gas.HandleFunc("/estimate", a.GasEstimation).Methods("POST")
 
 	v1Account := v1.PathPrefix("/account").Subrouter()
@@ -203,14 +202,10 @@ func (a *API) SendTx(w http.ResponseWriter, r *http.Request) {
 //   422: ValidationError
 //   500: InternalServerError
 func (a *API) GasEstimation(w http.ResponseWriter, r *http.Request) {
-	body := &api.TxBody{}
-	err := json.NewDecoder(r.Body).Decode(&body)
-	if err != nil {
-		handleError(w, http.StatusBadRequest, "invalid post body")
-		return
-	}
+	rawTx := &api.TxBody{}
 
-	gasUsed, err := a.handler.GetGasEstimation(body.Hex)
+	err := json.NewDecoder(r.Body).Decode(rawTx)
+	gasUsed, err := a.handler.GetGasEstimation(rawTx.Hex)
 	if err != nil {
 		handleError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/go/coinstacks/cosmos/api/api.go
+++ b/go/coinstacks/cosmos/api/api.go
@@ -1,4 +1,4 @@
-// Package api Package classification Cosmos Unchained API
+// Package classification Cosmos Unchained API
 //
 // Provides access to cosmos chain data
 //

--- a/go/coinstacks/cosmos/api/handlers.go
+++ b/go/coinstacks/cosmos/api/handlers.go
@@ -119,6 +119,7 @@ func (h *Handler) SendTx(hex string) (string, error) {
 }
 
 func (h *Handler) GetGasEstimation(hex string) (api.Gas, error) {
+
 	res, err := h.httpClient.GetGasEstimation([]byte(hex))
 	if err != nil {
 		return "", err

--- a/go/coinstacks/cosmos/api/handlers.go
+++ b/go/coinstacks/cosmos/api/handlers.go
@@ -117,3 +117,11 @@ func (h *Handler) GetTxHistory(pubkey string, page int, pageSize int) (api.TxHis
 func (h *Handler) SendTx(hex string) (string, error) {
 	return h.httpClient.BroadcastTx([]byte(hex))
 }
+
+func (h *Handler) GetGasEstimation(hex string) (api.Gas, error) {
+	res, err := h.httpClient.GetGasEstimation([]byte(hex))
+	if err != nil {
+		return "", err
+	}
+	return api.Gas(res), nil
+}

--- a/go/coinstacks/cosmos/api/middleware.go
+++ b/go/coinstacks/cosmos/api/middleware.go
@@ -28,7 +28,7 @@ func validatePubkey(next http.Handler) http.Handler {
 
 func validateRawTx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rawTx, ok := mux.Vars(r)["rawtransactionhex"]
+		rawTx, ok := mux.Vars(r)["txbytes"]
 		if !ok || rawTx == "" {
 			handleError(w, http.StatusBadRequest, "raw transaction hash required")
 			return

--- a/go/coinstacks/cosmos/api/middleware.go
+++ b/go/coinstacks/cosmos/api/middleware.go
@@ -22,5 +22,23 @@ func validatePubkey(next http.Handler) http.Handler {
 		}
 
 		next.ServeHTTP(w, r)
+
+	})
+}
+
+func validateRawTx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawTx, ok := mux.Vars(r)["rawtransactionhex"]
+		if !ok || rawTx == "" {
+			handleError(w, http.StatusBadRequest, "raw transaction hash required")
+			return
+		}
+
+		if !cosmos.IsValidRawTx(rawTx) {
+			handleError(w, http.StatusBadRequest, fmt.Sprintf("invalid transaction: %s", rawTx))
+			return
+		}
+
+		next.ServeHTTP(w, r)
 	})
 }

--- a/go/coinstacks/cosmos/api/middleware.go
+++ b/go/coinstacks/cosmos/api/middleware.go
@@ -1,9 +1,7 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/shapeshift/go-unchained/pkg/api"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -25,29 +23,5 @@ func validatePubkey(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 
-	})
-}
-
-func validateRawTx(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-		rawTx := api.TxBody{}
-		err := json.NewDecoder(r.Body).Decode(&rawTx)
-
-		if err != nil {
-			handleError(w, http.StatusBadRequest, "invalid post body")
-			return
-		}
-		if rawTx.Hex == "" {
-			handleError(w, http.StatusBadRequest, "raw transaction hash required")
-			return
-		}
-
-		if !cosmos.IsValidRawTx(rawTx.Hex) {
-			handleError(w, http.StatusBadRequest, fmt.Sprintf("invalid transaction: %s", rawTx))
-			return
-		}
-
-		next.ServeHTTP(w, r)
 	})
 }

--- a/go/coinstacks/cosmos/api/middleware.go
+++ b/go/coinstacks/cosmos/api/middleware.go
@@ -22,6 +22,5 @@ func validatePubkey(next http.Handler) http.Handler {
 		}
 
 		next.ServeHTTP(w, r)
-
 	})
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/osmosis-labs/osmosis v1.0.4
 	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.6.0
-	github.com/spf13/viper v1.7.1
-	github.com/tendermint/tendermint v0.34.10
-	gitlab.com/thorchain/thornode v0.77.1
-	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	google.golang.org/grpc v1.40.0
-
+	github.com/sirupsen/logrus v1.8.1
+    github.com/spf13/viper v1.10.1
+    github.com/tendermint/liquidity v1.4.5
+    github.com/tendermint/tendermint v0.34.14
+    gitlab.com/thorchain/thornode v0.80.0
+    golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+    google.golang.org/grpc v1.44.0
 )
 
 require (

--- a/go/go.mod
+++ b/go/go.mod
@@ -14,6 +14,7 @@ require (
 	gitlab.com/thorchain/thornode v0.77.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	google.golang.org/grpc v1.40.0
+
 )
 
 require (

--- a/go/pkg/api/api.go
+++ b/go/pkg/api/api.go
@@ -1,4 +1,4 @@
-// provides a common base set of api types and functionality for all coinstacks to use,
+// Package api provides a common base set of api types and functionality for all coinstacks to use,
 // along with useful middlewares for an http server.
 package api
 

--- a/go/pkg/api/api.go
+++ b/go/pkg/api/api.go
@@ -1,4 +1,4 @@
-// Package api provides a common base set of api types and functionality for all coinstacks to use,
+// provides a common base set of api types and functionality for all coinstacks to use,
 // along with useful middlewares for an http server.
 package api
 
@@ -161,10 +161,13 @@ type TxParam struct {
 // swagger:model TransactionHash
 type TransactionHash string
 
+type Gas string
+
 // BaseAPI interface for all coinstacks to implement
 type BaseAPI interface {
 	GetInfo() (Info, error)
 	GetAccount(pubkey string) (Account, error)
 	GetTxHistory(pubkey string, page int, pageSize int) (TxHistory, error)
 	SendTx(hex string) (string, error)
+	GetGasEstimation(hex string) (Gas, error)
 }

--- a/go/pkg/cosmos/cosmos.go
+++ b/go/pkg/cosmos/cosmos.go
@@ -3,6 +3,7 @@ package cosmos
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptotypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -179,7 +180,8 @@ func IsValidAddress(address string) bool {
 
 func IsValidRawTx(txbyte string) bool {
 	encoding := NewEncoding()
-	decodedTx, err := encoding.TxConfig.TxJSONDecoder()([]byte(txbyte))
+	base64decode , err := base64.StdEncoding.DecodeString(txbyte)
+	decodedTx, err := encoding.TxConfig.TxJSONDecoder()((base64decode))
 	if err != nil {
 		return false
 	}

--- a/go/pkg/cosmos/cosmos.go
+++ b/go/pkg/cosmos/cosmos.go
@@ -3,8 +3,6 @@ package cosmos
 
 import (
 	"context"
-	"encoding/base64"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptotypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -180,8 +178,8 @@ func IsValidAddress(address string) bool {
 
 func IsValidRawTx(txbyte string) bool {
 	encoding := NewEncoding()
-	base64decode , err := base64.StdEncoding.DecodeString(txbyte)
-	decodedTx, err := encoding.TxConfig.TxJSONDecoder()((base64decode))
+	//base64decode , err := base64.StdEncoding.DecodeString(txbyte)
+	decodedTx, err := encoding.TxConfig.TxJSONDecoder()([]byte((txbyte)))
 	if err != nil {
 		return false
 	}

--- a/go/pkg/cosmos/cosmos.go
+++ b/go/pkg/cosmos/cosmos.go
@@ -176,21 +176,6 @@ func IsValidAddress(address string) bool {
 	return true
 }
 
-func IsValidRawTx(txbyte string) bool {
-	if len(txbyte) == 0 {
-		return false
-	}
-	checkValidity, err := DecodeData([]byte(txbyte))
-	if err != nil {
-		return false
-	}
-	err = checkValidity.ValidateBasic()
-	if err != nil {
-		return false
-	}
-	return true
-}
-
 func CodecRegister() *codec.ProtoCodec {
 	registry := cryptotypes.NewInterfaceRegistry()
 

--- a/go/pkg/cosmos/cosmos.go
+++ b/go/pkg/cosmos/cosmos.go
@@ -21,6 +21,7 @@ import (
 	ibcchanneltypes "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types"
 	ibctenderminttypes "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/07-tendermint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/go-resty/resty/v2"
 	"github.com/shapeshift/go-unchained/internal/log"
 	tendermintclient "github.com/shapeshift/go-unchained/pkg/tendermint/client"
@@ -173,5 +174,18 @@ func IsValidAddress(address string) bool {
 		return false
 	}
 
+	return true
+}
+
+func IsValidRawTx(txbyte string) bool {
+	encoding := NewEncoding()
+	decodedTx, err := encoding.TxConfig.TxJSONDecoder()([]byte(txbyte))
+	if err != nil {
+		return false
+	}
+	validateTxerr := decodedTx.ValidateBasic()
+	if validateTxerr != nil {
+		return false
+	}
 	return true
 }

--- a/go/pkg/cosmos/cosmos.go
+++ b/go/pkg/cosmos/cosmos.go
@@ -3,6 +3,7 @@ package cosmos
 
 import (
 	"context"
+	"encoding/base64"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptotypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -11,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -20,7 +22,6 @@ import (
 	ibcchanneltypes "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types"
 	ibctenderminttypes "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/07-tendermint/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
 	"github.com/go-resty/resty/v2"
 	"github.com/shapeshift/go-unchained/internal/log"
 	tendermintclient "github.com/shapeshift/go-unchained/pkg/tendermint/client"
@@ -177,9 +178,12 @@ func IsValidAddress(address string) bool {
 }
 
 func IsValidRawTx(txbyte string) bool {
-	encoding := NewEncoding()
-	//base64decode , err := base64.StdEncoding.DecodeString(txbyte)
-	decodedTx, err := encoding.TxConfig.TxJSONDecoder()([]byte((txbyte)))
+	base64decode, err := base64.StdEncoding.DecodeString(txbyte)
+	if err != nil {
+		return false
+	}
+	marshaler := codec.NewProtoCodec(cryptotypes.NewInterfaceRegistry())
+	decodedTx, err := authtx.DefaultTxDecoder(marshaler)(base64decode)
 	if err != nil {
 		return false
 	}

--- a/go/pkg/cosmos/gas.go
+++ b/go/pkg/cosmos/gas.go
@@ -2,24 +2,63 @@ package cosmos
 
 import (
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/pkg/errors"
+	types1 "github.com/tendermint/tendermint/abci/types"
 	"strconv"
 )
 
-var encoding = NewEncoding()
-
 func (c *HTTPClient) GetGasEstimation(txBytes []byte) (string, error) {
+	var res struct {
+		GasInfo struct {
+			GasWanted string `json:"gas_wanted"`
+			GasUsed   string `json:"gas_used"`
+		} `json:"gas_info"`
+		Result struct {
+			Data   string         `json:"data"`
+			Log    string         `json:"log"`
+			Events []types1.Event `json:"events"`
+		} `json:"result"`
+	}
+	hexToUnmarshal, err := c.encoding.TxConfig.TxDecoder()(txBytes)
+	if err != nil {
+		return "", err
+	}
+	reqData, err := c.encoding.TxConfig.WrapTxBuilder(hexToUnmarshal)
+	if err != nil {
+		return "", err
+	}
+	protoProvider, ok := reqData.(authtx.ProtoTxProvider)
+	if !ok {
+		return "", err
+	}
+	protoTx := protoProvider.GetProtoTx()
 
+	_, err = c.cosmos.R().SetBody(&txtypes.SimulateRequest{Tx: protoTx}).SetResult(&res).Post("/cosmos/tx/v1beta1/simulate")
+	if err != nil {
+		return "", errors.Wrap(err, res.Result.Log)
+	}
+	if res.GasInfo.GasWanted == "" {
+		return "", errors.New("gas_wanted is empty")
+	}
+	return res.GasInfo.GasUsed, nil
 }
 
 func (c *GRPCClient) GetGasEstimation(txBytes []byte) (string, error) {
-	// TODO : How to get asterisk Tx structure
+	hexToUnmarshal, err := c.encoding.TxConfig.TxDecoder()(txBytes)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to decode tx")
+		return "", err
 	}
-	request := txtypes.SimulateRequest{Tx: decodedTx}
-
-	res, err := c.tx.Simulate(c.ctx, &request)
+	reqData, err := c.encoding.TxConfig.WrapTxBuilder(hexToUnmarshal)
+	if err != nil {
+		return "", err
+	}
+	protoProvider, ok := reqData.(authtx.ProtoTxProvider)
+	if !ok {
+		return "", err
+	}
+	protoTx := protoProvider.GetProtoTx()
+	res, err := c.tx.Simulate(c.ctx, &txtypes.SimulateRequest{Tx: protoTx})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to Get transaction's gas estimation")
 	}

--- a/go/pkg/cosmos/gas.go
+++ b/go/pkg/cosmos/gas.go
@@ -1,0 +1,27 @@
+package cosmos
+
+import (
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/pkg/errors"
+	"strconv"
+)
+
+var encoding = NewEncoding()
+
+func (c *HTTPClient) GetGasEstimation(txBytes []byte) (string, error) {
+
+}
+
+func (c *GRPCClient) GetGasEstimation(txBytes []byte) (string, error) {
+	// TODO : How to get asterisk Tx structure
+	if err != nil {
+		return "", errors.Wrap(err, "failed to decode tx")
+	}
+	request := txtypes.SimulateRequest{Tx: decodedTx}
+
+	res, err := c.tx.Simulate(c.ctx, &request)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to Get transaction's gas estimation")
+	}
+	return strconv.FormatUint(res.GasInfo.GasUsed, 10), nil
+}

--- a/go/pkg/cosmos/gas.go
+++ b/go/pkg/cosmos/gas.go
@@ -24,18 +24,9 @@ func (c *HTTPClient) GetGasEstimation(txBytes []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	reqData, err := c.encoding.TxConfig.WrapTxBuilder(hexToUnmarshal)
-	if err != nil {
-		return "", err
-	}
-	protoProvider, ok := reqData.(authtx.ProtoTxProvider)
-	if !ok {
-		return "", err
-	}
-	protoTx := protoProvider.GetProtoTx()
-
-	_, err = c.tendermintClient.R().SetBody(&txtypes.SimulateRequest{Tx: protoTx}).SetResult(&res).Post("/cosmos/tx/v1beta1/simulate")
-
+	jsonreq, err := authtx.DefaultJSONTxEncoder(CodecRegister())(hexToUnmarshal)
+	response, err := c.cosmos.R().SetBody(jsonreq).SetResult(&res).Post("/cosmos/tx/v1beta1/simulate")
+	logger.Info(string(response.Body()))
 	if err != nil {
 		return "", errors.Wrap(err, res.Result.Log)
 	}

--- a/go/pkg/cosmos/gas.go
+++ b/go/pkg/cosmos/gas.go
@@ -4,7 +4,7 @@ import (
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/pkg/errors"
-	types1 "github.com/tendermint/tendermint/abci/types"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
 	"strconv"
 )
 
@@ -17,7 +17,7 @@ func (c *HTTPClient) GetGasEstimation(txBytes []byte) (string, error) {
 		Result struct {
 			Data   string         `json:"data"`
 			Log    string         `json:"log"`
-			Events []types1.Event `json:"events"`
+			Events []abcitypes.Event `json:"events"`
 		} `json:"result"`
 	}
 	hexToUnmarshal, err := c.encoding.TxConfig.TxDecoder()(txBytes)

--- a/go/pkg/cosmos/gas.go
+++ b/go/pkg/cosmos/gas.go
@@ -1,61 +1,125 @@
 package cosmos
 
 import (
-	"encoding/json"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/pkg/errors"
-	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"strconv"
 )
 
+//func (c *HTTPClient) GetGasEstimation(txBytes []byte) (string, error) {
+//	var res txtypes.SimulateResponse
+//
+//	decodeTx, err := DecodeData(txBytes)
+//	if err != nil {
+//		return "", err
+//	}
+//
+//	err = decodeTx.ValidateBasic()
+//	if err != nil {
+//		return "", err
+//	}
+//
+//	wrappedTxBuilder, err := c.encoding.TxConfig.WrapTxBuilder(decodeTx)
+//	if err != nil {
+//		return "", err
+//	}
+//	reqData := wrappedTxBuilder.(authtx.ProtoTxProvider).GetProtoTx()
+//	reqRawBody := txtypes.SimulateRequest{Tx: reqData}
+//	jsonBody, err := c.encoding.Marshaler.MarshalJSON(&reqRawBody)
+//	if err != nil {
+//		return "", err
+//	}
+//
+//	ret, err := c.cosmos.R().SetBody(jsonBody).SetResult(&res).Post("/cosmos/tx/v1beta1/simulate")
+//	if err != nil || ret.IsError() {
+//		var status = spb.Status{}
+//		json.Unmarshal(ret.Body(), &status)
+//		return status.GetMessage(), errors.Wrap(err, string(ret.Body()))
+//	}
+//
+//	return strconv.FormatUint(res.GasInfo.GasUsed, 10), nil
+//}
+
 func (c *HTTPClient) GetGasEstimation(txBytes []byte) (string, error) {
-	var res txtypes.SimulateResponse
+
+	type result struct {
+		Code      int         `json:"code"`
+		Data      interface{} `json:"data"`
+		Log       string      `json:"log"`
+		Info      string      `json:"info"`
+		GasWanted string      `json:"gas_wanted"`
+		GasUsed   string      `json:"gas_used"`
+		Events    interface{} `json:"events"`
+		Codespace string      `json:"codespace"`
+	}
+
+	type res struct {
+		Jsonrpc string `json:"jsonrpc"`
+		Id      string `json:"id"`
+		Result  result `json:"result"`
+	}
+	type Txparam struct {
+		Txbyte string `json:"tx"`
+	}
+	type req struct {
+		Id      string  `json:"id"`
+		Jsonrpc string  `json:"jsonrpc"`
+		Method  string  `json:"method"`
+		Params  Txparam `json:"params"`
+	}
 
 	decodeTx, err := DecodeData(txBytes)
 	if err != nil {
 		return "", err
 	}
+
+	err = decodeTx.ValidateBasic()
+	if err != nil {
+		return "", err
+	}
+	var parambyte = Txparam{Txbyte: string(txBytes)}
+	var jsonBody = req{
+		Jsonrpc: "2.0",
+		Method:  "check_tx",
+		Id:      "unchained",
+		Params:  parambyte,
+	}
+
+	var parsRes res
+	_, err = c.tendermint.R().SetBody(jsonBody).SetResult(&parsRes).Post("")
+	if err != nil {
+		return "", err
+
+	}
+	return parsRes.Result.GasUsed, nil
+}
+
+func (c *GRPCClient) GetGasEstimation(txBytes []byte) (string, error) {
+	decodeTx, err := DecodeData(txBytes)
+	if err != nil {
+		return "", err
+	}
+
+	err = decodeTx.ValidateBasic()
+	if err != nil {
+		return "", err
+	}
+
 	wrappedTxBuilder, err := c.encoding.TxConfig.WrapTxBuilder(decodeTx)
 	if err != nil {
 		return "", err
 	}
-	reqData := wrappedTxBuilder.(authtx.ProtoTxProvider).GetProtoTx()
-	reqRawBody := txtypes.SimulateRequest{Tx: reqData}
-	jsonBody, err := c.encoding.Marshaler.MarshalJSON(&reqRawBody)
-	if err != nil {
-		return "", err
-	}
-	ret, err := c.cosmos.R().SetBody(jsonBody).SetResult(&res).Post("/cosmos/tx/v1beta1/simulate")
 
-	if err != nil || ret.IsError() {
-		var status = spb.Status{}
-		json.Unmarshal(ret.Body(), &status)
-		return status.GetMessage(), errors.Wrap(err, string(ret.Body()))
-	}
-	if res.GasInfo.GasUsed == 0 {
-		return "", errors.New("gas_used is empty")
-	}
-	return strconv.FormatUint(res.GasInfo.GasUsed, 10), nil
-}
-
-func (c *GRPCClient) GetGasEstimation(txBytes []byte) (string, error) {
-	hexToUnmarshal, err := DecodeData(txBytes)
-	if err != nil {
-		return "", err
-	}
-	reqData, err := c.encoding.TxConfig.WrapTxBuilder(hexToUnmarshal)
-	if err != nil {
-		return "", err
-	}
-	protoProvider, ok := reqData.(authtx.ProtoTxProvider)
+	protoProvider, ok := wrappedTxBuilder.(authtx.ProtoTxProvider)
 	if !ok {
 		return "", err
 	}
-	protoTx := protoProvider.GetProtoTx()
-	res, err := c.tx.Simulate(c.ctx, &txtypes.SimulateRequest{Tx: protoTx})
+
+	res, err := c.tx.Simulate(c.ctx, &txtypes.SimulateRequest{Tx: protoProvider.GetProtoTx()})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to Get transaction's gas estimation")
 	}
+
 	return strconv.FormatUint(res.GasInfo.GasUsed, 10), nil
 }


### PR DESCRIPTION
Related : https://github.com/shapeshift/unchained/issues/234

- [X]Add a GET /gas/estimate endpoint
- [X]Use a query parameter for txBytes
- [X]Return a string value for the estimated gas used by the transaction
- [X]Include the necessary [go-swagger](https://goswagger.io/use/spec.html#annotation-syntax) annotations
- [X]Add a grpc handler for estimating gas using the appropriate [cosmos-sdk](https://github.com/cosmos/cosmos-sdk) functionality
- [X]Add an http handler for estimating gas using the appropriate cosmos [rest](https://v1.cosmos.network/rpc/v0.42.6) endpoint
- [ ]Verify an accurate gas estimation returned