### PR TITLE
Transaction history endpoint re-implementation

### DIFF
--- a/node/coinstacks/bitcoin/api/src/controller.ts
+++ b/node/coinstacks/bitcoin/api/src/controller.ts
@@ -161,30 +161,28 @@ export class Bitcoin extends Controller implements BaseAPI, BitcoinAPI {
   @Response<ValidationError>(422, 'Validation Error')
   @Response<InternalServerError>(500, 'Internal Server Error')
   @Get('account/{pubkey}/txs')
-  async getTxHistory(@Path() pubkey: string, @Query() cursor?: string, @Query() pageSize?: number): Promise<TxHistory> {
+  async getTxHistory(@Path() pubkey: string, @Query() cursor?: string, @Query() pageSize = 25): Promise<TxHistory> {
     try {
       let page = 1
       if (cursor) {
         const cursorDecoded = Buffer.from(cursor, 'base64').toString('binary')
         if (isNaN(Number(cursorDecoded))) {
-          throw new ApiError('Bad Request', 400, 'Invalid cursor')
+          throw new ApiError('Bad Request', 400, 'Invalid cursor, please use the cursor returned in previous page')
         }
         page = Number(cursorDecoded)
       }
 
-      const pageSizeWithDefault = pageSize || 25
-
       let data: Address | Xpub
       if (isXpub(pubkey)) {
-        data = await blockbook.getXpub(pubkey, page, pageSizeWithDefault, undefined, undefined, 'txs')
+        data = await blockbook.getXpub(pubkey, page, pageSize, undefined, undefined, 'txs')
       } else {
-        data = await blockbook.getAddress(pubkey, page, pageSizeWithDefault, undefined, undefined, 'txs')
+        data = await blockbook.getAddress(pubkey, page, pageSize, undefined, undefined, 'txs')
       }
 
       const nextPage = page + 1
 
       const nextCursor =
-        (data.transactions?.length ?? 0) == pageSizeWithDefault
+        (data.transactions?.length ?? 0) == pageSize
           ? { cursor: Buffer.from(nextPage.toString(), 'binary').toString('base64') }
           : undefined
 

--- a/node/coinstacks/bitcoin/api/src/controller.ts
+++ b/node/coinstacks/bitcoin/api/src/controller.ts
@@ -145,36 +145,26 @@ export class Bitcoin extends Controller implements BaseAPI, BitcoinAPI {
    * @example pubkey "xpub6DQYbVJSVvJPzpYenir7zVSf2WPZRu69LxZuMezzAKuT6biPcug6Vw1zMk4knPBeNKvioutc4EGpPQ8cZiWtjcXYvJ6wPiwcGmCkihA9Jy3"
    */
   @Example<TxHistory>({
-    cursor: "MQ==",
-    pubkey: "336xGpGweq1wtY4kRTuA4w6d7yDkBU9czU",
-    txs: [
-    ],
+    cursor: 'MQ==',
+    pubkey: '336xGpGweq1wtY4kRTuA4w6d7yDkBU9czU',
+    txs: [],
   })
   @Response<BadRequestError>(400, 'Bad Request')
   @Response<ValidationError>(422, 'Validation Error')
   @Response<InternalServerError>(500, 'Internal Server Error')
   @Get('account/{pubkey}/txs')
-  async getTxHistory(
-    @Path() pubkey: string, 
-    @Query() cursor?: string, 
-    @Query() pageSize?: number
-    ): Promise<TxHistory> { 
-            
-      try {
+  async getTxHistory(@Path() pubkey: string, @Query() cursor?: string, @Query() pageSize?: number): Promise<TxHistory> {
+    try {
+      let makeTscHappy = ''
+      if (cursor && pageSize) {
+        makeTscHappy = ''
+      }
 
-        const pageTODO = Number(cursor || "1")
-        const pageSizeTODO = pageSize || 2
-        const contractTODO = undefined
-        const data = await blockbook.getAddress(pubkey, pageTODO, pageSizeTODO, undefined, undefined, 'txs', contractTODO)
-  
-        console.log(data.balance)
-        return {
-          // page: data.page ?? 1,
-          // totalPages: data.totalPages ?? 1,
-          // cursor: "MQ==",
-          pubkey: "TODO",
-          txs: []
-        }
+      return {
+        cursor: makeTscHappy,
+        pubkey: pubkey,
+        txs: [],
+      }
     } catch (err) {
       if (err.response) {
         throw new ApiError(err.response.statusText, err.response.status, JSON.stringify(err.response.data))

--- a/node/coinstacks/common/api/src/index.ts
+++ b/node/coinstacks/common/api/src/index.ts
@@ -50,14 +50,13 @@ export interface BaseAPI {
    * Get transaction history by address or xpub
    *
    * @param {string} pubkey account address or xpub
-   * @param {number} [page] page number
+   * @param {string} [cursor] the cursor returned in previous query
    * @param {number} [pageSize] page size
-   * @param {string} [contract] filter by contract address (only supported by coins which support contracts)
    *
    * @returns {Promise<TxHistory>} transaction history
    */
   // @Get('account/{pubkey}/txs')
-  getTxHistory(pubkey: string, page?: number, pageSize?: number, contract?: string): Promise<TxHistory>
+  getTxHistory(pubkey: string, cursor?: string, pageSize?: number): Promise<TxHistory>
 
   /**
    * Sends raw transaction to be broadcast to the node.

--- a/node/coinstacks/common/api/src/models.ts
+++ b/node/coinstacks/common/api/src/models.ts
@@ -47,10 +47,8 @@ export interface Info {
  * Contains info for pagination
  */
 export interface Pagination {
-  page: number
-  totalPages: number
+  cursor?: string
 }
-
 /**
  * Contains the serialized raw transaction hex
  */
@@ -63,21 +61,16 @@ export interface SendTxBody {
  */
 export interface Tx {
   txid: string
-  status: string
   blockHash?: string
   blockHeight?: number
-  confirmations?: number
   timestamp?: number
-  from: string
-  to?: string
-  value: string
-  fee: string
+  
 }
 
 /**
  * Contains paginated transaction history
  */
 export interface TxHistory extends Pagination {
-  txs: number
-  transactions: Array<Tx>
+  pubkey: string
+  txs: Array<Tx>
 }

--- a/node/coinstacks/common/api/src/models.ts
+++ b/node/coinstacks/common/api/src/models.ts
@@ -64,7 +64,6 @@ export interface Tx {
   blockHash?: string
   blockHeight?: number
   timestamp?: number
-  
 }
 
 /**

--- a/node/coinstacks/ethereum/api/src/controller.ts
+++ b/node/coinstacks/ethereum/api/src/controller.ts
@@ -11,7 +11,7 @@ import {
   SendTxBody,
   ValidationError,
 } from '../../../common/api/src' // unable to import models from a module with tsoa
-import { EthereumAPI, EthereumAccount, Token, GasFees, EthereumTxHistory,EthereumTx, TokenTransfer } from './models'
+import { EthereumAPI, EthereumAccount, Token, GasFees, EthereumTxHistory, EthereumTx, TokenTransfer } from './models'
 
 const INDEXER_URL = process.env.INDEXER_URL
 const INDEXER_WS_URL = process.env.INDEXER_WS_URL
@@ -123,99 +123,94 @@ export class Ethereum extends Controller implements BaseAPI, EthereumAPI {
     pubkey: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
     cursor: 'MQ==',
     txs: [
-    {
-      txid: '0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002',
-      blockHash: '0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8',
-      blockHeight: 12267105,
-      timestamp: 1618788849,
-      status: 1,
-      from: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
-      to: '0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7',
-      confirmations: 2088440,
-      value: '737092621690531649',
-      fee: '3180000000009000',
-      gasLimit: '21000',
-      gasUsed: '21000',
-      gasPrice: '151428571429',
-      inputData: '0x'
-    }
-  ]
+      {
+        txid: '0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002',
+        blockHash: '0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8',
+        blockHeight: 12267105,
+        timestamp: 1618788849,
+        status: 1,
+        from: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
+        to: '0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7',
+        confirmations: 2088440,
+        value: '737092621690531649',
+        fee: '3180000000009000',
+        gasLimit: '21000',
+        gasUsed: '21000',
+        gasPrice: '151428571429',
+        inputData: '0x',
+      },
+    ],
   })
   @Response<BadRequestError>(400, 'Bad Request')
   @Response<ValidationError>(422, 'Validation Error')
   @Response<InternalServerError>(500, 'Internal Server Error')
   @Get('account/{pubkey}/txs')
   async getTxHistory(
-    @Path() pubkey: string, 
-    @Query() cursor?: string, 
+    @Path() pubkey: string,
+    @Query() cursor?: string,
     @Query() pageSize?: number
-    ): Promise<EthereumTxHistory> { 
-            
-      try {
-        
-        var pageNumber = 0
-        if (cursor) {
-          const cursorDecoded = Buffer.from(cursor, 'base64').toString('binary');
-          if (Number(cursorDecoded) === NaN) {
-            throw new ApiError("",1,"Invalid cursor") // TODO: create errror message in localization
-          }
-          pageNumber = Number(cursorDecoded)
+  ): Promise<EthereumTxHistory> {
+    try {
+      let pageNumber = 0
+      if (cursor) {
+        const cursorDecoded = Buffer.from(cursor, 'base64').toString('binary')
+        if (isNaN(Number(cursorDecoded))) {
+          throw new ApiError('', 1, 'Invalid cursor')
         }
-        
-        const pageSizeWithDefault = pageSize || 25
-
-        const data = await blockbook.getAddress(pubkey, pageNumber, pageSizeWithDefault, undefined, undefined, 'txs')
-  
-        const nextPageNumber = pageNumber + 1 
-        // const nextCursor = (data.transactions?.length ?? 0) == pageSizeWithDefault ? Buffer.from(nextPageNumber.toString(), 'binary').toString('base64') : undefined
-        var nextCursor = (data.transactions?.length ?? 0) == pageSizeWithDefault ? {cursor: Buffer.from(nextPageNumber.toString(), 'binary').toString('base64')} : undefined
-
-
-        return {
-          pubkey: pubkey,
-          ...nextCursor,
-          txs:
-            data.transactions?.map<EthereumTx>((tx) => ({
-              txid: tx.txid,
-              blockHash: tx.blockHash,
-              blockHeight: tx.blockHeight,
-              timestamp: tx.blockTime,
-              status: tx.ethereumSpecific?.status ?? tx.confirmations > 0 ? 1 : -1, // assuming confirmed=1 pending=-1 based on mock data
-              from: tx.vin[0].addresses?.[0] ?? 'coinbase',
-              to: tx.vout[0].addresses?.[0] ?? 'unavailable',   // assuming an arbitrary default
-              confirmations: tx.confirmations,
-              value: tx.tokenTransfers?.[0].value ?? tx.value,
-              fee: tx.fees ?? '0',
-              gasLimit:  tx.ethereumSpecific?.gasLimit.toString() ?? 'unavailable', // assuming an arbitrary default
-              gasUsed: tx.ethereumSpecific?.gasUsed?.toString(),
-              gasPrice: tx.ethereumSpecific?.gasPrice.toString() ?? 'unavailable', // assuming an arbitrary default
-              inputData: tx.ethereumSpecific?.data,
-              tokenTransfers: tx.tokenTransfers?.map<TokenTransfer>((tt) => ({
-                balance: "",
-                contract: "",
-                decimals: tt.decimals,
-                name: tt.name,
-                symbol: tt.symbol,
-                type: tt.type,
-                from: tt.from,
-                to: tt.to,
-                value: tt.value
-              }))
-
-            })) ?? [],
-        }
-      } catch (err) {
-        if (err.response) {
-          throw new ApiError(err.response.statusText, err.response.status, JSON.stringify(err.response.data))
-        }
-  
-        throw err
+        pageNumber = Number(cursorDecoded)
       }
 
+      const pageSizeWithDefault = pageSize || 25
 
+      const data = await blockbook.getAddress(pubkey, pageNumber, pageSizeWithDefault, undefined, undefined, 'txs')
+
+      const nextPageNumber = pageNumber + 1
+
+      const nextCursor =
+        (data.transactions?.length ?? 0) == pageSizeWithDefault
+          ? { cursor: Buffer.from(nextPageNumber.toString(), 'binary').toString('base64') }
+          : undefined
+
+      return {
+        pubkey: pubkey,
+        ...nextCursor,
+        txs:
+          data.transactions?.map<EthereumTx>((tx) => ({
+            txid: tx.txid,
+            blockHash: tx.blockHash,
+            blockHeight: tx.blockHeight,
+            timestamp: tx.blockTime,
+            status: tx.ethereumSpecific?.status ?? tx.confirmations > 0 ? 1 : -1, // assuming confirmed=1 pending=-1 based on mock data
+            from: tx.vin[0].addresses?.[0] ?? 'coinbase',
+            to: tx.vout[0].addresses?.[0] ?? 'unavailable', // assuming an arbitrary default
+            confirmations: tx.confirmations,
+            value: tx.tokenTransfers?.[0].value ?? tx.value,
+            fee: tx.fees ?? '0',
+            gasLimit: tx.ethereumSpecific?.gasLimit.toString() ?? 'unavailable', // assuming an arbitrary default
+            gasUsed: tx.ethereumSpecific?.gasUsed?.toString(),
+            gasPrice: tx.ethereumSpecific?.gasPrice.toString() ?? 'unavailable', // assuming an arbitrary default
+            inputData: tx.ethereumSpecific?.data,
+            tokenTransfers: tx.tokenTransfers?.map<TokenTransfer>((tt) => ({
+              balance: '',
+              contract: '',
+              decimals: tt.decimals,
+              name: tt.name,
+              symbol: tt.symbol,
+              type: tt.type,
+              from: tt.from,
+              to: tt.to,
+              value: tt.value,
+            })),
+          })) ?? [],
+      }
+    } catch (err) {
+      if (err.response) {
+        throw new ApiError(err.response.statusText, err.response.status, JSON.stringify(err.response.data))
+      }
+
+      throw err
+    }
   }
-
-
 
   /**
    * Get the estimated gas cost of a transaction

--- a/node/coinstacks/ethereum/api/src/controller.ts
+++ b/node/coinstacks/ethereum/api/src/controller.ts
@@ -148,26 +148,24 @@ export class Ethereum extends Controller implements BaseAPI, EthereumAPI {
   async getTxHistory(
     @Path() pubkey: string,
     @Query() cursor?: string,
-    @Query() pageSize?: number
+    @Query() pageSize = 25
   ): Promise<EthereumTxHistory> {
     try {
       let page = 1
       if (cursor) {
         const cursorDecoded = Buffer.from(cursor, 'base64').toString('binary')
         if (isNaN(Number(cursorDecoded))) {
-          throw new ApiError('Bad Request', 400, 'Invalid cursor')
+          throw new ApiError('Bad Request', 400, 'Invalid cursor, please use the cursor returned in previous page')
         }
         page = Number(cursorDecoded)
       }
 
-      const pageSizeWithDefault = pageSize || 25
-
-      const data = await blockbook.getAddress(pubkey, page, pageSizeWithDefault, undefined, undefined, 'txs')
+      const data = await blockbook.getAddress(pubkey, page, pageSize, undefined, undefined, 'txs')
 
       const nextPage = page + 1
 
       const nextCursor =
-        (data.transactions?.length ?? 0) == pageSizeWithDefault
+        (data.transactions?.length ?? 0) == pageSize
           ? { cursor: Buffer.from(nextPage.toString(), 'binary').toString('base64') }
           : undefined
 

--- a/node/coinstacks/ethereum/api/src/models.ts
+++ b/node/coinstacks/ethereum/api/src/models.ts
@@ -1,5 +1,6 @@
 /* unable to import models from a module with tsoa */
-import { Account } from '../../../common/api/src'
+import { Account, Tx, TxHistory } from '../../../common/api/src'
+
 
 /**
  * Contains info about current recommended fees to use in a transaction
@@ -56,6 +57,39 @@ export interface EthereumTxSpecific {
       data: string
     }>
   }
+}
+
+/**
+ * Contains info about a TokenTransfer
+ */
+export interface TokenTransfer extends Token {
+  from: string
+  to: string
+  value: string
+}
+
+/**
+ * Contains info about a EthereumTx
+ */
+export interface EthereumTx extends Tx {
+  from: string
+  to: string
+  confirmations: number
+  value: string
+  fee: string
+  gasLimit: string
+  gasUsed?: string
+  gasPrice: string
+  status: number
+  inputData?: string
+  tokenTransfers?: Array<TokenTransfer>
+}
+
+/**
+ * Contains info about a EthereumTxHistory
+ */
+ export interface EthereumTxHistory extends TxHistory {
+  txs: Array<EthereumTx>
 }
 
 /**

--- a/node/coinstacks/ethereum/api/src/models.ts
+++ b/node/coinstacks/ethereum/api/src/models.ts
@@ -1,7 +1,6 @@
 /* unable to import models from a module with tsoa */
 import { Account, Tx, TxHistory } from '../../../common/api/src'
 
-
 /**
  * Contains info about current recommended fees to use in a transaction
  */
@@ -88,7 +87,7 @@ export interface EthereumTx extends Tx {
 /**
  * Contains info about a EthereumTxHistory
  */
- export interface EthereumTxHistory extends TxHistory {
+export interface EthereumTxHistory extends TxHistory {
   txs: Array<EthereumTx>
 }
 


### PR DESCRIPTION
#309

- [x] Update getTxHistory endpoint according to the reference spec.
- [x] Update to use base64 encoded cursor based pagination.
- [x] Verify working endpoint at /api/v1/account/{pubkey}/txs (I verified it using `docker-compose up api`)
- [x] Make minimal necessary modifications to bitcoin getTxHistory endpoint in order to pass build. 
- [x] Update all corresponding tsoa comment annotations to reflect all changes.

**A few doubts:**
1. Default values for this tx fields: `to`, `gasLimit` and `gasPrice`. (Currently I used "unavailable")
2. Default values for this tokenTransfers fields: `balance` and `contract` . (Currently I used "unavailable")

Let me know if you need anything else.