### PR TITLE
refactor: clean up code

### DIFF
--- a/node/packages/client/src/bitcoin/parser/index.ts
+++ b/node/packages/client/src/bitcoin/parser/index.ts
@@ -40,7 +40,7 @@ export class TransactionParser {
     }
 
     tx.vin.forEach((vin) => {
-      if (vin.isAddress === true && vin.addresses?.includes(address)) {
+      if (vin.isAddress && vin.addresses?.includes(address)) {
         // send amount
         const sendValue = new BigNumber(vin.value ?? 0)
         if (sendValue.gt(0)) {
@@ -63,7 +63,7 @@ export class TransactionParser {
     })
 
     tx.vout.forEach((vout) => {
-      if (vout.isAddress === true && vout.addresses?.includes(address)) {
+      if (vout.isAddress && vout.addresses?.includes(address)) {
         // receive amount
         const receiveValue = new BigNumber(vout.value ?? 0)
         if (receiveValue.gt(0)) {

--- a/node/packages/client/src/ethereum/parser/index.ts
+++ b/node/packages/client/src/ethereum/parser/index.ts
@@ -144,7 +144,7 @@ export class TransactionParser {
 
     tx.tokenTransfers?.forEach((transfer) => {
       // FTX Token (FTT) name and symbol was set backwards on the ERC20 contract
-      if (transfer.token == '0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9') {
+      if (transfer.token === '0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9') {
         transfer.name = transfer.symbol
         transfer.symbol = transfer.name
       }

--- a/node/packages/client/src/ethereum/parser/yearn.ts
+++ b/node/packages/client/src/ethereum/parser/yearn.ts
@@ -37,7 +37,7 @@ export class Parser implements SubParser {
     this.provider = args.provider
 
     // The only Yearn-supported chain we currently support is mainnet
-    if (args.network == 'mainnet') {
+    if (args.network === 'mainnet') {
       // 1 for EthMain (@yfi/sdk/dist/chain.d.ts)
       this.yearnSdk = new Yearn(1, { provider: this.provider, disableAllowlist: true })
     }

--- a/node/packages/client/src/types.ts
+++ b/node/packages/client/src/types.ts
@@ -63,8 +63,6 @@ export interface StandardTxMetadata {
   parser: TxParser
 }
 
-export type TxMetadata = StandardTxMetadata
-
 export interface StandardTx {
   address: string
   blockHash?: string


### PR DESCRIPTION
- Removes an unused type, `TxMetadata`
- Use `===` to avoid type coercion bugs
- Remove unnecessary boolean checks