### PR TITLE
refactor(caip): rename caip specifiers

### DIFF
--- a/node/packages/client/package.json
+++ b/node/packages/client/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@shapeshiftoss/blockbook": "^6.10.0",
-    "@shapeshiftoss/caip": "^2.0.0",
+    "@shapeshiftoss/caip": "^2.2.1",
     "@shapeshiftoss/logger": "^1.0.0",
     "@shapeshiftoss/types": "^2.0.0",
     "@yfi/sdk": "^1.0.30",

--- a/node/packages/client/src/cosmos/parser/index.ts
+++ b/node/packages/client/src/cosmos/parser/index.ts
@@ -1,17 +1,17 @@
 import { BigNumber } from 'bignumber.js'
-import { caip2, caip19, AssetNamespace, AssetReference, CAIP2, CAIP19 } from '@shapeshiftoss/caip'
+import { caip2, caip19, AssetNamespace, AssetReference, ChainId, AssetId } from '@shapeshiftoss/caip'
 import { Status, TransferType } from '../../types'
 import { Tx as CosmosTx } from '../index'
 import { ParsedTx } from '../types'
 import { valuesFromMsgEvents } from './utils'
 
 export interface TransactionParserArgs {
-  chainId: CAIP2
+  chainId: ChainId
 }
 
 export class TransactionParser {
-  chainId: CAIP2
-  assetId: CAIP19
+  chainId: ChainId
+  assetId: AssetId
 
   constructor(args: TransactionParserArgs) {
     this.chainId = args.chainId

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2167,10 +2167,10 @@
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
 
-"@shapeshiftoss/caip@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-2.0.0.tgz#6aba7a86eb0cb27576ae6d62dd9257e3d754d8a1"
-  integrity sha512-R3KpNrJFF4hibcZpBD81ANKJWmj5HuvYtVg59UVccUYWU3eNn5SNYkl+zukDvSnXcewwzJ0ukpcKHeSictpe6A==
+"@shapeshiftoss/caip@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-2.2.1.tgz#1c0fd53c479b60d5178ec4f14b3805f79b3215cd"
+  integrity sha512-AT7gjU3qM3t2mKyG36b0uAH4mSebl1hD9OjgjOPu4noBzukfFmxhcdBI9K7F4/PZdK+JIrZ/HhEQhtcraF6LaA==
 
 "@shapeshiftoss/cluster-launcher@0.7.2":
   version "0.7.2"


### PR DESCRIPTION
## Description

Replace `{ CAIP10, CAIP19, CAIP2 }` types in `unchained` with `{ AccountId, AssetId, ChainId }`.
There were very few - I'm going to create another issue to remove the caip vernacular on the parsers.

Requires https://github.com/shapeshift/lib/pull/559 to be published.

Closes https://github.com/shapeshift/unchained/issues/395