### PR TITLE
refactor(caip): flatten CAIP imports

### DIFF
--- a/node/packages/client/package.json
+++ b/node/packages/client/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@shapeshiftoss/blockbook": "^6.9.0",
-    "@shapeshiftoss/caip": "^2.0.0",
+    "@shapeshiftoss/caip": "^3.0.0",
     "@shapeshiftoss/logger": "^1.0.0",
     "@shapeshiftoss/types": "^2.0.0",
     "@yfi/sdk": "^1.0.30",

--- a/node/packages/client/src/bitcoin/parser/index.ts
+++ b/node/packages/client/src/bitcoin/parser/index.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
-import { caip2, caip19, AssetNamespace, AssetReference } from '@shapeshiftoss/caip'
+import { toCAIP2, toCAIP19, AssetNamespace, AssetReference } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { Tx as ParsedTx, Status, TransferType } from '../../types'
 import { aggregateTransfer } from '../../utils'
@@ -20,7 +20,7 @@ export class TransactionParser {
   }
 
   async parse(tx: BlockbookTx, address: string): Promise<ParsedTx> {
-    const caip19Bitcoin = caip19.toCAIP19({
+    const caip19Bitcoin = toCAIP19({
       chain: ChainTypes.Bitcoin,
       network: toNetworkType(this.network),
       assetNamespace: AssetNamespace.Slip44,
@@ -32,7 +32,7 @@ export class TransactionParser {
       blockHash: tx.blockHash,
       blockHeight: tx.blockHeight,
       blockTime: tx.blockTime,
-      caip2: caip2.toCAIP2({ chain: ChainTypes.Bitcoin, network: toNetworkType(this.network) }),
+      caip2: toCAIP2({ chain: ChainTypes.Bitcoin, network: toNetworkType(this.network) }),
       confirmations: tx.confirmations,
       status: tx.confirmations > 0 ? Status.Confirmed : Status.Pending,
       transfers: [],

--- a/node/packages/client/src/cosmos/parser/index.ts
+++ b/node/packages/client/src/cosmos/parser/index.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'bignumber.js'
-import { caip2, caip19, AssetNamespace, AssetReference, CAIP2, CAIP19 } from '@shapeshiftoss/caip'
+import { fromCAIP2, toCAIP19, AssetNamespace, AssetReference, CAIP2, CAIP19 } from '@shapeshiftoss/caip'
 import { Status, TransferType } from '../../types'
 import { Tx as CosmosTx } from '../index'
 import { ParsedTx } from '../types'
@@ -16,8 +16,8 @@ export class TransactionParser {
   constructor(args: TransactionParserArgs) {
     this.chainId = args.chainId
 
-    this.assetId = caip19.toCAIP19({
-      ...caip2.fromCAIP2(this.chainId),
+    this.assetId = toCAIP19({
+      ...fromCAIP2(this.chainId),
       assetNamespace: AssetNamespace.Slip44,
       assetReference: AssetReference.Cosmos,
     })

--- a/node/packages/client/src/ethereum/parser/index.ts
+++ b/node/packages/client/src/ethereum/parser/index.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'bignumber.js'
 import { ethers } from 'ethers'
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
-import { caip19, caip2, AssetNamespace, AssetReference } from '@shapeshiftoss/caip'
+import { toCAIP19, toCAIP2, AssetNamespace, AssetReference } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { Status, Token, TransferType } from '../../types'
 import { aggregateTransfer, findAsyncSequential } from '../../utils'
@@ -69,7 +69,7 @@ export class TransactionParser {
       blockHash: tx.blockHash,
       blockHeight: tx.blockHeight,
       blockTime: tx.blockTime,
-      caip2: caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) }),
+      caip2: toCAIP2({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) }),
       confirmations: tx.confirmations,
       status: TransactionParser.getStatus(tx),
       trade: contractParserResult?.trade,
@@ -97,7 +97,7 @@ export class TransactionParser {
     address: string,
     internalTxs?: Array<InternalTx>
   ) {
-    const caip19Ethereum = caip19.toCAIP19({
+    const caip19Ethereum = toCAIP19({
       chain: ChainTypes.Ethereum,
       network: toNetworkType(this.network),
       assetNamespace: AssetNamespace.Slip44,
@@ -157,7 +157,7 @@ export class TransactionParser {
       }
 
       const transferArgs = [
-        caip19.toCAIP19({
+        toCAIP19({
           chain: ChainTypes.Ethereum,
           network: toNetworkType(this.network),
           assetNamespace: AssetNamespace.ERC20,
@@ -182,7 +182,7 @@ export class TransactionParser {
 
     internalTxs?.forEach((internalTx) => {
       const transferArgs = [
-        caip19.toCAIP19({
+        toCAIP19({
           chain: ChainTypes.Ethereum,
           network: toNetworkType(this.network),
           assetNamespace: AssetNamespace.Slip44,

--- a/node/packages/client/src/ethereum/parser/uniV2.ts
+++ b/node/packages/client/src/ethereum/parser/uniV2.ts
@@ -1,4 +1,4 @@
-import { caip19, AssetNamespace } from '@shapeshiftoss/caip'
+import { toCAIP19, AssetNamespace } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
 import { ethers } from 'ethers'
@@ -81,7 +81,7 @@ export class Parser implements SubParser {
             type: TransferType.Send,
             from: sendAddress,
             to: lpTokenAddress,
-            caip19: caip19.toCAIP19({
+            caip19: toCAIP19({
               chain: ChainTypes.Ethereum,
               network: toNetworkType(this.network),
               assetNamespace: AssetNamespace.ERC20,
@@ -109,7 +109,7 @@ export class Parser implements SubParser {
             type: TransferType.Send,
             from: sendAddress,
             to: lpTokenAddress,
-            caip19: caip19.toCAIP19({
+            caip19: toCAIP19({
               chain: ChainTypes.Ethereum,
               network: toNetworkType(this.network),
               assetNamespace: AssetNamespace.ERC20,

--- a/node/packages/client/src/ethereum/parser/weth.ts
+++ b/node/packages/client/src/ethereum/parser/weth.ts
@@ -1,4 +1,4 @@
-import { caip19, AssetNamespace } from '@shapeshiftoss/caip'
+import { toCAIP19, AssetNamespace } from '@shapeshiftoss/caip'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
 import { ethers } from 'ethers'
@@ -59,7 +59,7 @@ export class Parser implements SubParser {
               type: TransferType.Receive,
               from: this.wethContract,
               to: sendAddress,
-              caip19: caip19.toCAIP19({
+              caip19: toCAIP19({
                 chain: ChainTypes.Ethereum,
                 network: toNetworkType(this.network),
                 assetNamespace: AssetNamespace.ERC20,
@@ -85,7 +85,7 @@ export class Parser implements SubParser {
               type: TransferType.Send,
               from: sendAddress,
               to: this.wethContract,
-              caip19: caip19.toCAIP19({
+              caip19: toCAIP19({
                 chain: ChainTypes.Ethereum,
                 network: toNetworkType(this.network),
                 assetNamespace: AssetNamespace.ERC20,


### PR DESCRIPTION
This imports CAIP utils from the new flattened exports.

⚠️ https://github.com/shapeshift/lib/pull/560 should be merged and published first - it contains the flattened exports. 

Once that's done, we should run `yarn` one more time here to update the yarn lockfile.

Closes https://github.com/shapeshift/unchained/issues/396
Partially completes https://github.com/shapeshift/lib/issues/548 