### PR TITLE
feat: make generic parser more generic

### DIFF
--- a/node/packages/parser/src/ethereum/index.ts
+++ b/node/packages/parser/src/ethereum/index.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers'
 import { Tx } from '@shapeshiftoss/blockbook'
 import { caip19, caip2 } from '@shapeshiftoss/caip'
 import { ChainTypes, ContractTypes } from '@shapeshiftoss/types'
-import { GenericParser, Status, Token, TransferType, Tx as ParseTx, TxSpecific } from '../types'
+import { GenericParser, Status, Token, TransferType, Tx as ParsedTx, TxSpecific } from '../types'
 import { aggregateTransfer, findAsyncSequential } from '../utils'
 import { InternalTx, Network } from './types'
 import { getInternalMultisigAddress, getSigHash, SENDMULTISIG_SIG_HASH, toNetworkType } from './utils'
@@ -11,6 +11,7 @@ import * as thor from './thor'
 import * as uniV2 from './uniV2'
 import * as zrx from './zrx'
 import * as yearn from './yearn'
+import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
 
 export * from './types'
 
@@ -27,7 +28,7 @@ export class TransactionParser {
   private readonly uniV2: uniV2.Parser
   private readonly zrx: zrx.Parser
   private readonly yearn: yearn.Parser
-  private readonly parsers: Array<GenericParser>
+  private readonly parsers: Array<GenericParser<BlockbookTx>>
 
   constructor(args: TransactionParserArgs) {
     const provider = new ethers.providers.JsonRpcProvider(args.rpcUrl)
@@ -54,14 +55,14 @@ export class TransactionParser {
     }
   }
 
-  async parse(tx: Tx, address: string, internalTxs?: Array<InternalTx>): Promise<ParseTx> {
+  async parse(tx: Tx, address: string, internalTxs?: Array<InternalTx>): Promise<ParsedTx> {
     // We expect only one Parser to return a result. If multiple do, we take the first and early exit.
-    const contractParserResult = await findAsyncSequential<GenericParser, TxSpecific<ParseTx>>(
+    const contractParserResult = await findAsyncSequential<GenericParser<BlockbookTx>, TxSpecific<ParsedTx>>(
       this.parsers,
       async (parser) => await parser.parse(tx)
     )
 
-    const parsedTx: ParseTx = {
+    const parsedTx: ParsedTx = {
       address,
       blockHash: tx.blockHash,
       blockHeight: tx.blockHeight,
@@ -89,7 +90,7 @@ export class TransactionParser {
     return Status.Unknown
   }
 
-  private getParsedTxWithTransfers(tx: Tx, parsedTx: ParseTx, address: string, internalTxs?: Array<InternalTx>) {
+  private getParsedTxWithTransfers(tx: Tx, parsedTx: ParsedTx, address: string, internalTxs?: Array<InternalTx>) {
     const caip19Ethereum = caip19.toCAIP19({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) })
     const sendAddress = tx.vin[0].addresses?.[0] ?? ''
     const receiveAddress = tx.vout[0].addresses?.[0] ?? ''

--- a/node/packages/parser/src/ethereum/thor.ts
+++ b/node/packages/parser/src/ethereum/thor.ts
@@ -1,10 +1,10 @@
-import { ethers } from 'ethers'
+import { Tx } from '@shapeshiftoss/blockbook'
 import { Thorchain } from '@shapeshiftoss/thorchain'
+import { ethers } from 'ethers'
 import { Dex, GenericParser, ThorTx, TradeType, TxSpecific } from '../types'
 import { Network } from './types'
 import THOR_ABI from './abi/thor'
 import { getSigHash, txInteractsWithContract } from './utils'
-import { Tx } from '@shapeshiftoss/blockbook'
 import { THOR_ROUTER_CONTRACT_MAINNET, THOR_ROUTER_CONTRACT_ROPSTEN } from './constants'
 
 const SWAP_TYPES = ['SWAP', '=', 's']
@@ -15,7 +15,7 @@ export interface ParserArgs {
   rpcUrl: string
 }
 
-export class Parser implements GenericParser {
+export class Parser implements GenericParser<Tx> {
   abiInterface: ethers.utils.Interface
   thorchain: Thorchain
 

--- a/node/packages/parser/src/ethereum/thor.ts
+++ b/node/packages/parser/src/ethereum/thor.ts
@@ -1,4 +1,4 @@
-import { Tx } from '@shapeshiftoss/blockbook'
+import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
 import { Thorchain } from '@shapeshiftoss/thorchain'
 import { ethers } from 'ethers'
 import { Dex, GenericParser, ThorTx, TradeType, TxSpecific } from '../types'
@@ -15,7 +15,7 @@ export interface ParserArgs {
   rpcUrl: string
 }
 
-export class Parser implements GenericParser<Tx> {
+export class Parser implements GenericParser<BlockbookTx> {
   abiInterface: ethers.utils.Interface
   thorchain: Thorchain
 
@@ -49,7 +49,7 @@ export class Parser implements GenericParser<Tx> {
     return result.to
   }
 
-  async parse(tx: Tx): Promise<TxSpecific<ThorTx> | undefined> {
+  async parse(tx: BlockbookTx): Promise<TxSpecific<ThorTx> | undefined> {
     const txData = tx.ethereumSpecific?.data
     if (!txInteractsWithContract(tx, this.routerContract)) return
     if (!txData) return

--- a/node/packages/parser/src/ethereum/uniV2.ts
+++ b/node/packages/parser/src/ethereum/uniV2.ts
@@ -1,7 +1,7 @@
-import { ethers } from 'ethers'
-import { Tx } from '@shapeshiftoss/blockbook'
 import { caip19 } from '@shapeshiftoss/caip'
 import { ChainTypes, ContractTypes } from '@shapeshiftoss/types'
+import { Tx } from '@shapeshiftoss/blockbook'
+import { ethers } from 'ethers'
 import { GenericParser, Transfer, TransferType, TxSpecific, UniV2Tx } from '../types'
 import { Network } from './types'
 import UNIV2_ABI from './abi/uniV2'
@@ -14,7 +14,7 @@ export interface ParserArgs {
   provider: ethers.providers.JsonRpcProvider
 }
 
-export class Parser implements GenericParser {
+export class Parser implements GenericParser<Tx> {
   abiInterface = new ethers.utils.Interface(UNIV2_ABI)
   network: Network
   provider: ethers.providers.JsonRpcProvider

--- a/node/packages/parser/src/ethereum/uniV2.ts
+++ b/node/packages/parser/src/ethereum/uniV2.ts
@@ -1,6 +1,6 @@
 import { caip19 } from '@shapeshiftoss/caip'
 import { ChainTypes, ContractTypes } from '@shapeshiftoss/types'
-import { Tx } from '@shapeshiftoss/blockbook'
+import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
 import { ethers } from 'ethers'
 import { GenericParser, Transfer, TransferType, TxSpecific, UniV2Tx } from '../types'
 import { Network } from './types'
@@ -14,7 +14,7 @@ export interface ParserArgs {
   provider: ethers.providers.JsonRpcProvider
 }
 
-export class Parser implements GenericParser<Tx> {
+export class Parser implements GenericParser<BlockbookTx> {
   abiInterface = new ethers.utils.Interface(UNIV2_ABI)
   network: Network
   provider: ethers.providers.JsonRpcProvider
@@ -35,7 +35,7 @@ export class Parser implements GenericParser<Tx> {
     }[this.network]
   }
 
-  async parse(tx: Tx): Promise<TxSpecific<UniV2Tx> | undefined> {
+  async parse(tx: BlockbookTx): Promise<TxSpecific<UniV2Tx> | undefined> {
     if (!tx.ethereumSpecific?.data) return
     if (!txInteractsWithContract(tx, UNI_V2_ROUTER_CONTRACT)) return
     if (!(tx.confirmations === 0)) return
@@ -60,7 +60,7 @@ export class Parser implements GenericParser<Tx> {
     return ethers.utils.getCreate2Address(factoryContract, salt, initCodeHash)
   }
 
-  private async getTransfers(tx: Tx): Promise<Transfer[] | undefined> {
+  private async getTransfers(tx: BlockbookTx): Promise<Transfer[] | undefined> {
     const data = tx.ethereumSpecific?.data
     if (!data) return
     const sendAddress = tx.vin[0].addresses?.[0] ?? ''

--- a/node/packages/parser/src/ethereum/yearn.ts
+++ b/node/packages/parser/src/ethereum/yearn.ts
@@ -13,7 +13,7 @@ interface ParserArgs {
   provider: ethers.providers.JsonRpcProvider
 }
 
-export class Parser implements GenericParser {
+export class Parser implements GenericParser<Tx> {
   provider: ethers.providers.JsonRpcProvider
   yearnSdk: Yearn<ChainId> | undefined
 

--- a/node/packages/parser/src/ethereum/yearn.ts
+++ b/node/packages/parser/src/ethereum/yearn.ts
@@ -1,5 +1,5 @@
 import { ChainId, Yearn } from '@yfi/sdk'
-import { Tx } from '@shapeshiftoss/blockbook'
+import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
 import { ethers } from 'ethers'
 import { GenericParser, TxSpecific, YearnTx } from '../types'
 import { SHAPE_SHIFT_ROUTER_CONTRACT } from './constants'
@@ -13,7 +13,7 @@ interface ParserArgs {
   provider: ethers.providers.JsonRpcProvider
 }
 
-export class Parser implements GenericParser<Tx> {
+export class Parser implements GenericParser<BlockbookTx> {
   provider: ethers.providers.JsonRpcProvider
   yearnSdk: Yearn<ChainId> | undefined
 
@@ -36,7 +36,7 @@ export class Parser implements GenericParser<Tx> {
     }
   }
 
-  async parse(tx: Tx): Promise<TxSpecific<YearnTx> | undefined> {
+  async parse(tx: BlockbookTx): Promise<TxSpecific<YearnTx> | undefined> {
     const data = tx.ethereumSpecific?.data
     if (!data) return
 

--- a/node/packages/parser/src/ethereum/zrx.ts
+++ b/node/packages/parser/src/ethereum/zrx.ts
@@ -1,10 +1,10 @@
-import { Tx } from '@shapeshiftoss/blockbook'
+import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
 import { Dex, GenericParser, TradeType, TxSpecific, ZrxTx } from '../types'
 import { txInteractsWithContract } from './utils'
 import { ZRX_PROXY_CONTRACT } from './constants'
 
-export class Parser implements GenericParser<Tx> {
-  async parse(tx: Tx): Promise<TxSpecific<ZrxTx> | undefined> {
+export class Parser implements GenericParser<BlockbookTx> {
+  async parse(tx: BlockbookTx): Promise<TxSpecific<ZrxTx> | undefined> {
     if (!txInteractsWithContract(tx, ZRX_PROXY_CONTRACT)) return
     if (!(tx.tokenTransfers && tx.tokenTransfers.length)) return
 

--- a/node/packages/parser/src/ethereum/zrx.ts
+++ b/node/packages/parser/src/ethereum/zrx.ts
@@ -3,7 +3,7 @@ import { Dex, GenericParser, TradeType, TxSpecific, ZrxTx } from '../types'
 import { txInteractsWithContract } from './utils'
 import { ZRX_PROXY_CONTRACT } from './constants'
 
-export class Parser implements GenericParser {
+export class Parser implements GenericParser<Tx> {
   async parse(tx: Tx): Promise<TxSpecific<ZrxTx> | undefined> {
     if (!txInteractsWithContract(tx, ZRX_PROXY_CONTRACT)) return
     if (!(tx.tokenTransfers && tx.tokenTransfers.length)) return

--- a/node/packages/parser/src/types.ts
+++ b/node/packages/parser/src/types.ts
@@ -1,5 +1,3 @@
-import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
-
 export enum Dex {
   Thor = 'thor',
   Zrx = 'zrx',
@@ -96,6 +94,6 @@ export type Tx = StandardTx | UniV2Tx | ZrxTx | ThorTx
 
 export type TxSpecific<T extends Tx> = Partial<Pick<T, 'trade' | 'transfers' | 'data'>>
 
-export interface GenericParser {
-  parse: (tx: BlockbookTx) => Promise<TxSpecific<Tx> | undefined>
+export interface GenericParser<T> {
+  parse: (tx: T) => Promise<TxSpecific<Tx> | undefined>
 }


### PR DESCRIPTION
- Makes `GenericParser` more generic
- Re-names `ParseTx` to `ParsedTx`
- Uses `BlockbookTx` type alias to be more specific about the Tx type we are using in our parsers

Closes https://github.com/shapeshift/unchained/issues/280