### PR TITLE
Use explicit glob for prettier formatting

### DIFF
--- a/node/.lintstagedrc.json
+++ b/node/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*": "prettier --write"
+  "*.{js,json,ts,md,yml,yaml}": "prettier --write"
 }


### PR DESCRIPTION
I had expected `.prettierignore` to be honored up front by `lint-staged`, but it turns out that was not the case.

This change explicitly matches file extensions supported by prettier to be linted, in which .prettierignore will then ignore writing files thereafter.