### PR TITLE
Add useful error message on failed transaction broadcast

### DIFF
--- a/go/pkg/cosmos/tx.go
+++ b/go/pkg/cosmos/tx.go
@@ -8,6 +8,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
@@ -82,7 +83,8 @@ func (c *HTTPClient) BroadcastTx(rawTx string) (string, error) {
 	}
 
 	if res.TxResponse.Code != 0 {
-		return "", errors.New(res.TxResponse.RawLog)
+		message := fmt.Sprintf("failed to broadcast transaction: codespace: %s, code: %d, description", res.TxResponse.Codespace, res.TxResponse.Code)
+		return "", errortypes.ABCIError(res.TxResponse.Codespace, res.TxResponse.Code, message)
 	}
 
 	return res.TxResponse.TxHash, nil


### PR DESCRIPTION
```
useStakingAction.tsx:89 Cosmos:useStakingAction error:  Error: {"message":"failed to broadcast transaction: codespace: sdk, code: 20, description: mempool is full"}
    at ErrorHandler (ErrorHandler.js:7:1)
    at ChainAdapter.signAndBroadcastTransaction (CosmosChainAdapter.js:419:1)
    at async handleStakingAction (useStakingAction.tsx:83:1)
    at async onSubmit (StakeBroadcast.tsx:64:1)
    at async createFormControl.ts:1044:1
    ```