### PR TITLE
Only get blocks to put together txs for registered addresses

### DIFF
--- a/go/coinstacks/cosmos/api/handlers.go
+++ b/go/coinstacks/cosmos/api/handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/shapeshift/unchained/pkg/api"
 	"github.com/shapeshift/unchained/pkg/cosmos"
+	"github.com/shapeshift/unchained/pkg/websocket"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -20,13 +21,25 @@ type Handler struct {
 }
 
 func (h *Handler) StartWebsocket() error {
-	h.wsClient.TxHandler(func(tx types.EventDataTx) (interface{}, []string, error) {
+	h.wsClient.TxHandler(func(tx types.EventDataTx, registry websocket.Registry) (interface{}, []string, error) {
 		cosmosTx, signingTx, err := cosmos.DecodeTx(h.wsClient.EncodingConfig(), tx.Tx)
+
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to decode tx: %v", tx.Tx)
 		}
 
 		txid := fmt.Sprintf("%X", sha256.Sum256(tx.Tx))
+
+		Messages := cosmos.Messages(cosmosTx.GetMsgs())
+
+		if len(Messages) > 0 {
+			// Dont bother getting blocks for or creating transactions that arent in the registry
+			origin := Messages[0].Origin
+			to := Messages[0].To
+			if !registry.HasRegisteredAddress(registry.GetRegisteredAddresses(), origin) && !registry.HasRegisteredAddress(registry.GetRegisteredAddresses(), to) {
+				return nil, nil, errors.Errorf("skipping tx for unregistered address: %s", txid)
+			}
+		}
 
 		block, err := h.blockService.GetBlock(int(tx.Height))
 		if err != nil {
@@ -47,7 +60,7 @@ func (h *Handler) StartWebsocket() error {
 			GasUsed:       strconv.Itoa(int(tx.Result.GasUsed)),
 			Index:         int(tx.Index),
 			Memo:          signingTx.GetMemo(),
-			Messages:      cosmos.Messages(cosmosTx.GetMsgs()),
+			Messages:      Messages,
 		}
 
 		seen := make(map[string]bool)

--- a/go/coinstacks/cosmos/api/handlers.go
+++ b/go/coinstacks/cosmos/api/handlers.go
@@ -28,8 +28,6 @@ func (h *Handler) StartWebsocket() error {
 
 		txid := fmt.Sprintf("%X", sha256.Sum256(tx.Tx))
 
-		logger.Infof("StartWebsocket TxHandler txid %s", txid)
-
 		block, err := h.blockService.GetBlock(int(tx.Height))
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to handle tx: %s", txid)

--- a/go/coinstacks/osmosis/api/handlers.go
+++ b/go/coinstacks/osmosis/api/handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shapeshift/unchained/coinstacks/osmosis"
 	"github.com/shapeshift/unchained/pkg/api"
 	"github.com/shapeshift/unchained/pkg/cosmos"
+	"github.com/shapeshift/unchained/pkg/websocket"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -19,13 +20,24 @@ type Handler struct {
 }
 
 func (h *Handler) StartWebsocket() error {
-	h.wsClient.TxHandler(func(tx types.EventDataTx) (interface{}, []string, error) {
+	h.wsClient.TxHandler(func(tx types.EventDataTx, registry websocket.Registry) (interface{}, []string, error) {
 		cosmosTx, signingTx, err := cosmos.DecodeTx(h.wsClient.EncodingConfig(), tx.Tx)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to decode tx: %v", tx.Tx)
 		}
 
 		txid := fmt.Sprintf("%X", sha256.Sum256(tx.Tx))
+
+		Messages := cosmos.Messages(cosmosTx.GetMsgs())
+
+		if len(Messages) > 0 {
+			// Dont bother getting blocks for or creating transactions that arent in the registry
+			origin := Messages[0].Origin
+			to := Messages[0].To
+			if !registry.HasRegisteredAddress(registry.GetRegisteredAddresses(), origin) && !registry.HasRegisteredAddress(registry.GetRegisteredAddresses(), to) {
+				return nil, nil, errors.Errorf("skipping tx for unregistered address: %s", txid)
+			}
+		}
 
 		block, err := h.blockService.GetBlock(int(tx.Height))
 		if err != nil {

--- a/go/pkg/cosmos/websocket.go
+++ b/go/pkg/cosmos/websocket.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-type TxHandlerFunc = func(tx types.EventDataTx) (interface{}, []string, error)
+type TxHandlerFunc = func(tx types.EventDataTx, registry websocket.Registry) (interface{}, []string, error)
 
 type WSClient struct {
 	*websocket.Registry
@@ -125,7 +125,7 @@ func (ws *WSClient) listen() {
 }
 
 func (ws *WSClient) handleTx(tx types.EventDataTx) {
-	data, addrs, err := ws.txHandler(tx)
+	data, addrs, err := ws.txHandler(tx, *ws.Registry)
 	if err != nil {
 		logger.Error(err)
 		return

--- a/go/pkg/websocket/registry.go
+++ b/go/pkg/websocket/registry.go
@@ -91,3 +91,23 @@ func (r *Registry) Publish(addrs []string, data interface{}) {
 		}
 	}
 }
+
+func (r *Registry) GetRegisteredAddresses() (addrs []string) {
+
+	i := 0
+	keys := make([]string, len(r.addresses))
+	for k := range r.addresses {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+func (r *Registry) HasRegisteredAddress(s []string, str string) bool {
+	registeredAddresses := r.GetRegisteredAddresses()
+	for _, v := range registeredAddresses {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Only get blocks to put together txs for registered addresses.

Previously we try to get block data for all transactions including ones we dont care about causing it to often print an error message that the block doesnt exist yet because tx is so new.

Now it will only try and get block and print that error message for txs we care about.