### PR TITLE
Remove references to unpublished packages

### DIFF
--- a/node/coinstacks/common/api/package.json
+++ b/node/coinstacks/common/api/package.json
@@ -14,10 +14,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@shapeshiftoss/common-ingester": "^6.10.0",
-    "@shapeshiftoss/common-mongo": "^6.10.0",
     "amqp-ts": "^1.8.0",
-    "mongodb": "^3.6.3",
     "tsoa": "^3.4.0",
     "uuid": "^8.3.2",
     "ws": "^8.3.0"
@@ -25,7 +22,6 @@
   "devDependencies": {
     "@types/amqplib": "^0.5.16",
     "@types/express": "^4.17.9",
-    "@types/mongodb": "^3.6.3",
     "@types/uuid": "^8.3.1",
     "@types/ws": "^8.2.1"
   }

--- a/node/coinstacks/common/api/src/websocket.ts
+++ b/node/coinstacks/common/api/src/websocket.ts
@@ -1,12 +1,33 @@
 import WebSocket from 'ws'
 import { v4 } from 'uuid'
 import { Connection, Exchange, Message, Queue } from 'amqp-ts'
-import { RegistryMessage } from '@shapeshiftoss/common-ingester'
 import { Logger } from '@shapeshiftoss/logger'
 
 const BROKER_URI = process.env.BROKER_URI as string
 
 if (!BROKER_URI) throw new Error('BROKER_URI env var not set')
+
+/** TO BE REMOVED WITH REMOVAL OF INGESTER */
+export interface RegistryMessage {
+  action: string
+  client_id: string
+  ingester_meta?: Record<
+    string,
+    {
+      block?: number
+      syncing?: {
+        key?: string
+        startTime: number
+        endTime: number
+      }
+    }
+  >
+  registration: {
+    addresses?: string[]
+    pubkey?: string
+  }
+}
+/** END OF REMOVAL */
 
 export interface RequestPayload {
   subscriptionId: string


### PR DESCRIPTION
- Required to be able to pull out unchained-client package into web
- Will be able to remove the dupe type upon removal of the ingester