### PR TITLE
feat: handle osmosis swap_exact_amount_in

### DIFF
--- a/go/coinstacks/osmosis/osmosis.go
+++ b/go/coinstacks/osmosis/osmosis.go
@@ -2,8 +2,11 @@ package osmosis
 
 import (
 	"github.com/pkg/errors"
+	"github.com/shapeshift/unchained/internal/log"
 	"github.com/shapeshift/unchained/pkg/cosmos"
 )
+
+var logger = log.WithoutFields()
 
 type HTTPClient struct {
 	*cosmos.HTTPClient

--- a/go/coinstacks/thorchain/tx.go
+++ b/go/coinstacks/thorchain/tx.go
@@ -13,6 +13,10 @@ import (
 func ParseMessages(msgs []sdk.Msg, events cosmos.EventsByMsgIndex) []cosmos.Message {
 	messages := []cosmos.Message{}
 
+	if _, ok := events["0"]["error"]; ok {
+		return messages
+	}
+
 	coinToValue := func(c common.Coin) cosmos.Value {
 		denom, ok := assetToDenom[c.Asset.String()]
 		if !ok {
@@ -39,11 +43,8 @@ func ParseMessages(msgs []sdk.Msg, events cosmos.EventsByMsgIndex) []cosmos.Mess
 			}
 			messages = append(messages, message)
 		case *thorchaintypes.MsgDeposit:
-			var to string
-			if _, ok := events["0"]["error"]; !ok {
-				events[strconv.Itoa(i)]["message"]["memo"] = v.Memo // add memo value from message to events
-				to = events[strconv.Itoa(i)]["transfer"]["recipient"]
-			}
+			to := events[strconv.Itoa(i)]["transfer"]["recipient"]
+			events[strconv.Itoa(i)]["message"]["memo"] = v.Memo // add memo value from message to events
 
 			message := cosmos.Message{
 				Addresses: []string{v.Signer.String(), to},


### PR DESCRIPTION
- don't create transfer messages for failed transactions (no value transferred)
- create a message for each side of the swap_exact_amount_in event. (log parsing currently does not support handling of multiple values for same attribute key resulting the `NOTE:` logic)