### PR TITLE
Pod CPU Requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,15 +30,18 @@ aliases:
     pulumi-stack: public
     pulumi-dir: coinstacks/bitcoin/pulumi
     broker-url: bitcoin-rabbitmq-svc.unchained.svc.cluster.local:5672
-    mongo-cpu-limit: 512m
+    mongo-cpu-limit: 500m
+    mongo-cpu-request: 500m
     mongo-memory-limit: 512Mi
     mongo-replicas: 3
     mongo-storage-size: 10Gi
     mongo-url: mongodb://bitcoin-mongodb-0.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017,bitcoin-mongodb-1.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017,bitcoin-mongodb-2.bitcoin-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
-    rabbit-cpu-limit: "2"
+    rabbit-cpu-limit: "1"
+    rabbit-cpu-request: "1"
     rabbit-memory-limit: "8Gi"
     rabbit-storage-size: "10Gi"
     indexer-cpu-limit: "4"
+    indexer-cpu-request: "4"
     indexer-memory-limit: 24Gi
     indexer-replicas: 2
     indexer-storage-size: 500Gi
@@ -46,12 +49,14 @@ aliases:
     indexer-ws-url: ws://bitcoin-indexer-svc.unchained.svc.cluster.local:8001/websocket
     daemon-image: ruimarinho/bitcoin-core:0.21.0
     daemon-cpu-limit: "2"
+    daemon-cpu-request: "2"
     daemon-memory-limit: 12Gi
     daemon-storage-size: 1500Gi
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 6
     api-cpu-limit: "500m"
+    api-cpu-request: "500m"
     api-cpu-threshold: 30
     api-memory-limit: "2Gi"
     ingester-autoscaling: true
@@ -59,6 +64,7 @@ aliases:
     ingester-max-replicas: 4
     ingester-cpu-threshold: 20
     ingester-cpu-limit: "500m"
+    ingester-cpu-request: "500m"
     ingester-memory-limit: "3Gi"
     rpc-url: http://user:password@bitcoin-indexer-svc.unchained.svc.cluster.local:8332
 
@@ -77,12 +83,14 @@ aliases:
     api-replicas: 2
     api-max-replicas: 3
     api-cpu-limit: "300m"
+    api-cpu-request: "200m"
     api-cpu-threshold: 30
     api-memory-limit: "1Gi"
     ingester-autoscaling: true
     ingester-replicas: 1
     ingester-max-replicas: 2
     ingester-cpu-limit: "500m"
+    ingester-cpu-request: "250m"
     ingester-cpu-threshold: 20
     ingester-memory-limit: "2Gi"
 
@@ -91,15 +99,18 @@ aliases:
     pulumi-stack: public
     pulumi-dir: coinstacks/ethereum/pulumi
     broker-url: ethereum-rabbitmq-svc.unchained.svc.cluster.local:5672
-    mongo-cpu-limit: 512m
+    mongo-cpu-limit: 500m
+    mongo-cpu-request: 500m
     mongo-memory-limit: 512Mi
     mongo-replicas: 3
     mongo-storage-size: 10Gi
     mongo-url: mongodb://ethereum-mongodb-0.ethereum-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-mongodb-1.ethereum-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-mongodb-2.ethereum-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
-    rabbit-cpu-limit: "2"
+    rabbit-cpu-limit: "1"
+    rabbit-cpu-request: "1"
     rabbit-memory-limit: "8Gi"
     rabbit-storage-size: "10Gi"
     indexer-cpu-limit: "4"
+    indexer-cpu-request: "4"
     indexer-memory-limit: 12Gi
     indexer-replicas: 2
     indexer-storage-size: 500Gi
@@ -107,12 +118,14 @@ aliases:
     indexer-ws-url: ws://ethereum-indexer-svc.unchained.svc.cluster.local:8001/websocket
     daemon-image: ethereum/client-go:v1.10.15
     daemon-cpu-limit: "4"
+    daemon-cpu-request: "4"
     daemon-memory-limit: 32Gi
     daemon-storage-size: 2000Gi
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 6
     api-cpu-limit: "500m"
+    api-cpu-request: "500m"
     api-cpu-threshold: 30
     api-memory-limit: "2Gi"
     ingester-autoscaling: true
@@ -120,6 +133,7 @@ aliases:
     ingester-max-replicas: 4
     ingester-cpu-threshold: 20
     ingester-cpu-limit: "500m"
+    ingester-cpu-request: "500m"
     ingester-memory-limit: "3Gi"
     rpc-url: http://ethereum-indexer-svc.unchained.svc.cluster.local:8332
 
@@ -138,12 +152,14 @@ aliases:
     api-replicas: 2
     api-max-replicas: 3
     api-cpu-limit: "300m"
+    api-cpu-request: "200m"
     api-cpu-threshold: 30
     api-memory-limit: "1Gi"
     ingester-autoscaling: true
     ingester-replicas: 1
     ingester-max-replicas: 2
     ingester-cpu-limit: "500m"
+    ingester-cpu-request: "250m"
     ingester-cpu-threshold: 20
     ingester-memory-limit: "2Gi"
 
@@ -152,15 +168,18 @@ aliases:
     pulumi-stack: public-ropsten
     pulumi-dir: coinstacks/ethereum/pulumi
     broker-url: ethereum-ropsten-rabbitmq-svc.unchained.svc.cluster.local:5672
-    mongo-cpu-limit: 512m
+    mongo-cpu-limit: 500m
+    mongo-cpu-request: 250m
     mongo-memory-limit: 512Mi
     mongo-replicas: 3
     mongo-storage-size: 10Gi
     mongo-url: mongodb://ethereum-ropsten-mongodb-0.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-ropsten-mongodb-1.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-ropsten-mongodb-2.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
     rabbit-cpu-limit: "1"
+    rabbit-cpu-request: 500m
     rabbit-memory-limit: "4Gi"
     rabbit-storage-size: "10Gi"
     indexer-cpu-limit: "4"
+    indexer-cpu-request: "4"
     indexer-memory-limit: 12Gi
     indexer-replicas: 2
     indexer-storage-size: 250Gi
@@ -168,6 +187,7 @@ aliases:
     indexer-ws-url: ws://ethereum-ropsten-indexer-svc.unchained.svc.cluster.local:8001/websocket
     daemon-image: ethereum/client-go:v1.10.15
     daemon-cpu-limit: "2"
+    daemon-cpu-request: "2"
     daemon-memory-limit: 24Gi
     daemon-storage-size: 500Gi
     api-autoscaling: true
@@ -175,6 +195,7 @@ aliases:
     api-max-replicas: 4
     api-cpu-threshold: 30
     api-cpu-limit: "500m"
+    api-cpu-request: "500m"
     api-memory-limit: "2Gi"
     ingester-autoscaling: true
     ingester-replicas: 2
@@ -200,12 +221,14 @@ aliases:
     api-replicas: 2
     api-max-replicas: 3
     api-cpu-limit: "300m"
+    api-cpu-request: "200m"
     api-cpu-threshold: 30
     api-memory-limit: "1Gi"
     ingester-autoscaling: true
     ingester-replicas: 1
     ingester-max-replicas: 2
     ingester-cpu-limit: "500m"
+    ingester-cpu-request: "250m"
     ingester-cpu-threshold: 20
     ingester-memory-limit: "2Gi"
 
@@ -220,6 +243,7 @@ aliases:
     api-replicas: 2
     api-max-replicas: 6
     api-cpu-limit: "500m"
+    api-cpu-request: "500m"
     api-cpu-threshold: 30
     api-memory-limit: "2Gi"
 
@@ -231,6 +255,7 @@ aliases:
     api-replicas: 2
     api-max-replicas: 3
     api-cpu-limit: "300m"
+    api-cpu-request: "300m"
     api-cpu-threshold: 30
     api-memory-limit: "1Gi"
 
@@ -494,6 +519,8 @@ jobs:
         type: string
       mongo-cpu-limit:
         type: string
+      mongo-cpu-request:
+        type: string
       mongo-memory-limit:
         type: string
       mongo-replicas:
@@ -504,11 +531,15 @@ jobs:
         type: string
       rabbit-cpu-limit:
         type: string
+      rabbit-cpu-request:
+        type: string
       rabbit-memory-limit:
         type: string
       rabbit-storage-size:
         type: string
       indexer-cpu-limit:
+        type: string
+      indexer-cpu-request:
         type: string
       indexer-memory-limit:
         type: string
@@ -526,6 +557,8 @@ jobs:
         type: string
       daemon-cpu-limit:
         type: string
+      daemon-cpu-request:
+        type: string
       daemon-memory-limit:
         type: string
       daemon-storage-size:
@@ -538,6 +571,8 @@ jobs:
         type: integer
       api-cpu-limit:
         type: string
+      api-cpu-request:
+        type: string
       api-memory-limit:
         type: string
       api-replicas:
@@ -545,6 +580,8 @@ jobs:
       ingester-autoscaling:
         type: boolean
       ingester-cpu-limit:
+        type: string
+      ingester-cpu-request:
         type: string
       ingester-cpu-threshold:
         type: integer
@@ -583,29 +620,35 @@ jobs:
             pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
             pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
             pulumi config set --path unchained:<< parameters.coinstack >>.api.cpuLimit << parameters.api-cpu-limit >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.api.cpuRequest << parameters.api-cpu-request >>
             pulumi config set --path unchained:<< parameters.coinstack >>.api.memoryLimit << parameters.api-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.api.replicas << parameters.api-replicas >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.enableDatadogLogs true
             pulumi config set --path unchained:<< parameters.coinstack >>.mongo.cpuLimit << parameters.mongo-cpu-limit >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.mongo.cpuRequest << parameters.mongo-cpu-request >>
             pulumi config set --path unchained:<< parameters.coinstack >>.mongo.memoryLimit << parameters.mongo-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.mongo.helmChartVersion 10.19.0
             pulumi config set --path unchained:<< parameters.coinstack >>.mongo.replicaCount << parameters.mongo-replicas >>
             pulumi config set --path unchained:<< parameters.coinstack >>.mongo.storageSize << parameters.mongo-storage-size >>
             pulumi config set --path unchained:<< parameters.coinstack >>.rabbit.cpuLimit << parameters.rabbit-cpu-limit >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.rabbit.cpuRequest << parameters.rabbit-cpu-request >>
             pulumi config set --path unchained:<< parameters.coinstack >>.rabbit.memoryLimit << parameters.rabbit-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.rabbit.storageSize << parameters.rabbit-storage-size >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.cpuLimit << parameters.indexer-cpu-limit >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.indexer.cpuRequest << parameters.indexer-cpu-request >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.memoryLimit << parameters.indexer-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.replicas << parameters.indexer-replicas >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.storageSize << parameters.indexer-storage-size >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.daemon.image << parameters.daemon-image >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.daemon.cpuLimit << parameters.daemon-cpu-limit >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.indexer.daemon.cpuRequest << parameters.daemon-cpu-request >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.daemon.memoryLimit << parameters.daemon-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.indexer.daemon.storageSize << parameters.daemon-storage-size >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.autoscaling.enabled << parameters.ingester-autoscaling >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.autoscaling.cpuThreshold << parameters.ingester-cpu-threshold >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.autoscaling.maxReplicas << parameters.ingester-max-replicas >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.cpuLimit << parameters.ingester-cpu-limit >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.ingester.cpuRequest << parameters.ingester-cpu-request >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.memoryLimit << parameters.ingester-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.ingester.replicas << parameters.ingester-replicas >>
             pulumi << parameters.pulumi-command >> --suppress-outputs
@@ -651,6 +694,8 @@ jobs:
         type: integer
       api-cpu-limit:
         type: string
+      api-cpu-request:
+        type: string
       api-memory-limit:
         type: string
       api-replicas:
@@ -682,6 +727,7 @@ jobs:
             pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
             pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
             pulumi config set --path unchained:<< parameters.coinstack >>.api.cpuLimit << parameters.api-cpu-limit >>
+            pulumi config set --path unchained:<< parameters.coinstack >>.api.cpuRequest << parameters.api-cpu-request >>
             pulumi config set --path unchained:<< parameters.coinstack >>.api.memoryLimit << parameters.api-memory-limit >>
             pulumi config set --path unchained:<< parameters.coinstack >>.api.replicas << parameters.api-replicas >>
             pulumi << parameters.pulumi-command >> --suppress-outputs

--- a/node/coinstacks/bitcoin/pulumi/Pulumi.sample.yaml
+++ b/node/coinstacks/bitcoin/pulumi/Pulumi.sample.yaml
@@ -10,9 +10,9 @@ config:
     ## for individual accounts, use your account name (pulumi whoami) for the organization component.
     stack: # run `pulumi stack ls` in `unchained/pulumi` and reference the url
 
-    ## environment - specify environment if you deployed multiples into cluster. specified as 'additionalEnvironments' in the cluster stack 
+    ## environment - specify environment if you deployed multiples into cluster. specified as 'additionalEnvironments' in the cluster stack
     ## if falsy use default environment created in cluster stack
-    #environment: 
+    #environment:
 
     ## network - chain network (ie. mainnet, testnet, etc.)
     network: mainnet
@@ -24,8 +24,9 @@ config:
         enabled: false
         cpuThreshold: 30
         maxReplicas: 2
-      cpuLimit: '300m'
-      memoryLimit: '512Mi'
+      cpuLimit: "300m"
+      cpuRequest: "300m"
+      memoryLimit: "512Mi"
       replicas: 1
 
     ## ingester - if specified all ingestion workers will be deployed
@@ -37,32 +38,37 @@ config:
         enabled: false
         cpuThreshold: 30
         maxReplicas: 2
-      cpuLimit: '300m'
-      memoryLimit: '512Mi'
+      cpuLimit: "300m"
+      cpuRequest: "300m"
+      memoryLimit: "512Mi"
       replicas: 1
 
     ## mongo - if specified a mongo database will be deployed
     mongo:
-      cpuLimit: '0.25'
-      helmChartVersion: '10.19.0'
-      memoryLimit: '256Mi'
+      cpuLimit: "250m"
+      cpuRequest: "250m"
+      helmChartVersion: "10.19.0"
+      memoryLimit: "256Mi"
       replicaCount: 1
-      storageSize: '1Gi'
+      storageSize: "1Gi"
 
     rabbit:
-      cpuLimit: '1'
-      memoryLimit: '2Gi'
-      storageSize: '10Gi'
+      cpuLimit: "1"
+      cpuRequest: "1"
+      memoryLimit: "2Gi"
+      storageSize: "10Gi"
 
     ## indexer - if specified an indexer service and optional node will be deployed
     ## this is very resource intensive, so you can point at public endpoints instead of running your own.
     #indexer:
     #  cpuLimit: '2'
+    #  cpuRequest: '2'
     #  memoryLimit: '8Gi'
     #  replicas: 1
     #  storageSize: '400Gi'
     #  daemon:
     #    cpuLimit: '2'
+    #    cpuRequest: '2'
     #    image: 'ruimarinho/bitcoin-core:0.21.1'
     #    memoryLimit: '24Gi'
     #    storageSize: '1500Gi'

--- a/node/coinstacks/bitcoin/pulumi/config.ts
+++ b/node/coinstacks/bitcoin/pulumi/config.ts
@@ -62,6 +62,7 @@ export const getConfig = async (): Promise<BitcoinConfig> => {
     if (!config.api.autoscaling.maxReplicas) missingRequiredConfig.push('api.autoscaling.maxReplicas')
     if (!config.api.autoscaling.cpuThreshold) missingRequiredConfig.push('api.autoscaling.cpuThreshold')
     if (!config.api.cpuLimit) missingRequiredConfig.push('api.cpuLimit')
+    if (!config.api.cpuRequest) missingRequiredConfig.push('api.cpuRequest')
     if (!config.api.memoryLimit) missingRequiredConfig.push('api.memoryLimit')
     if (!config.api.replicas) missingRequiredConfig.push('api.replicas')
   }
@@ -70,6 +71,7 @@ export const getConfig = async (): Promise<BitcoinConfig> => {
     config.mongo.storageClass = getStorageClassName(config.cluster)
 
     if (!config.mongo.cpuLimit) missingRequiredConfig.push('mongo.cpuLimit')
+    if (!config.mongo.cpuRequest) missingRequiredConfig.push('mongo.cpuRequest')
     if (!config.mongo.helmChartVersion) missingRequiredConfig.push('mongo.helmChartVersion')
     if (!config.mongo.memoryLimit) missingRequiredConfig.push('mongo.memoryLimit')
     if (!config.mongo.replicaCount) missingRequiredConfig.push('mongo.replicaCount')
@@ -80,6 +82,7 @@ export const getConfig = async (): Promise<BitcoinConfig> => {
     config.indexer.storageClass = getStorageClassName(config.cluster)
 
     if (!config.indexer.cpuLimit) missingRequiredConfig.push('indexer.cpuLimit')
+    if (!config.indexer.cpuRequest) missingRequiredConfig.push('indexer.cpuRequest')
     if (!config.indexer.memoryLimit) missingRequiredConfig.push('indexer.memoryLimit')
     if (!config.indexer.replicas) missingRequiredConfig.push('indexer.replicas')
     if (!config.indexer.storageSize) missingRequiredConfig.push('indexer.storageSize')
@@ -89,6 +92,7 @@ export const getConfig = async (): Promise<BitcoinConfig> => {
     config.indexer.daemon.storageClass = getStorageClassName(config.cluster)
 
     if (!config.indexer.daemon.cpuLimit) missingRequiredConfig.push('indexer.daemon.cpuLimit')
+    if (!config.indexer.daemon.cpuRequest) missingRequiredConfig.push('indexer.daemon.cpuRequest')
     if (!config.indexer.daemon.image) missingRequiredConfig.push('indexer.daemon.image')
     if (!config.indexer.daemon.memoryLimit) missingRequiredConfig.push('indexer.daemon.memoryLimit')
     if (!config.indexer.daemon.storageSize) missingRequiredConfig.push('indexer.daemon.storageSize')
@@ -99,6 +103,7 @@ export const getConfig = async (): Promise<BitcoinConfig> => {
     if (!config.ingester.autoscaling.maxReplicas) missingRequiredConfig.push('ingester.autoscaling.maxReplicas')
     if (!config.ingester.autoscaling.cpuThreshold) missingRequiredConfig.push('ingester.autoscaling.cpuThreshold')
     if (!config.ingester.cpuLimit) missingRequiredConfig.push('ingester.cpuLimit')
+    if (!config.ingester.cpuRequest) missingRequiredConfig.push('ingester.cpuRequest')
     if (!config.ingester.memoryLimit) missingRequiredConfig.push('ingester.memoryLimit')
     if (!config.ingester.replicas) missingRequiredConfig.push('ingester.replicas')
   }
@@ -107,6 +112,7 @@ export const getConfig = async (): Promise<BitcoinConfig> => {
     config.rabbit.storageClassName = getStorageClassName(config.cluster)
 
     if (!config.rabbit.cpuLimit) missingRequiredConfig.push('rabbit.cpuLimit')
+    if (!config.rabbit.cpuRequest) missingRequiredConfig.push('rabbit.cpuRequest')
     if (!config.rabbit.memoryLimit) missingRequiredConfig.push('rabbit.memoryLimit')
     if (!config.rabbit.storageSize) missingRequiredConfig.push('rabbit.storageSize')
   }

--- a/node/coinstacks/common/pulumi/src/api.ts
+++ b/node/coinstacks/common/pulumi/src/api.ts
@@ -10,6 +10,7 @@ import { buildAndPushImage, Config, hasTag, getBaseHash } from './index'
 
 export interface ApiConfig {
   cpuLimit: string
+  cpuRequest: string
   memoryLimit: string
   replicas: number
   autoscaling: { enabled: boolean; maxReplicas: number; cpuThreshold: number }
@@ -254,6 +255,9 @@ export async function deployApi(
             limits: {
               cpu: config.api.cpuLimit,
               memory: config.api.memoryLimit,
+            },
+            requests: {
+              cpu: config.api.cpuRequest ?? config.api.cpuLimit,
             },
           },
           readinessProbe: {

--- a/node/coinstacks/common/pulumi/src/ingester.ts
+++ b/node/coinstacks/common/pulumi/src/ingester.ts
@@ -11,6 +11,7 @@ import { buildAndPushImage, Config, hasTag, getBaseHash } from './index'
 export interface IngesterConfig {
   autoscaling: { enabled: boolean; cpuThreshold: number; maxReplicas: number }
   cpuLimit: string
+  cpuRequest: string
   memoryLimit: string
   replicas: number
   enableDatadogLogs?: boolean
@@ -185,7 +186,7 @@ export async function deployIngester(
     worker({ name: 'worker-registry', path: 'workers/registry', replicas: 1, autoscaling: false }),
   ]
 
-  const { enableDatadogLogs, cpuLimit, memoryLimit, autoscaling } = config.ingester
+  const { enableDatadogLogs, cpuLimit, cpuRequest, memoryLimit, autoscaling } = config.ingester
 
   return workers.map((worker) => {
     const datadogAnnotation = enableDatadogLogs
@@ -226,6 +227,9 @@ export async function deployIngester(
               limits: {
                 cpu: cpuLimit,
                 memory: memoryLimit,
+              },
+              requests: {
+                cpu: cpuRequest ?? cpuLimit,
               },
             },
             readinessProbe: {

--- a/node/coinstacks/common/pulumi/src/mongo.ts
+++ b/node/coinstacks/common/pulumi/src/mongo.ts
@@ -4,6 +4,7 @@ import { Config } from './index'
 
 export interface MongoConfig {
   cpuLimit: string
+  cpuRequest: string
   helmChartVersion: string
   memoryLimit: string
   replicaCount: number
@@ -69,6 +70,9 @@ export async function deployMongo(
           limits: {
             cpu: config.mongo.cpuLimit,
             memory: config.mongo.memoryLimit,
+          },
+          requests: {
+            cpu: config.mongo.cpuRequest ?? config.mongo.cpuLimit,
           },
         },
       },

--- a/node/coinstacks/common/pulumi/src/rabbit.ts
+++ b/node/coinstacks/common/pulumi/src/rabbit.ts
@@ -5,6 +5,7 @@ import { Config } from './index'
 export interface RabbitConfig {
   adminPort?: number
   cpuLimit: string
+  cpuRequest: string
   memoryLimit: string
   rabbitPort?: number
   storageClassName: 'hostpath' | 'standard' | 'gp2'
@@ -66,6 +67,9 @@ export async function deployRabbit(
       limits: {
         cpu: config.rabbit.cpuLimit,
         memory: config.rabbit.memoryLimit,
+      },
+      requests: {
+        cpu: config.rabbit.cpuRequest ?? config.rabbit.cpuLimit,
       },
     },
     volumeMounts: [

--- a/node/coinstacks/ethereum/pulumi/Pulumi.sample.yaml
+++ b/node/coinstacks/ethereum/pulumi/Pulumi.sample.yaml
@@ -24,10 +24,10 @@ config:
         enabled: false
         cpuThreshold: 30
         maxReplicas: 2
-      cpuLimit: '300m'
-      memoryLimit: '512Mi'
+      cpuLimit: "300m"
+      cpuRequest: "300m"
+      memoryLimit: "512Mi"
       replicas: 1
-
 
     ## ingester - if specified all ingestion workers will be deployed
     ## All ingesters use 1 replica with the exception of tx and address workers, which are configured for high availability
@@ -38,13 +38,15 @@ config:
         enabled: false
         cpuThreshold: 30
         maxReplicas: 2
-      cpuLimit: '300m'
-      memoryLimit: '512Mi'
+      cpuLimit: "300m"
+      cpuRequest: "300m"
+      memoryLimit: "512Mi"
       replicas: 1
 
     ## mongo - if specified a mongo database will be deployed
     mongo:
-      cpuLimit: "0.25"
+      cpuLimit: "250m"
+      cpuRequest: "250m"
       helmChartVersion: "10.19.0"
       memoryLimit: "256Mi"
       replicaCount: 1
@@ -52,6 +54,7 @@ config:
 
     rabbit:
       cpuLimit: "1"
+      cpuRequest: "1"
       memoryLimit: "2Gi"
       storageSize: "10Gi"
 
@@ -59,11 +62,13 @@ config:
     ## this is very resource intensive, so you can point at public endpoints instead of running your own.
     #indexer:
     #  cpuLimit: '2'
+    #  cpuRequest: '2'
     #  memoryLimit: '8Gi'
     #  replicas: 1
     #  storageSize: '250Gi'
     #  daemon:
     #    cpuLimit: '2'
+    #    cpuRequest: '2'
     #    image: 'ethereum/client-go:v1.10.15'
     #    memoryLimit: '24Gi'
     #    storageSize: '1500Gi'

--- a/node/coinstacks/ethereum/pulumi/config.ts
+++ b/node/coinstacks/ethereum/pulumi/config.ts
@@ -62,6 +62,7 @@ export const getConfig = async (): Promise<EthereumConfig> => {
     if (!config.api.autoscaling.maxReplicas) missingRequiredConfig.push('api.autoscaling.maxReplicas')
     if (!config.api.autoscaling.cpuThreshold) missingRequiredConfig.push('api.autoscaling.cpuThreshold')
     if (!config.api.cpuLimit) missingRequiredConfig.push('api.cpuLimit')
+    if (!config.api.cpuRequest) missingRequiredConfig.push('api.cpuRequest')
     if (!config.api.memoryLimit) missingRequiredConfig.push('api.memoryLimit')
     if (!config.api.replicas) missingRequiredConfig.push('api.replicas')
   }
@@ -70,6 +71,7 @@ export const getConfig = async (): Promise<EthereumConfig> => {
     config.mongo.storageClass = getStorageClassName(config.cluster)
 
     if (!config.mongo.cpuLimit) missingRequiredConfig.push('mongo.cpuLimit')
+    if (!config.mongo.cpuRequest) missingRequiredConfig.push('mongo.cpuRequest')
     if (!config.mongo.helmChartVersion) missingRequiredConfig.push('mongo.helmChartVersion')
     if (!config.mongo.memoryLimit) missingRequiredConfig.push('mongo.memoryLimit')
     if (!config.mongo.replicaCount) missingRequiredConfig.push('mongo.replicaCount')
@@ -80,6 +82,7 @@ export const getConfig = async (): Promise<EthereumConfig> => {
     config.indexer.storageClass = getStorageClassName(config.cluster)
 
     if (!config.indexer.cpuLimit) missingRequiredConfig.push('indexer.cpuLimit')
+    if (!config.indexer.cpuRequest) missingRequiredConfig.push('indexer.cpuRequest')
     if (!config.indexer.memoryLimit) missingRequiredConfig.push('indexer.memoryLimit')
     if (!config.indexer.replicas) missingRequiredConfig.push('indexer.replicas')
     if (!config.indexer.storageSize) missingRequiredConfig.push('indexer.storageSize')
@@ -89,6 +92,7 @@ export const getConfig = async (): Promise<EthereumConfig> => {
     config.indexer.daemon.storageClass = getStorageClassName(config.cluster)
 
     if (!config.indexer.daemon.cpuLimit) missingRequiredConfig.push('indexer.daemon.cpuLimit')
+    if (!config.indexer.daemon.cpuRequest) missingRequiredConfig.push('indexer.daemon.cpuRequest')
     if (!config.indexer.daemon.image) missingRequiredConfig.push('indexer.daemon.image')
     if (!config.indexer.daemon.memoryLimit) missingRequiredConfig.push('indexer.daemon.memoryLimit')
     if (!config.indexer.daemon.storageSize) missingRequiredConfig.push('indexer.daemon.storageSize')
@@ -99,6 +103,7 @@ export const getConfig = async (): Promise<EthereumConfig> => {
     if (!config.ingester.autoscaling.maxReplicas) missingRequiredConfig.push('ingester.autoscaling.maxReplicas')
     if (!config.ingester.autoscaling.cpuThreshold) missingRequiredConfig.push('ingester.autoscaling.cpuThreshold')
     if (!config.ingester.cpuLimit) missingRequiredConfig.push('ingester.cpuLimit')
+    if (!config.ingester.cpuRequest) missingRequiredConfig.push('ingester.cpuRequest')
     if (!config.ingester.memoryLimit) missingRequiredConfig.push('ingester.memoryLimit')
     if (!config.ingester.replicas) missingRequiredConfig.push('ingester.replicas')
   }
@@ -107,6 +112,7 @@ export const getConfig = async (): Promise<EthereumConfig> => {
     config.rabbit.storageClassName = getStorageClassName(config.cluster)
 
     if (!config.rabbit.cpuLimit) missingRequiredConfig.push('rabbit.cpuLimit')
+    if (!config.rabbit.cpuRequest) missingRequiredConfig.push('rabbit.cpuRequest')
     if (!config.rabbit.memoryLimit) missingRequiredConfig.push('rabbit.memoryLimit')
     if (!config.rabbit.storageSize) missingRequiredConfig.push('rabbit.storageSize')
   }

--- a/node/packages/blockbook/pulumi/index.ts
+++ b/node/packages/blockbook/pulumi/index.ts
@@ -5,6 +5,7 @@ import { Config } from '@shapeshiftoss/common-pulumi'
 
 interface DaemonConfig {
   cpuLimit: string
+  cpuRequest: string
   image: string
   memoryLimit: string
   storageClass: 'gp2' | 'hostpath' | 'standard'
@@ -13,6 +14,7 @@ interface DaemonConfig {
 
 export interface IndexerConfig {
   cpuLimit: string
+  cpuRequest: string
   daemon?: DaemonConfig
   memoryLimit: string
   replicas: number
@@ -128,6 +130,9 @@ export async function deployIndexer(
               cpu: config.indexer.cpuLimit,
               memory: config.indexer.memoryLimit,
             },
+            requests: {
+              cpu: config.indexer.cpuRequest ?? config.indexer.cpuLimit,
+            },
           },
         },
         {
@@ -176,6 +181,9 @@ export async function deployIndexer(
                   limits: {
                     cpu: config.indexer.daemon.cpuLimit,
                     memory: config.indexer.daemon.memoryLimit,
+                  },
+                  requests: {
+                    cpu: config.indexer.daemon.cpuRequest ?? config.indexer.daemon.cpuLimit,
                   },
                 },
                 ports: [{ containerPort: 8332, name: 'daemon-rpc' }],


### PR DESCRIPTION
This PR introduces the ability to set CPU requests explicitly instead of assuming a 1:1 request:limit ratio. This will allow us to request fewer CPU resources per service, while allowing the service to burst beyond what CPU we request when it needs to. 

We're not making any changes to public services CPU requests in this PR, just getting the configuration in place so we can manipulate CPU requests one service at a time, iteratively. We are modifying the request:limit ratio in develop, in order to validate these changes.

As a bonus CPU savings I've reduced RabbitMQ CPU Limits from 2-->1, based on monitoring this service does not need to request more than 1 CPU. 