### PR TITLE
fix: avax config and host match

### DIFF
--- a/node/coinstacks/avalanche/daemon/init.sh
+++ b/node/coinstacks/avalanche/daemon/init.sh
@@ -5,6 +5,8 @@ set -e
 start() {
   /avalanchego/build/avalanchego \
     --data-dir /data \
+    --http-host= \
+    --staking-ephemeral-cert-enabled=true \
     --chain-config-dir=/configs/chains &
   PID="$!"
 }

--- a/node/coinstacks/avalanche/pulumi/index.ts
+++ b/node/coinstacks/avalanche/pulumi/index.ts
@@ -57,7 +57,7 @@ export = async (): Promise<Outputs> => {
         prev[service.name] = createService({
           asset,
           config: service,
-          ports: { 'daemon-rpc': { port: 8332 } },
+          ports: { 'daemon-rpc': { port: 9650 } },
           configMapData: { 'c-chain-config.json': readFileSync('../daemon/config.json').toString() },
           volumeMounts: [
             { name: 'config-map', mountPath: '/configs/chains/C/config.json', subPath: 'c-chain-config.json' },

--- a/pulumi/src/statefulService.ts
+++ b/pulumi/src/statefulService.ts
@@ -275,17 +275,12 @@ export async function deployStatefulService(
 
     const additionalRootDomainName = process.env.ADDITIONAL_ROOT_DOMAIN_NAME
 
-    const additionalDomain = (service: string) => {
-      const baseDomain = `${service}.${asset}.${additionalRootDomainName}`
-      return config.environment ? `${config.environment}-${baseDomain}` : baseDomain
-    }
-
     const match = (service: string, prefix?: string) => {
       const pathPrefixMatch = prefix ? ` && PathPrefix(\`${prefix}\`)` : ''
       const hostMatch = `(Host(\`${domain(`${service}`)}\`)${pathPrefixMatch})`
-      const additionalHostMatch = `(Host(\`${additionalDomain(`${service}`)}\`)${pathPrefixMatch})`
-      const additionalAlphaHostMatch = `(Host(\`alpha-${additionalDomain(`${service}`)}\`)${pathPrefixMatch})`
-      return additionalRootDomainName ? `${hostMatch} || ${additionalHostMatch} || ${additionalAlphaHostMatch}` : hostMatch
+      const additionalHostMatch = `(Host(\`${service}.${asset}.${additionalRootDomainName}\`)${pathPrefixMatch})`
+      const additionalDevHostMatch = `(Host(\`dev-${service}.${asset}.${additionalRootDomainName}\`)${pathPrefixMatch})`
+      return additionalRootDomainName ? `${hostMatch} || ${additionalHostMatch} || ${additionalDevHostMatch}` : hostMatch
     }
 
     const middleware = new k8s.apiextensions.CustomResource(


### PR DESCRIPTION
- open host traffic
- use ephemeral certs for unique NodeID on shared volume snapshots
- fix incorrect port mapping
- allow both prod and dev dns to be directed to either cluster