### PR TITLE
chore: add effort and sponsor to bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -47,7 +47,19 @@ body:
           required: true
         - label: As the sponsor of this bounty I will review the changes in a preview environment (ops/product) or review the PR (engineering)
           required: true
-  - type: textarea
+- type: input
+    id: estimate
+    attributes:
+      label: Estimated effort
+      description: "Estimated effort to complete the bounty, in hours or days"
+      placeholder: "Half a day"
+  - type: input
+    id: stakeholder
+    attributes:
+      label: Sponsor / Stakeholder
+      description: "To whom can the bounty hunter go to for questions and support?"
+      placeholder: "github_handle or discord_handle"
+- type: textarea
     id: bounty-hunters
     attributes:
       label: Bounty Hunters

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -47,18 +47,18 @@ body:
           required: true
         - label: As the sponsor of this bounty I will review the changes in a preview environment (ops/product) or review the PR (engineering)
           required: true
-    - type: input
-        id: estimate
-        attributes:
-          label: Estimated effort
-          description: "Estimated effort to complete the bounty, in hours or days"
-          placeholder: "Half a day"
-    - type: input
-      id: stakeholder
-      attributes:
-        label: Sponsor / Stakeholder
-        description: "To whom can the bounty hunter go to for questions and support?"
-        placeholder: "github_handle or discord_handle"
+  - type: input
+    id: estimate
+    attributes:
+      label: Estimated effort
+      description: "Estimated effort to complete the bounty, in hours or days"
+      placeholder: "Half a day"
+  - type: input
+    id: stakeholder
+    attributes:
+      label: Sponsor / Stakeholder
+      description: "To whom can the bounty hunter go to for questions and support?"
+      placeholder: "github_handle or discord_handle"
   - type: textarea
     id: bounty-hunters
     attributes:

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -47,19 +47,19 @@ body:
           required: true
         - label: As the sponsor of this bounty I will review the changes in a preview environment (ops/product) or review the PR (engineering)
           required: true
-- type: input
-    id: estimate
-    attributes:
-      label: Estimated effort
-      description: "Estimated effort to complete the bounty, in hours or days"
-      placeholder: "Half a day"
-  - type: input
-    id: stakeholder
-    attributes:
-      label: Sponsor / Stakeholder
-      description: "To whom can the bounty hunter go to for questions and support?"
-      placeholder: "github_handle or discord_handle"
-- type: textarea
+    - type: input
+        id: estimate
+        attributes:
+          label: Estimated effort
+          description: "Estimated effort to complete the bounty, in hours or days"
+          placeholder: "Half a day"
+    - type: input
+      id: stakeholder
+      attributes:
+        label: Sponsor / Stakeholder
+        description: "To whom can the bounty hunter go to for questions and support?"
+        placeholder: "github_handle or discord_handle"
+  - type: textarea
     id: bounty-hunters
     attributes:
       label: Bounty Hunters


### PR DESCRIPTION
Bring the `unchained` bounty template in line with `web` by adding effort and sponsor inputs.

<img width="412" alt="Screen Shot 2022-03-26 at 7 03 39 pm" src="https://user-images.githubusercontent.com/97164662/160230624-4d77a35e-37fd-4f89-88fb-979a425864a8.png">