### PR TITLE
chore: upgrade axios to 0.26.0

### DIFF
--- a/node/coinstacks/bitcoin/ingester/package.json
+++ b/node/coinstacks/bitcoin/ingester/package.json
@@ -17,6 +17,6 @@
     "@shapeshiftoss/logger": "^1.0.0",
     "@shapeshiftoss/thorchain": "^5.2.0",
     "@shapeshiftoss/unchained-tx-parser": "^5.2.0",
-    "axios": "^0.21.2"
+    "axios": "^0.26.0"
   }
 }

--- a/node/coinstacks/ethereum/ingester/package.json
+++ b/node/coinstacks/ethereum/ingester/package.json
@@ -17,7 +17,7 @@
     "@shapeshiftoss/logger": "^1.0.0",
     "@shapeshiftoss/thorchain": "^5.2.0",
     "@shapeshiftoss/unchained-tx-parser": "^5.2.0",
-    "axios": "^0.21.2",
+    "axios": "^0.26.0",
     "bignumber.js": "^9.0.1",
     "ethers": "^5.5.3"
   }

--- a/node/packages/blockbook/package.json
+++ b/node/packages/blockbook/package.json
@@ -17,7 +17,7 @@
     "watch": "nodemon -e ts --watch src --ignore src/routes.ts -x yarn build"
   },
   "dependencies": {
-    "axios": "^0.21.2",
+    "axios": "^0.26.0",
     "express": "^4.17.1",
     "swagger-ui-express": "^4.1.5",
     "tsoa": "^3.4.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2962,12 +2962,12 @@ axios@0.21.1, axios@^0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-axios@^0.21.2:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
+  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.8"
 
 babel-jest@^27.2.5:
   version "27.2.5"
@@ -4758,10 +4758,10 @@ follow-redirects@^1.10.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
   integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
 
-follow-redirects@^1.14.0:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
-  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Upgrade `axios` to the latest version which includes various security improvements over the current version being used.