### PR TITLE
Re-implement Ethereum transaction history endpoint

### DIFF
--- a/node/coinstacks/common/api/src/index.ts
+++ b/node/coinstacks/common/api/src/index.ts
@@ -50,14 +50,13 @@ export interface BaseAPI {
    * Get transaction history by address or xpub
    *
    * @param {string} pubkey account address or xpub
-   * @param {number} [page] page number
+   * @param {string} [cursor] base64 cursor (encoded page number)
    * @param {number} [pageSize] page size
-   * @param {string} [contract] filter by contract address (only supported by coins which support contracts)
    *
    * @returns {Promise<TxHistory>} transaction history
    */
   // @Get('account/{pubkey}/txs')
-  getTxHistory(pubkey: string, page?: number, pageSize?: number, contract?: string): Promise<TxHistory>
+  getTxHistory(pubkey: string, cursor?: string, pageSize?: number): Promise<TxHistory>
 
   /**
    * Sends raw transaction to be broadcast to the node.

--- a/node/coinstacks/common/api/src/index.ts
+++ b/node/coinstacks/common/api/src/index.ts
@@ -50,7 +50,7 @@ export interface BaseAPI {
    * Get transaction history by address or xpub
    *
    * @param {string} pubkey account address or xpub
-   * @param {string} [cursor] base64 cursor (encoded page number)
+   * @param {string} [cursor] pagination cursor from previous response or empty string for first page fetch
    * @param {number} [pageSize] page size
    *
    * @returns {Promise<TxHistory>} transaction history

--- a/node/coinstacks/common/api/src/models.ts
+++ b/node/coinstacks/common/api/src/models.ts
@@ -47,8 +47,7 @@ export interface Info {
  * Contains info for pagination
  */
 export interface Pagination {
-  page: number
-  totalPages: number
+  cursor?: string
 }
 
 /**
@@ -63,21 +62,15 @@ export interface SendTxBody {
  */
 export interface Tx {
   txid: string
-  status: string
   blockHash?: string
   blockHeight?: number
-  confirmations?: number
   timestamp?: number
-  from: string
-  to?: string
-  value: string
-  fee: string
 }
 
 /**
  * Contains paginated transaction history
  */
 export interface TxHistory extends Pagination {
-  txs: number
-  transactions: Array<Tx>
+  pubkey: string
+  txs: Array<Tx>
 }

--- a/node/coinstacks/ethereum/api/src/models.ts
+++ b/node/coinstacks/ethereum/api/src/models.ts
@@ -1,5 +1,6 @@
 /* unable to import models from a module with tsoa */
 import { Account } from '../../../common/api/src'
+import { Tx, TxHistory } from '@shapeshiftoss/common-api'
 
 /**
  * Contains info about current recommended fees to use in a transaction
@@ -23,6 +24,15 @@ export interface Token {
 }
 
 /**
+ * Contains info about a specific token transfer
+ */
+export interface TokenTransfer extends Token {
+  from: string
+  to: string
+  value: string
+}
+
+/**
  * Contains additional ethereum specific info
  */
 export interface EthereumAccount extends Account {
@@ -33,29 +43,25 @@ export interface EthereumAccount extends Account {
 /**
  * Contains ethereum specific transaction info as returned from the node
  */
-export interface EthereumTxSpecific {
-  tx: {
-    nonce: string
-    gasPrice: string
-    gas: string
-    to: string
-    value: string
-    input: string
-    hash: string
-    blockNumber: string
-    blockHash?: string
-    from: string
-    transactionIndex: string
-  }
-  receipt?: {
-    gasUsed: string
-    status: string
-    logs: Array<{
-      address: string
-      topics: Array<string>
-      data: string
-    }>
-  }
+export interface EthereumTx extends Tx {
+  from: string
+  to: string
+  confirmations: number
+  value: string
+  fee: string
+  gasLimit: string
+  gasUsed?: string
+  gasPrice: string
+  status: number
+  inputData?: string
+  tokenTransfers?: Array<TokenTransfer>
+}
+
+/**
+ * Contains ethereum specific transaction history
+ */
+export interface EthereumTxHistory extends TxHistory {
+  txs: Array<EthereumTx>
 }
 
 /**


### PR DESCRIPTION
Note: some properties like `gasLimit` or `to` are not guaranteed as per Blockbook typings, so I'm using fallback values that I considered sensible (typically empty strings). These can easily be changed if needed.