### PR TITLE
fix: use upgrade header to check for websocket connection

### DIFF
--- a/go/pkg/cosmos/api.go
+++ b/go/pkg/cosmos/api.go
@@ -72,7 +72,7 @@ func (a *API) Shutdown() {
 }
 
 func (a *API) Root(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Scheme == "ws" || r.URL.Scheme == "wss" {
+	if r.Header.Get("Upgrade") == "websocket" {
 		a.Websocket(w, r)
 		return
 	}


### PR DESCRIPTION
for unknown reasons, websocket connection are not handled correctly for taxistake endpoints via cloudflare dns. this is an attempt to check for websocket upgrades in a better way and hopefully clear up the proxy issue :crossed_fingers: 