### PR TITLE
Remove Ropsten

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,12 @@ aliases:
         ignore:
           - main
           - develop
-          - remove-ropsten
 
   - &only-develop
     filters:
       branches:
         only:
           - develop
-          - remove-ropsten
 
   - &only-main
     filters:
@@ -136,68 +134,6 @@ aliases:
     indexer-url: http://ethereum-indexer-svc.unchained-dev.svc.cluster.local:8001
     indexer-ws-url: ws://ethereum-indexer-svc.unchained-dev.svc.cluster.local:8001/websocket
     rpc-url: http://ethereum-indexer-svc.unchained-dev.svc.cluster.local:8332
-    api-autoscaling: true
-    api-replicas: 2
-    api-max-replicas: 3
-    api-cpu-limit: "300m"
-    api-cpu-threshold: 30
-    api-memory-limit: "1Gi"
-    ingester-autoscaling: true
-    ingester-replicas: 1
-    ingester-max-replicas: 2
-    ingester-cpu-limit: "500m"
-    ingester-cpu-threshold: 20
-    ingester-memory-limit: "2Gi"
-
-  - &ethereum-ropsten
-    coinstack: ethereum
-    pulumi-stack: public-ropsten
-    pulumi-dir: coinstacks/ethereum/pulumi
-    broker-url: ethereum-ropsten-rabbitmq-svc.unchained.svc.cluster.local:5672
-    mongo-cpu-limit: 512m
-    mongo-memory-limit: 512Mi
-    mongo-replicas: 3
-    mongo-storage-size: 5Gi
-    mongo-url: mongodb://ethereum-ropsten-mongodb-0.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-ropsten-mongodb-1.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017,ethereum-ropsten-mongodb-2.ethereum-ropsten-mongodb-headless.unchained.svc.cluster.local:27017/?replicaSet=rs0
-    rabbit-cpu-limit: "1"
-    rabbit-memory-limit: "4Gi"
-    rabbit-storage-size: "5Gi"
-    indexer-cpu-limit: "4"
-    indexer-memory-limit: 12Gi
-    indexer-replicas: 2
-    indexer-storage-size: 250Gi
-    indexer-url: http://ethereum-ropsten-indexer-svc.unchained.svc.cluster.local:8001
-    indexer-ws-url: ws://ethereum-ropsten-indexer-svc.unchained.svc.cluster.local:8001/websocket
-    daemon-image: ethereum/client-go:v1.10.15
-    daemon-cpu-limit: "2"
-    daemon-memory-limit: 24Gi
-    daemon-storage-size: 500Gi
-    api-autoscaling: true
-    api-replicas: 2
-    api-max-replicas: 4
-    api-cpu-threshold: 30
-    api-cpu-limit: "500m"
-    api-memory-limit: "2Gi"
-    ingester-autoscaling: true
-    ingester-replicas: 2
-    ingester-max-replicas: 4
-    ingester-cpu-threshold: 20
-    ingester-cpu-limit: "500m"
-    ingester-memory-limit: "3Gi"
-    rpc-url: http://ethereum-ropsten-indexer-svc.unchained.svc.cluster.local:8332
-
-  - &ethereum-ropsten-dev
-    <<: *ethereum-ropsten
-    environment: dev
-    network: ropsten
-    pulumi-stack: public-dev-ropsten
-    broker-url: ethereum-ropsten-rabbitmq-svc.unchained-dev.svc.cluster.local:5672
-    mongo-replicas: 2
-    mongo-url: mongodb://ethereum-ropsten-mongodb-0.ethereum-ropsten-mongodb-headless.unchained-dev.svc.cluster.local:27017,ethereum-ropsten-mongodb-1.ethereum-ropsten-mongodb-headless.unchained-dev.svc.cluster.local:27017/?replicaSet=rs0
-    indexer-replicas: 1
-    indexer-url: http://ethereum-ropsten-indexer-svc.unchained-dev.svc.cluster.local:8001
-    indexer-ws-url: ws://ethereum-ropsten-indexer-svc.unchained-dev.svc.cluster.local:8001/websocket
-    rpc-url: http://ethereum-ropsten-indexer-svc.unchained-dev.svc.cluster.local:8332
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 3
@@ -810,17 +746,6 @@ workflows:
           <<: *ethereum-dev
           <<: *only-develop
 
-      - deploy-coinstack-node:
-          name: deploy ethereum-ropsten develop (shapeshift)
-          organization: SHAPESHIFT
-          pulumi-command: destroy -f --yes
-          indexer-storage-size: 50Gi
-          daemon-storage-size: 300Gi
-          requires:
-            - deploy dependencies (shapeshift)
-          <<: *ethereum-ropsten-dev
-          <<: *only-develop
-
       - deploy-coinstack-go:
           name: deploy cosmos develop (shapeshift)
           organization: SHAPESHIFT
@@ -870,15 +795,6 @@ workflows:
           requires:
             - deploy dependencies (taxistake)
           <<: *ethereum-dev
-          <<: *only-develop
-
-      - deploy-coinstack-node:
-          name: deploy ethereum-ropsten develop (taxistake)
-          organization: TAXISTAKE
-          pulumi-command: destroy -f --yes
-          requires:
-            - deploy dependencies (taxistake)
-          <<: *ethereum-ropsten-dev
           <<: *only-develop
 
   deploy-monitoring:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,7 +811,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy ethereum-ropsten develop (shapeshift)
           organization: SHAPESHIFT
-          pulumi-command: up -f --yes
+          pulumi-command: destroy -f --yes
           indexer-storage-size: 50Gi
           daemon-storage-size: 300Gi
           requires:
@@ -873,7 +873,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy ethereum-ropsten develop (taxistake)
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: destroy -f --yes
           requires:
             - deploy dependencies (taxistake)
           <<: *ethereum-ropsten-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,14 @@ aliases:
         ignore:
           - main
           - develop
+          - remove-ropsten
 
   - &only-develop
     filters:
       branches:
         only:
           - develop
+          - remove-ropsten
 
   - &only-main
     filters:


### PR DESCRIPTION
This PR removes the ethereum-ropsten coinstack. Initially we will destroy pulumi resources, then we will remove ropsten configuration from circleci/config.yaml completely.