### PR TITLE
feat: add "interactedWith" contract to Yearn metadata

### DIFF
--- a/node/packages/parser/src/ethereum/__tests__/ethereum.test.ts
+++ b/node/packages/parser/src/ethereum/__tests__/ethereum.test.ts
@@ -1122,6 +1122,7 @@ describe('parseTx', () => {
         data: {
           method: 'approve',
           parser: 'yearn',
+          interactedWith: SHAPE_SHIFT_ROUTER_CONTRACT,
         },
         value: tx.value,
         status: Status.Confirmed,
@@ -1151,6 +1152,7 @@ describe('parseTx', () => {
         data: {
           method: 'deposit',
           parser: 'yearn',
+          interactedWith: SHAPE_SHIFT_ROUTER_CONTRACT,
         },
         value: tx.value,
         status: Status.Confirmed,
@@ -1199,6 +1201,7 @@ describe('parseTx', () => {
         data: {
           method: 'withdraw',
           parser: 'yearn',
+          interactedWith: linkYearnVault.contract,
         },
         value: tx.value,
         status: Status.Confirmed,

--- a/node/packages/parser/src/ethereum/yearn.ts
+++ b/node/packages/parser/src/ethereum/yearn.ts
@@ -41,6 +41,11 @@ export class Parser implements GenericParser<BlockbookTx> {
     if (!data) return
 
     const txSigHash = getSigHash(data)
+    const isSupportedSigHash = txSigHash
+      ? [this.approvalSigHash, this.depositSigHash, this.withdrawSigHash].includes(txSigHash)
+      : false
+    if (!isSupportedSigHash) return
+
     const abiInterface = this.getAbiInterface(txSigHash)
     if (!abiInterface) return
 
@@ -61,10 +66,13 @@ export class Parser implements GenericParser<BlockbookTx> {
     )
       return
 
+    const interactedWith = txSigHash === this.approvalSigHash ? decoded?.args._spender : receiveAddress
+
     return {
       data: {
         method: decoded?.name,
         parser: 'yearn',
+        interactedWith,
       },
     }
   }

--- a/node/packages/parser/src/ethereum/yearn.ts
+++ b/node/packages/parser/src/ethereum/yearn.ts
@@ -41,11 +41,6 @@ export class Parser implements GenericParser<BlockbookTx> {
     if (!data) return
 
     const txSigHash = getSigHash(data)
-    const isSupportedSigHash = txSigHash
-      ? [this.approvalSigHash, this.depositSigHash, this.withdrawSigHash].includes(txSigHash)
-      : false
-    if (!isSupportedSigHash) return
-
     const abiInterface = this.getAbiInterface(txSigHash)
     if (!abiInterface) return
 
@@ -78,16 +73,14 @@ export class Parser implements GenericParser<BlockbookTx> {
   }
 
   getAbiInterface(txSigHash: string | undefined): ethers.utils.Interface | undefined {
-    return (() => {
-      switch (txSigHash) {
-        case this.approvalSigHash:
-        case this.withdrawSigHash:
-          return this.yearnInterface
-        case this.depositSigHash:
-          return this.shapeShiftInterface
-        default:
-          return undefined
-      }
-    })()
+    switch (txSigHash) {
+      case this.approvalSigHash:
+      case this.withdrawSigHash:
+        return this.yearnInterface
+      case this.depositSigHash:
+        return this.shapeShiftInterface
+      default:
+        return undefined
+    }
   }
 }

--- a/node/packages/parser/src/types.ts
+++ b/node/packages/parser/src/types.ts
@@ -56,6 +56,7 @@ export enum TransferType {
 export interface TxMetadata {
   method?: string
   parser: string
+  interactedWith?: string
 }
 
 export interface StandardTx {


### PR DESCRIPTION
@kaladinlight a little POC for you - add the contract address that the Yearn transaction interacted with to our parser metadata.

I'm also getting the feeling that all parsers will use a shared metadata type, rather than their own, but we'll see.

Supports https://github.com/shapeshift/unchained/issues/286 and https://github.com/shapeshift/web/issues/1086.