### PR TITLE
chore: replace CAIP property names in the parser with generic names

### DIFF
--- a/node/packages/client/src/bitcoin/parser/__tests__/bitcoin.test.ts
+++ b/node/packages/client/src/bitcoin/parser/__tests__/bitcoin.test.ts
@@ -18,8 +18,10 @@ describe('parseTx', () => {
       status: Status.Pending,
       address: address,
       caip2: 'bip122:000000000019d6689c085ae165831e93',
+      chainId: 'bip122:000000000019d6689c085ae165831e93',
       fee: {
         caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
         value: '6528',
       },
       transfers: [
@@ -28,6 +30,7 @@ describe('parseTx', () => {
           from: '1ALpDTSP3BmBYKDudG8sLmt9ppDRNwqunj',
           to: '1KcXirKZg5bNnwAKGCTDprwJXivtFyAQc7',
           caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+          assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
           totalValue: '12989718',
           components: [{ value: '12989718' }],
         },
@@ -52,8 +55,10 @@ describe('parseTx', () => {
       status: Status.Confirmed,
       address: address,
       caip2: 'bip122:000000000019d6689c085ae165831e93',
+      chainId: 'bip122:000000000019d6689c085ae165831e93',
       fee: {
         caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
         value: '6528',
       },
       transfers: [
@@ -62,6 +67,7 @@ describe('parseTx', () => {
           from: '1ALpDTSP3BmBYKDudG8sLmt9ppDRNwqunj',
           to: '1KcXirKZg5bNnwAKGCTDprwJXivtFyAQc7',
           caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+          assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
           totalValue: '12989718',
           components: [{ value: '12989718' }],
         },
@@ -85,12 +91,14 @@ describe('parseTx', () => {
       status: Status.Pending,
       address: address,
       caip2: 'bip122:000000000019d6689c085ae165831e93',
+      chainId: 'bip122:000000000019d6689c085ae165831e93',
       transfers: [
         {
           type: TransferType.Receive,
           to: '1KcXirKZg5bNnwAKGCTDprwJXivtFyAQc7',
           from: '1ALpDTSP3BmBYKDudG8sLmt9ppDRNwqunj',
           caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+          assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
           totalValue: '12983190',
           components: [{ value: '12983190' }],
         },
@@ -115,12 +123,14 @@ describe('parseTx', () => {
       status: Status.Confirmed,
       address: address,
       caip2: 'bip122:000000000019d6689c085ae165831e93',
+      chainId: 'bip122:000000000019d6689c085ae165831e93',
       transfers: [
         {
           type: TransferType.Receive,
           to: '1KcXirKZg5bNnwAKGCTDprwJXivtFyAQc7',
           from: '1ALpDTSP3BmBYKDudG8sLmt9ppDRNwqunj',
           caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+          assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
           totalValue: '12983190',
           components: [{ value: '12983190' }],
         },
@@ -144,8 +154,10 @@ describe('parseTx', () => {
       status: Status.Pending,
       address: address,
       caip2: 'bip122:000000000019d6689c085ae165831e93',
+      chainId: 'bip122:000000000019d6689c085ae165831e93',
       fee: {
         caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
         value: '6112',
       },
       transfers: [
@@ -154,6 +166,7 @@ describe('parseTx', () => {
           to: '1Ex6unDe3gt4twj8GDHTutUbKvvHzMPj3e',
           from: '19BJg2jSvz8pHiz7kKSgdp69iVV5CnAvzB',
           caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+          assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
           totalValue: '4098889',
           components: [{ value: '4098889' }],
         },
@@ -162,6 +175,7 @@ describe('parseTx', () => {
           to: '19BJg2jSvz8pHiz7kKSgdp69iVV5CnAvzB',
           from: '19BJg2jSvz8pHiz7kKSgdp69iVV5CnAvzB',
           caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+          assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
           totalValue: '3908177',
           components: [{ value: '3908177' }],
         },
@@ -186,8 +200,10 @@ describe('parseTx', () => {
       status: Status.Confirmed,
       address: address,
       caip2: 'bip122:000000000019d6689c085ae165831e93',
+      chainId: 'bip122:000000000019d6689c085ae165831e93',
       fee: {
         caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
         value: '6112',
       },
       transfers: [
@@ -196,6 +212,7 @@ describe('parseTx', () => {
           to: '1Ex6unDe3gt4twj8GDHTutUbKvvHzMPj3e',
           from: '19BJg2jSvz8pHiz7kKSgdp69iVV5CnAvzB',
           caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+          assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
           totalValue: '4098889',
           components: [{ value: '4098889' }],
         },
@@ -204,6 +221,7 @@ describe('parseTx', () => {
           to: '19BJg2jSvz8pHiz7kKSgdp69iVV5CnAvzB',
           from: '19BJg2jSvz8pHiz7kKSgdp69iVV5CnAvzB',
           caip19: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+          assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
           totalValue: '3908177',
           components: [{ value: '3908177' }],
         },

--- a/node/packages/client/src/bitcoin/parser/index.ts
+++ b/node/packages/client/src/bitcoin/parser/index.ts
@@ -33,6 +33,7 @@ export class TransactionParser {
       blockHeight: tx.blockHeight,
       blockTime: tx.blockTime,
       caip2: caip2.toCAIP2({ chain: ChainTypes.Bitcoin, network: toNetworkType(this.network) }),
+      chainId: caip2.toCAIP2({ chain: ChainTypes.Bitcoin, network: toNetworkType(this.network) }),
       confirmations: tx.confirmations,
       status: tx.confirmations > 0 ? Status.Confirmed : Status.Pending,
       transfers: [],
@@ -57,7 +58,7 @@ export class TransactionParser {
         // network fee
         const fees = new BigNumber(tx.fees ?? 0)
         if (fees.gt(0)) {
-          parsedTx.fee = { caip19: caip19Bitcoin, value: fees.toString(10) }
+          parsedTx.fee = { caip19: caip19Bitcoin, assetId: caip19Bitcoin, value: fees.toString(10) }
         }
       }
     })

--- a/node/packages/client/src/cosmos/parser/__tests__/cosmos.test.ts
+++ b/node/packages/client/src/cosmos/parser/__tests__/cosmos.test.ts
@@ -25,8 +25,10 @@ describe('parseTx', () => {
       status: Status.Confirmed,
       address: address,
       caip2: 'cosmos:cosmoshub-4',
+      chainId: 'cosmos:cosmoshub-4',
       fee: {
         caip19: 'cosmos:cosmoshub-4/slip44:118',
+        assetId: 'cosmos:cosmoshub-4/slip44:118',
         value: '2500',
       },
       transfers: [
@@ -35,6 +37,7 @@ describe('parseTx', () => {
           from: address,
           to: 'cosmos14e25lpsedq863vgweqg4m9n0z28c203kfdlzmz',
           caip19: 'cosmos:cosmoshub-4/slip44:118',
+          assetId: 'cosmos:cosmoshub-4/slip44:118',
           totalValue: '2002965',
           components: [{ value: '2002965' }],
         },
@@ -59,12 +62,14 @@ describe('parseTx', () => {
       status: Status.Confirmed,
       address: address,
       caip2: 'cosmos:cosmoshub-4',
+      chainId: 'cosmos:cosmoshub-4',
       transfers: [
         {
           type: TransferType.Receive,
           from: 'cosmos1t5u0jfg3ljsjrh2m9e47d4ny2hea7eehxrzdgd',
           to: address,
           caip19: 'cosmos:cosmoshub-4/slip44:118',
+          assetId: 'cosmos:cosmoshub-4/slip44:118',
           totalValue: '2002965',
           components: [{ value: '2002965' }],
         },
@@ -85,12 +90,14 @@ describe('parseTx', () => {
       blockHeight: 9636923,
       blockTime: 1645207449,
       caip2: 'cosmos:cosmoshub-4',
+      chainId: 'cosmos:cosmoshub-4',
       confirmations: 358801,
       status: Status.Confirmed,
       transfers: [
         {
           type: TransferType.Send,
           caip19: 'cosmos:cosmoshub-4/slip44:118',
+          assetId: 'cosmos:cosmoshub-4/slip44:118',
           from: 'cosmos179k2lz70rxvjrvvr65cynw9x5c8v3kftg46v05',
           to: 'cosmosvaloper1lzhlnpahvznwfv4jmay2tgaha5kmz5qxerarrl',
           totalValue: '1920000',
@@ -105,7 +112,7 @@ describe('parseTx', () => {
         destinationValidator: 'cosmosvaloper1lzhlnpahvznwfv4jmay2tgaha5kmz5qxerarrl',
         value: `1920000`,
       },
-      fee: { caip19: 'cosmos:cosmoshub-4/slip44:118', value: '6250' },
+      fee: { caip19: 'cosmos:cosmoshub-4/slip44:118', assetId: 'cosmos:cosmoshub-4/slip44:118', value: '6250' },
     }
 
     const actual = await txParser.parse(tx, address)
@@ -122,15 +129,18 @@ describe('parseTx', () => {
       blockHeight: 9636932,
       blockTime: 1646429915,
       caip2: 'cosmos:cosmoshub-4',
+      chainId: 'cosmos:cosmoshub-4',
       confirmations: 229191,
       status: Status.Confirmed,
       fee: {
         caip19: 'cosmos:cosmoshub-4/slip44:118',
+        assetId: 'cosmos:cosmoshub-4/slip44:118',
         value: '6250',
       },
       transfers: [
         {
           caip19: 'cosmos:cosmoshub-4/slip44:118',
+          assetId: 'cosmos:cosmoshub-4/slip44:118',
           components: [
             {
               value: '200000',
@@ -167,6 +177,7 @@ describe('parseTx', () => {
       blockHeight: 9636911,
       blockTime: 1646429755,
       caip2: 'cosmos:cosmoshub-4',
+      chainId: 'cosmos:cosmoshub-4',
       confirmations: 229341,
       status: Status.Confirmed,
       transfers: [],
@@ -178,10 +189,12 @@ describe('parseTx', () => {
         delegator: 'cosmos1fx4jwv3aalxqwmrpymn34l582lnehr3eqwuz9e',
         destinationValidator: 'cosmosvaloper156gqf9837u7d4c4678yt3rl4ls9c5vuursrrzf',
         caip19: 'cosmos:cosmoshub-4/slip44:118',
+        assetId: 'cosmos:cosmoshub-4/slip44:118',
         value: `500000`,
       },
       fee: {
         caip19: 'cosmos:cosmoshub-4/slip44:118',
+        assetId: 'cosmos:cosmoshub-4/slip44:118',
         value: '6250',
       },
     }
@@ -200,12 +213,14 @@ describe('parseTx', () => {
       blockHeight: 9636957,
       blockTime: 1646430088,
       caip2: 'cosmos:cosmoshub-4',
+      chainId: 'cosmos:cosmoshub-4',
       confirmations: 229401,
       status: Status.Confirmed,
       transfers: [
         {
           type: TransferType.Receive,
           caip19: 'cosmos:cosmoshub-4/slip44:118',
+          assetId: 'cosmos:cosmoshub-4/slip44:118',
           from: 'cosmosvaloper1hdrlqvyjfy5sdrseecjrutyws9khtxxaux62l7',
           to: 'cosmos179k2lz70rxvjrvvr65cynw9x5c8v3kftg46v05',
           totalValue: '39447',
@@ -219,8 +234,9 @@ describe('parseTx', () => {
         destinationValidator: 'cosmos179k2lz70rxvjrvvr65cynw9x5c8v3kftg46v05',
         value: '39447',
         caip19: 'cosmos:cosmoshub-4/slip44:118',
+        assetId: 'cosmos:cosmoshub-4/slip44:118',
       },
-      fee: { caip19: 'cosmos:cosmoshub-4/slip44:118', value: '7000' },
+      fee: { caip19: 'cosmos:cosmoshub-4/slip44:118', assetId: 'cosmos:cosmoshub-4/slip44:118', value: '7000' },
     }
 
     const actual = await txParser.parse(tx, address)
@@ -238,12 +254,14 @@ describe('parseTx', () => {
       blockHeight: 8418140,
       blockTime: 1637387732,
       caip2: 'cosmos:cosmoshub-4',
+      chainId: 'cosmos:cosmoshub-4',
       confirmations: 1632185,
       status: Status.Confirmed,
       transfers: [
         {
           type: TransferType.Send,
           caip19: 'cosmos:cosmoshub-4/slip44:118',
+          assetId: 'cosmos:cosmoshub-4/slip44:118',
           from: 'cosmos1fx4jwv3aalxqwmrpymn34l582lnehr3eqwuz9e',
           to: 'osmo1fx4jwv3aalxqwmrpymn34l582lnehr3eg40jnt',
           totalValue: '108444',
@@ -261,6 +279,7 @@ describe('parseTx', () => {
         ibcDestination: 'osmo1fx4jwv3aalxqwmrpymn34l582lnehr3eg40jnt',
         ibcSource: 'cosmos1fx4jwv3aalxqwmrpymn34l582lnehr3eqwuz9e',
         caip19: 'cosmos:cosmoshub-4/slip44:118',
+        assetId: 'cosmos:cosmoshub-4/slip44:118',
         value: '108444',
       },
     }
@@ -281,12 +300,14 @@ it('should be able to parse an ibc receive tx', async () => {
     blockHeight: 9636880,
     blockTime: 1646429517,
     caip2: 'cosmos:cosmoshub-4',
+    chainId: 'cosmos:cosmoshub-4',
     confirmations: 231594,
     status: Status.Confirmed,
     transfers: [
       {
         type: TransferType.Receive,
         caip19: 'cosmos:cosmoshub-4/slip44:118',
+        assetId: 'cosmos:cosmoshub-4/slip44:118',
         from: 'osmo1fx4jwv3aalxqwmrpymn34l582lnehr3eg40jnt',
         to: 'cosmos1fx4jwv3aalxqwmrpymn34l582lnehr3eqwuz9e',
         totalValue: '3230396',
@@ -304,6 +325,7 @@ it('should be able to parse an ibc receive tx', async () => {
       ibcDestination: 'cosmos1fx4jwv3aalxqwmrpymn34l582lnehr3eqwuz9e',
       ibcSource: 'osmo1fx4jwv3aalxqwmrpymn34l582lnehr3eg40jnt',
       caip19: 'cosmos:cosmoshub-4/slip44:118',
+      assetId: 'cosmos:cosmoshub-4/slip44:118',
       value: '3230396',
     },
   }

--- a/node/packages/client/src/cosmos/parser/index.ts
+++ b/node/packages/client/src/cosmos/parser/index.ts
@@ -30,6 +30,7 @@ export class TransactionParser {
       blockHeight: tx.blockHeight ?? -1,
       blockTime: tx.timestamp ?? Math.floor(Date.now() / 1000),
       caip2: this.chainId,
+      chainId: this.chainId,
       confirmations: tx.confirmations,
       status: tx.confirmations > 0 ? Status.Confirmed : Status.Pending, // TODO: handle failed case
       transfers: [],
@@ -48,6 +49,7 @@ export class TransactionParser {
           {
             type: from === address ? TransferType.Send : TransferType.Receive,
             caip19: this.assetId,
+            assetId: this.assetId,
             from,
             to,
             totalValue: value.toString(10),
@@ -62,7 +64,7 @@ export class TransactionParser {
       // network fee
       const fees = new BigNumber(tx.fee.amount)
       if (fees.gt(0)) {
-        parsedTx.fee = { caip19: this.assetId, value: fees.toString(10) }
+        parsedTx.fee = { caip19: this.assetId, assetId: this.assetId, value: fees.toString(10) }
       }
     }
 

--- a/node/packages/client/src/cosmos/parser/utils.ts
+++ b/node/packages/client/src/cosmos/parser/utils.ts
@@ -11,10 +11,10 @@ const logger = new Logger({
 export const valuesFromMsgEvents = (
   msg: Message,
   events: { [key: string]: Event[] },
-  caip19: string
+  assetId: string
 ): { from: string; to: string; value: BigNumber; data: TxMetadata | undefined; origin: string } => {
   const virtualMsg = virtualMessageFromEvents(msg, events)
-  const data = metaData(virtualMsg, caip19)
+  const data = metaData(virtualMsg, assetId)
   const from = virtualMsg?.from ?? ''
   const to = virtualMsg?.to ?? ''
   const origin = virtualMsg?.origin ?? ''
@@ -22,7 +22,7 @@ export const valuesFromMsgEvents = (
   return { from, to, value, data, origin }
 }
 
-const metaData = (msg: Message | undefined, caip19: string): TxMetadata | undefined => {
+const metaData = (msg: Message | undefined, assetId: string): TxMetadata | undefined => {
   if (!msg) return
   switch (msg.type) {
     case 'delegate':
@@ -42,7 +42,8 @@ const metaData = (msg: Message | undefined, caip19: string): TxMetadata | undefi
         delegator: msg.origin,
         destinationValidator: msg.to,
         value: msg?.value?.amount,
-        caip19: caip19,
+        caip19: assetId,
+        assetId: assetId,
       }
     case 'withdraw_delegator_reward':
       return {
@@ -50,7 +51,8 @@ const metaData = (msg: Message | undefined, caip19: string): TxMetadata | undefi
         method: msg.type,
         destinationValidator: msg.to,
         value: msg?.value?.amount,
-        caip19: caip19,
+        caip19: assetId,
+        assetId: assetId,
       }
     case 'ibc_send':
     case 'ibc_receive':
@@ -59,7 +61,8 @@ const metaData = (msg: Message | undefined, caip19: string): TxMetadata | undefi
         method: msg.type,
         ibcDestination: msg.to,
         ibcSource: msg.from,
-        caip19: caip19,
+        caip19: assetId,
+        assetId: assetId,
         value: msg?.value?.amount,
       }
     // known message types with no applicable metadata

--- a/node/packages/client/src/cosmos/types.ts
+++ b/node/packages/client/src/cosmos/types.ts
@@ -5,7 +5,11 @@ export interface TxMetadata extends Omit<StandardTxMetadata, 'parser'> {
   delegator?: string
   sourceValidator?: string
   destinationValidator?: string
+  /**
+   * @deprecated use 'assetId' instead
+   */
   caip19?: string
+  assetId?: string
   value?: string
   ibcDestination?: string
   ibcSource?: string

--- a/node/packages/client/src/ethereum/parser/__tests__/ethereum.test.ts
+++ b/node/packages/client/src/ethereum/parser/__tests__/ethereum.test.ts
@@ -52,6 +52,7 @@ describe('parseTx', () => {
 
       const standardTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [{ value: '1201235000000000000' }],
         from: '0x79fE68B3e4Bc2B91a4C8dfFb5317C7B8813d8Ae7',
         to: '0x76DA1578aC163CA7ca4143B7dEAa428e85Db3042',
@@ -67,6 +68,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
@@ -90,6 +92,7 @@ describe('parseTx', () => {
       }
       const sellTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [{ value: '295040000000000000' }],
         from: '0xCeb660E7623E8f8312B3379Df747c35f2217b595',
         to: '0xC145990E84155416144C532E31f89B840Ca8c2cE',
@@ -104,6 +107,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'deposit',
@@ -112,6 +116,7 @@ describe('parseTx', () => {
         status: Status.Confirmed,
         fee: {
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
           value: '1700235000000000',
         },
         transfers: [sellTransfer],
@@ -133,6 +138,7 @@ describe('parseTx', () => {
       }
       const sellTransfer = {
         caip19: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         components: [{ value: '16598881497' }],
         from: '0x5a8C5afbCC1A58cCbe17542957b587F46828B38E',
         to: '0xC145990E84155416144C532E31f89B840Ca8c2cE',
@@ -148,6 +154,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'deposit',
@@ -156,6 +163,7 @@ describe('parseTx', () => {
         status: Status.Confirmed,
         fee: {
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
           value: '4700280000000000',
         },
         transfers: [sellTransfer],
@@ -177,6 +185,7 @@ describe('parseTx', () => {
       }
       const buyTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [{ value: '1579727090000000000' }],
         from: '0xC145990E84155416144C532E31f89B840Ca8c2cE',
         to: '0x5a8C5afbCC1A58cCbe17542957b587F46828B38E',
@@ -192,6 +201,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'transferOut',
@@ -217,6 +227,7 @@ describe('parseTx', () => {
       }
       const buyTransfer = {
         caip19: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         components: [{ value: '47596471640' }],
         from: '0xC145990E84155416144C532E31f89B840Ca8c2cE',
         to: '0x5a8C5afbCC1A58cCbe17542957b587F46828B38E',
@@ -232,6 +243,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'transferOut',
@@ -257,6 +269,7 @@ describe('parseTx', () => {
       }
       const buyTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [{ value: '6412730000000000' }],
         from: '0xC145990E84155416144C532E31f89B840Ca8c2cE',
         to: '0xfc0Cc6E85dFf3D75e3985e0CB83B090cfD498dd1',
@@ -272,6 +285,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'transferOut',
@@ -298,6 +312,7 @@ describe('parseTx', () => {
       }
       const buyTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [
           {
             value: '541566754246167133',
@@ -312,6 +327,7 @@ describe('parseTx', () => {
 
       const sellTransfer = {
         caip19: 'eip155:1/erc20:0xc7283b66eb1eb5fb86327f08e1b5816b0720212b',
+        assetId: 'eip155:1/erc20:0xc7283b66eb1eb5fb86327f08e1b5816b0720212b',
         components: [
           {
             value: '1000000000000000000000',
@@ -331,6 +347,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: undefined,
@@ -340,6 +357,7 @@ describe('parseTx', () => {
         fee: {
           value: '8308480000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [sellTransfer, buyTransfer],
         trade,
@@ -360,6 +378,7 @@ describe('parseTx', () => {
 
       const buyTransfer = {
         caip19: 'eip155:1/erc20:0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
+        assetId: 'eip155:1/erc20:0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
         components: [
           {
             value: '50000000000000000000000',
@@ -374,6 +393,7 @@ describe('parseTx', () => {
 
       const sellTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [
           {
             value: '10000000000000000000',
@@ -393,6 +413,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: undefined,
@@ -402,6 +423,7 @@ describe('parseTx', () => {
         fee: {
           value: '19815285000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [sellTransfer, buyTransfer],
         trade,
@@ -425,6 +447,7 @@ describe('parseTx', () => {
         from: '0xF82d8Ec196Fb0D56c6B82a8B1870F09502A49F88',
         to: '0xb8b19c048296E086DaF69F54d48dE2Da444dB047',
         caip19: 'eip155:1/erc20:0xa2b4c0af19cc16a6cfacce81f192b024d625817d',
+        assetId: 'eip155:1/erc20:0xa2b4c0af19cc16a6cfacce81f192b024d625817d',
         totalValue: '9248567698016204727450',
         components: [{ value: '9248567698016204727450' }],
         token: kishuToken,
@@ -435,6 +458,7 @@ describe('parseTx', () => {
         from: '0xb8b19c048296E086DaF69F54d48dE2Da444dB047',
         to: '0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852',
         caip19: 'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7',
+        assetId: 'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7',
         totalValue: '45000000000',
         components: [{ value: '45000000000' }],
         token: usdtToken,
@@ -447,6 +471,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: undefined,
@@ -456,6 +481,7 @@ describe('parseTx', () => {
         fee: {
           value: '78183644000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [sellTransfer, buyTransfer],
         trade,
@@ -479,6 +505,7 @@ describe('parseTx', () => {
         from: '0xEBFb684dD2b01E698ca6c14F10e4f289934a54D6',
         to: address,
         caip19: 'eip155:1/erc20:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        assetId: 'eip155:1/erc20:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
         totalValue: '56639587020747520629',
         components: [{ value: '56639587020747520629' }],
         token: uniToken,
@@ -489,6 +516,7 @@ describe('parseTx', () => {
         from: '0xd3d2E2692501A5c9Ca623199D38826e513033a17',
         to: address,
         caip19: 'eip155:1/erc20:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        assetId: 'eip155:1/erc20:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
         totalValue: '47448670568188553620',
         components: [{ value: '47448670568188553620' }],
         token: uniToken,
@@ -499,6 +527,7 @@ describe('parseTx', () => {
         from: address,
         to: '0x6591c4BcD6D7A1eb4E537DA8B78676C1576Ba244',
         caip19: 'eip155:1/erc20:0x0391d2021f89dc339f60fff84546ea23e337750f',
+        assetId: 'eip155:1/erc20:0x0391d2021f89dc339f60fff84546ea23e337750f',
         totalValue: '53910224825217010944',
         components: [{ value: '53910224825217010944' }],
         token: bondToken,
@@ -509,6 +538,7 @@ describe('parseTx', () => {
         from: address,
         to: '0xB17B1342579e4bcE6B6e9A426092EA57d33843D9',
         caip19: 'eip155:1/erc20:0x0391d2021f89dc339f60fff84546ea23e337750f',
+        assetId: 'eip155:1/erc20:0x0391d2021f89dc339f60fff84546ea23e337750f',
         totalValue: '46089775174782989056',
         components: [{ value: '46089775174782989056' }],
         token: bondToken,
@@ -521,6 +551,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: undefined,
@@ -530,6 +561,7 @@ describe('parseTx', () => {
         fee: {
           value: '18399681000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [sellTransfer1, buyTransfer1, sellTransfer2, buyTransfer2],
         trade,
@@ -552,6 +584,7 @@ describe('parseTx', () => {
         blockTime: txMempool.blockTime,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: txMempool.confirmations,
         data: undefined,
         status: Status.Pending,
@@ -561,6 +594,7 @@ describe('parseTx', () => {
             to: address,
             from: address,
             caip19: 'eip155:1/slip44:60',
+            assetId: 'eip155:1/slip44:60',
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -569,6 +603,7 @@ describe('parseTx', () => {
             to: address,
             from: address,
             caip19: 'eip155:1/slip44:60',
+            assetId: 'eip155:1/slip44:60',
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -591,12 +626,14 @@ describe('parseTx', () => {
         blockTime: tx.blockTime,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
         fee: {
           value: '399000000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -604,6 +641,7 @@ describe('parseTx', () => {
             from: address,
             to: address,
             caip19: 'eip155:1/slip44:60',
+            assetId: 'eip155:1/slip44:60',
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -612,6 +650,7 @@ describe('parseTx', () => {
             from: address,
             to: address,
             caip19: 'eip155:1/slip44:60',
+            assetId: 'eip155:1/slip44:60',
             totalValue: '503100000000000',
             components: [{ value: '503100000000000' }],
           },
@@ -633,6 +672,7 @@ describe('parseTx', () => {
         blockTime: txMempool.blockTime,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: txMempool.confirmations,
         data: undefined,
         status: Status.Pending,
@@ -642,6 +682,7 @@ describe('parseTx', () => {
             from: address,
             to: address,
             caip19: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             totalValue: '1502080',
             components: [{ value: '1502080' }],
             token: usdcToken,
@@ -651,6 +692,7 @@ describe('parseTx', () => {
             from: address,
             to: address,
             caip19: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             totalValue: '1502080',
             components: [{ value: '1502080' }],
             token: usdcToken,
@@ -674,12 +716,14 @@ describe('parseTx', () => {
         blockTime: tx.blockTime,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
         fee: {
           value: '1011738000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -687,6 +731,7 @@ describe('parseTx', () => {
             from: address,
             to: address,
             caip19: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             totalValue: '1502080',
             components: [{ value: '1502080' }],
             token: usdcToken,
@@ -696,6 +741,7 @@ describe('parseTx', () => {
             from: address,
             to: address,
             caip19: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             totalValue: '1502080',
             components: [{ value: '1502080' }],
             token: usdcToken,
@@ -721,12 +767,14 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
         fee: {
           value: '1447243200000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [],
       }
@@ -746,6 +794,7 @@ describe('parseTx', () => {
         blockTime: txMempool.blockTime,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: txMempool.confirmations,
         data: {
           method: 'addLiquidityETH',
@@ -758,6 +807,7 @@ describe('parseTx', () => {
             from: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             to: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
             caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+            assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
             totalValue: '100000000000000000000',
             components: [{ value: '100000000000000000000' }],
             token: {
@@ -772,6 +822,7 @@ describe('parseTx', () => {
             from: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             to: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
             caip19: 'eip155:1/slip44:60',
+            assetId: 'eip155:1/slip44:60',
             totalValue: '42673718176645189',
             components: [{ value: '42673718176645189' }],
           },
@@ -794,12 +845,14 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
         fee: {
           value: '26926494400000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -807,6 +860,7 @@ describe('parseTx', () => {
             from: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             to: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
             caip19: 'eip155:1/slip44:60',
+            assetId: 'eip155:1/slip44:60',
             totalValue: '42673718176645189',
             components: [{ value: '42673718176645189' }],
           },
@@ -815,6 +869,7 @@ describe('parseTx', () => {
             from: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             to: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
             caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+            assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
             totalValue: '100000000000000000000',
             components: [{ value: '100000000000000000000' }],
             token: foxToken,
@@ -824,6 +879,7 @@ describe('parseTx', () => {
             from: '0x0000000000000000000000000000000000000000',
             to: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             caip19: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
+            assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
             totalValue: '1888842410762840601',
             components: [{ value: '1888842410762840601' }],
             token: uniV2Token,
@@ -846,6 +902,7 @@ describe('parseTx', () => {
         blockTime: txMempool.blockTime,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: txMempool.confirmations,
         data: {
           method: 'removeLiquidityETH',
@@ -858,6 +915,7 @@ describe('parseTx', () => {
             from: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             to: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
             caip19: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
+            assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
             totalValue: '298717642142382954',
             components: [{ value: '298717642142382954' }],
             token: uniV2Token,
@@ -881,12 +939,14 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
         fee: {
           value: '4082585000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -894,6 +954,7 @@ describe('parseTx', () => {
             from: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             to: '0x470e8de2eBaef52014A47Cb5E6aF86884947F08c',
             caip19: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
+            assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
             totalValue: '298717642142382954',
             components: [{ value: '298717642142382954' }],
             token: uniV2Token,
@@ -903,6 +964,7 @@ describe('parseTx', () => {
             from: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
             to: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+            assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
             totalValue: '15785079906515930982',
             components: [{ value: '15785079906515930982' }],
             token: foxToken,
@@ -912,6 +974,7 @@ describe('parseTx', () => {
             from: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
             to: '0x6bF198c2B5c8E48Af4e876bc2173175b89b1DA0C',
             caip19: 'eip155:1/slip44:60',
+            assetId: 'eip155:1/slip44:60',
             totalValue: '6761476182340434',
             components: [{ value: '6761476182340434' }],
           },
@@ -936,12 +999,14 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
         fee: {
           value: '2559843000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -949,6 +1014,7 @@ describe('parseTx', () => {
             from: '0x02FfdC5bfAbe5c66BE067ff79231585082CA5fe2',
             to: address,
             caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+            assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
             totalValue: '1500000000000000000000',
             components: [{ value: '1500000000000000000000' }],
             token: foxToken,
@@ -972,6 +1038,7 @@ describe('parseTx', () => {
         blockTime: txMempool.blockTime,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: txMempool.confirmations,
         data: undefined,
         status: Status.Pending,
@@ -994,12 +1061,14 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
         fee: {
           value: '4650509500000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -1007,6 +1076,7 @@ describe('parseTx', () => {
             from: address,
             to: '0xDd80E21669A664Bce83E3AD9a0d74f8Dad5D9E72',
             caip19: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
+            assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
             totalValue: '99572547380794318',
             components: [{ value: '99572547380794318' }],
             token: uniV2Token,
@@ -1029,6 +1099,7 @@ describe('parseTx', () => {
         blockTime: txMempool.blockTime,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: txMempool.confirmations,
         data: undefined,
         status: Status.Pending,
@@ -1051,12 +1122,14 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: undefined,
         status: Status.Confirmed,
         fee: {
           value: '6136186875000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -1064,6 +1137,7 @@ describe('parseTx', () => {
             from: '0xDd80E21669A664Bce83E3AD9a0d74f8Dad5D9E72',
             to: address,
             caip19: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
+            assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
             totalValue: '531053586030903030',
             components: [{ value: '531053586030903030' }],
             token: uniV2Token,
@@ -1073,6 +1147,7 @@ describe('parseTx', () => {
             from: '0xDd80E21669A664Bce83E3AD9a0d74f8Dad5D9E72',
             to: address,
             caip19: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+            assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
             totalValue: '317669338073988',
             components: [{ value: '317669338073988' }],
             token: foxToken,
@@ -1098,6 +1173,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'approve',
@@ -1107,6 +1183,7 @@ describe('parseTx', () => {
         fee: {
           value: '4519526097650998',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [],
       }
@@ -1126,6 +1203,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'deposit',
@@ -1135,6 +1213,7 @@ describe('parseTx', () => {
         fee: {
           value: '18139009291874667',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -1142,6 +1221,7 @@ describe('parseTx', () => {
             from: address,
             to: SHAPE_SHIFT_ROUTER_CONTRACT,
             caip19: 'eip155:1/erc20:0x514910771af9ca656af840dff83e8264ecf986ca',
+            assetId: 'eip155:1/erc20:0x514910771af9ca656af840dff83e8264ecf986ca',
             totalValue: '999961394864662132',
             components: [{ value: '999961394864662132' }],
             token: linkToken,
@@ -1151,6 +1231,7 @@ describe('parseTx', () => {
             from: '0x0000000000000000000000000000000000000000',
             to: address,
             caip19: 'eip155:1/erc20:0x671a912c10bba0cfa74cfc2d6fba9ba1ed9530b2',
+            assetId: 'eip155:1/erc20:0x671a912c10bba0cfa74cfc2d6fba9ba1ed9530b2',
             totalValue: '987002304279657611',
             components: [{ value: '987002304279657611' }],
             token: linkYearnVault,
@@ -1173,6 +1254,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'withdraw',
@@ -1182,6 +1264,7 @@ describe('parseTx', () => {
         fee: {
           value: '19460274119661600',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -1189,6 +1272,7 @@ describe('parseTx', () => {
             from: address,
             to: '0x0000000000000000000000000000000000000000',
             caip19: 'eip155:1/erc20:0x671a912c10bba0cfa74cfc2d6fba9ba1ed9530b2',
+            assetId: 'eip155:1/erc20:0x671a912c10bba0cfa74cfc2d6fba9ba1ed9530b2',
             totalValue: '493501152139828806',
             components: [{ value: '493501152139828806' }],
             token: linkYearnVault,
@@ -1198,6 +1282,7 @@ describe('parseTx', () => {
             from: '0x671a912C10bba0CFA74Cfc2d6Fba9BA1ed9530B2',
             to: address,
             caip19: 'eip155:1/erc20:0x514910771af9ca656af840dff83e8264ecf986ca',
+            assetId: 'eip155:1/erc20:0x514910771af9ca656af840dff83e8264ecf986ca',
             totalValue: '500482168225493862',
             components: [{ value: '500482168225493862' }],
             token: linkToken,
@@ -1220,6 +1305,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'deposit',
@@ -1229,6 +1315,7 @@ describe('parseTx', () => {
         fee: {
           value: '9099683709794574',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         transfers: [
           {
@@ -1236,6 +1323,7 @@ describe('parseTx', () => {
             to: address,
             from: '0x0000000000000000000000000000000000000000',
             caip19: 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9',
+            assetId: 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9',
             totalValue: '9178352',
             components: [{ value: '9178352' }],
             token: yvUsdcToken,
@@ -1245,6 +1333,7 @@ describe('parseTx', () => {
             to: '0x5f18C75AbDAe578b483E5F43f12a39cF75b973a9',
             from: address,
             caip19: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             totalValue: '10000000',
             components: [{ value: '10000000' }],
             token: usdcToken,
@@ -1265,6 +1354,7 @@ describe('parseTx', () => {
 
       const standardTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [{ value: '30000000000000000' }],
         from: address,
         to: contractAddress,
@@ -1280,6 +1370,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'deposit',
@@ -1289,6 +1380,7 @@ describe('parseTx', () => {
         fee: {
           value: '2161335000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         trade: undefined,
         transfers: [
@@ -1297,6 +1389,7 @@ describe('parseTx', () => {
             to: address,
             from: contractAddress,
             caip19: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            assetId: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
             totalValue: '30000000000000000',
             components: [{ value: '30000000000000000' }],
             token: {
@@ -1322,6 +1415,7 @@ describe('parseTx', () => {
 
       const standardTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [{ value: '3264000000000000' }],
         from: address,
         to: contractAddress,
@@ -1337,6 +1431,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'deposit',
@@ -1346,6 +1441,7 @@ describe('parseTx', () => {
         fee: {
           value: '1087028000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         trade: undefined,
         transfers: [
@@ -1354,6 +1450,7 @@ describe('parseTx', () => {
             to: address,
             from: contractAddress,
             caip19: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            assetId: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
             totalValue: '3264000000000000',
             components: [{ value: '3264000000000000' }],
             token: {
@@ -1379,6 +1476,7 @@ describe('parseTx', () => {
 
       const internalTransfer = {
         caip19: 'eip155:1/slip44:60',
+        assetId: 'eip155:1/slip44:60',
         components: [{ value: '100000000000000000' }],
         from: contractAddress,
         to: address,
@@ -1394,6 +1492,7 @@ describe('parseTx', () => {
         blockHash: tx.blockHash,
         address: address,
         caip2: 'eip155:1',
+        chainId: 'eip155:1',
         confirmations: tx.confirmations,
         data: {
           method: 'withdraw',
@@ -1403,6 +1502,7 @@ describe('parseTx', () => {
         fee: {
           value: '1482223000000000',
           caip19: 'eip155:1/slip44:60',
+          assetId: 'eip155:1/slip44:60',
         },
         trade: undefined,
         transfers: [
@@ -1411,6 +1511,7 @@ describe('parseTx', () => {
             to: contractAddress,
             from: address,
             caip19: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            assetId: 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
             totalValue: '100000000000000000',
             components: [{ value: '100000000000000000' }],
             token: {

--- a/node/packages/client/src/ethereum/parser/index.ts
+++ b/node/packages/client/src/ethereum/parser/index.ts
@@ -70,6 +70,7 @@ export class TransactionParser {
       blockHeight: tx.blockHeight,
       blockTime: tx.blockTime,
       caip2: caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) }),
+      chainId: caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: toNetworkType(this.network) }),
       confirmations: tx.confirmations,
       status: TransactionParser.getStatus(tx),
       trade: contractParserResult?.trade,
@@ -123,7 +124,7 @@ export class TransactionParser {
       // network fee
       const fees = new BigNumber(tx.fees ?? 0)
       if (fees.gt(0)) {
-        parsedTx.fee = { caip19: caip19Ethereum, value: fees.toString(10) }
+        parsedTx.fee = { caip19: caip19Ethereum, assetId: caip19Ethereum, value: fees.toString(10) }
       }
     }
 

--- a/node/packages/client/src/ethereum/parser/uniV2.ts
+++ b/node/packages/client/src/ethereum/parser/uniV2.ts
@@ -87,6 +87,12 @@ export class Parser implements SubParser {
               assetNamespace: AssetNamespace.ERC20,
               assetReference: tokenAddress,
             }),
+            assetId: caip19.toCAIP19({
+              chain: ChainTypes.Ethereum,
+              network: toNetworkType(this.network),
+              assetNamespace: AssetNamespace.ERC20,
+              assetReference: tokenAddress,
+            }),
             totalValue: value,
             components: [{ value }],
             token: { contract: tokenAddress, decimals, name, symbol },
@@ -110,6 +116,12 @@ export class Parser implements SubParser {
             from: sendAddress,
             to: lpTokenAddress,
             caip19: caip19.toCAIP19({
+              chain: ChainTypes.Ethereum,
+              network: toNetworkType(this.network),
+              assetNamespace: AssetNamespace.ERC20,
+              assetReference: lpTokenAddress,
+            }),
+            assetId: caip19.toCAIP19({
               chain: ChainTypes.Ethereum,
               network: toNetworkType(this.network),
               assetNamespace: AssetNamespace.ERC20,

--- a/node/packages/client/src/ethereum/parser/weth.ts
+++ b/node/packages/client/src/ethereum/parser/weth.ts
@@ -65,6 +65,12 @@ export class Parser implements SubParser {
                 assetNamespace: AssetNamespace.ERC20,
                 assetReference: this.wethContract,
               }),
+              assetId: caip19.toCAIP19({
+                chain: ChainTypes.Ethereum,
+                network: toNetworkType(this.network),
+                assetNamespace: AssetNamespace.ERC20,
+                assetReference: this.wethContract,
+              }),
               totalValue: value,
               components: [{ value }],
               token: {
@@ -86,6 +92,12 @@ export class Parser implements SubParser {
               from: sendAddress,
               to: this.wethContract,
               caip19: caip19.toCAIP19({
+                chain: ChainTypes.Ethereum,
+                network: toNetworkType(this.network),
+                assetNamespace: AssetNamespace.ERC20,
+                assetReference: this.wethContract,
+              }),
+              assetId: caip19.toCAIP19({
                 chain: ChainTypes.Ethereum,
                 network: toNetworkType(this.network),
                 assetNamespace: AssetNamespace.ERC20,

--- a/node/packages/client/src/types.ts
+++ b/node/packages/client/src/types.ts
@@ -4,7 +4,11 @@ export enum Dex {
 }
 
 export interface Fee {
+  /**
+   * @deprecated use 'assetId' instead
+   */
   caip19: string
+  assetId: string
   value: string
 }
 
@@ -36,7 +40,11 @@ export enum TradeType {
 export interface Transfer {
   from: string
   to: string
+  /**
+   * @deprecated use 'assetId' instead
+   */
   caip19: string
+  assetId: string
   type: TransferType
   totalValue: string
   components: Array<{ value: string }>
@@ -70,7 +78,11 @@ export interface StandardTx {
   blockHash?: string
   blockHeight: number
   blockTime: number
+  /**
+   * @deprecated use 'chainId' instead
+   */
   caip2: string
+  chainId: string
   confirmations: number
   fee?: Fee
   status: Status

--- a/node/packages/client/src/utils.ts
+++ b/node/packages/client/src/utils.ts
@@ -18,7 +18,7 @@ export async function findAsyncSequential<T, U>(
 export function aggregateTransfer(
   transfers: Array<Transfer>,
   type: TransferType,
-  caip19: string,
+  assetId: string,
   from: string,
   to: string,
   value: string,
@@ -26,7 +26,7 @@ export function aggregateTransfer(
 ): Array<Transfer> {
   if (!new BigNumber(value).gt(0)) return transfers
 
-  const index = transfers?.findIndex((t) => t.type === type && t.caip19 === caip19 && t.from === from && t.to === to)
+  const index = transfers?.findIndex((t) => t.type === type && t.assetId === assetId && t.from === from && t.to === to)
   const transfer = transfers?.[index]
 
   if (transfer) {
@@ -34,7 +34,10 @@ export function aggregateTransfer(
     transfer.components.push({ value: value })
     transfers[index] = transfer
   } else {
-    transfers = [...transfers, { type, caip19, from, to, totalValue: value, components: [{ value: value }], token }]
+    transfers = [
+      ...transfers,
+      { type, caip19: assetId, assetId, from, to, totalValue: value, components: [{ value: value }], token },
+    ]
   }
 
   return transfers


### PR DESCRIPTION
PR 1/4 to make property names in the parser generic.

Adds new types alongside deprecated ones.

Contributes to https://github.com/shapeshift/unchained/issues/398