### PR TITLE
feat: prefix q cashaddr with bitcoincash:

### DIFF
--- a/node/coinstacks/avalanche/api/src/app.ts
+++ b/node/coinstacks/avalanche/api/src/app.ts
@@ -8,7 +8,6 @@ import {
   middleware,
   ConnectionHandler,
   Registry,
-  AddressFormatter,
   BlockHandler,
   TransactionHandler,
 } from '@shapeshiftoss/common-api'
@@ -56,8 +55,6 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler)
 app.use(middleware.notFoundHandler)
 
-const addressFormatter: AddressFormatter = (address) => evm.formatAddress(address)
-
 const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
   const txs = await service.handleBlock(block.hash)
   return { txs }
@@ -71,7 +68,7 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
   return { addresses, tx }
 }
 
-const registry = new Registry({ addressFormatter, blockHandler, transactionHandler })
+const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })

--- a/node/coinstacks/bitcoin/api/src/app.ts
+++ b/node/coinstacks/bitcoin/api/src/app.ts
@@ -4,14 +4,7 @@ import { join } from 'path'
 import { Server } from 'ws'
 import swaggerUi from 'swagger-ui-express'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  middleware,
-  ConnectionHandler,
-  Registry,
-  AddressFormatter,
-  BlockHandler,
-  TransactionHandler,
-} from '@shapeshiftoss/common-api'
+import { middleware, ConnectionHandler, Registry, BlockHandler, TransactionHandler } from '@shapeshiftoss/common-api'
 import { getAddresses, NewBlock, Tx as BlockbookTx, WebsocketClient } from '@shapeshiftoss/blockbook'
 import { utxo } from '@shapeshiftoss/common-api'
 import { service, formatAddress } from './controller'
@@ -56,8 +49,6 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler)
 app.use(middleware.notFoundHandler)
 
-const addressFormatter: AddressFormatter = (address) => formatAddress(address)
-
 const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
   const txs = await service.handleBlock(block.hash)
   return { txs }
@@ -69,7 +60,7 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
   return { addresses, tx }
 }
 
-const registry = new Registry({ addressFormatter, blockHandler, transactionHandler })
+const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })

--- a/node/coinstacks/bitcoin/api/src/controller.ts
+++ b/node/coinstacks/bitcoin/api/src/controller.ts
@@ -21,9 +21,7 @@ export const formatAddress = (address: string): string => {
   if (address.startsWith('bitcoin') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc')
     return address.toLowerCase()
 
-  // Slap the prefix in if it isn't present
-  // https://en.bitcoin.it/wiki/BIP_0021#Specification
-  return `bitcoin:${address}`
+  return address
 }
 
 export const service = new Service({ blockbook, rpcUrl: RPC_URL, isXpub })

--- a/node/coinstacks/bitcoin/api/src/controller.ts
+++ b/node/coinstacks/bitcoin/api/src/controller.ts
@@ -18,8 +18,7 @@ const isXpub = (pubkey: string): boolean => {
 }
 
 export const formatAddress = (address: string): string => {
-  if (address.startsWith('bitcoin') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc')
-    return address.toLowerCase()
+  if (bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc') return address.toLowerCase()
 
   return address
 }

--- a/node/coinstacks/bitcoin/api/src/controller.ts
+++ b/node/coinstacks/bitcoin/api/src/controller.ts
@@ -18,8 +18,12 @@ const isXpub = (pubkey: string): boolean => {
 }
 
 export const formatAddress = (address: string): string => {
-  if (bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc') return address.toLowerCase()
-  return address
+  if (address.startsWith('bitcoin') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc')
+    return address.toLowerCase()
+
+  // Slap the prefix in if it isn't present
+  // https://en.bitcoin.it/wiki/BIP_0021#Specification
+  return `bitcoin:${address}`
 }
 
 export const service = new Service({ blockbook, rpcUrl: RPC_URL, isXpub })

--- a/node/coinstacks/bitcoincash/api/src/app.ts
+++ b/node/coinstacks/bitcoincash/api/src/app.ts
@@ -4,14 +4,7 @@ import { join } from 'path'
 import { Server } from 'ws'
 import swaggerUi from 'swagger-ui-express'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  middleware,
-  ConnectionHandler,
-  Registry,
-  AddressFormatter,
-  BlockHandler,
-  TransactionHandler,
-} from '@shapeshiftoss/common-api'
+import { middleware, ConnectionHandler, Registry, BlockHandler, TransactionHandler } from '@shapeshiftoss/common-api'
 import { getAddresses, NewBlock, Tx as BlockbookTx, WebsocketClient } from '@shapeshiftoss/blockbook'
 import { utxo } from '@shapeshiftoss/common-api'
 import { service, formatAddress } from './controller'
@@ -58,8 +51,6 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler)
 app.use(middleware.notFoundHandler)
 
-const addressFormatter: AddressFormatter = (address) => formatAddress(address)
-
 const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
   const txs = await service.handleBlock(block.hash)
   return { txs }
@@ -71,7 +62,7 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
   return { addresses, tx }
 }
 
-const registry = new Registry({ addressFormatter, blockHandler, transactionHandler })
+const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })

--- a/node/coinstacks/bitcoincash/api/src/controller.ts
+++ b/node/coinstacks/bitcoincash/api/src/controller.ts
@@ -18,8 +18,7 @@ const isXpub = (pubkey: string): boolean => {
 }
 
 export const formatAddress = (address: string): string => {
-  if (address.startsWith('bitcoincash') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc')
-    return address.toLowerCase()
+  if (bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc') return address.toLowerCase()
 
   // Slap the prefix in if it isn't present, blockbook only understands prefixed CashAddrs
   // https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#prefix

--- a/node/coinstacks/bitcoincash/api/src/controller.ts
+++ b/node/coinstacks/bitcoincash/api/src/controller.ts
@@ -21,6 +21,8 @@ export const formatAddress = (address: string): string => {
   if (address.startsWith('bitcoincash') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc')
     return address.toLowerCase()
 
+  // Slap the prefix in if it isn't present, blockbook only understands prefixed CashAddrs
+  // https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#prefix
   if (address.startsWith('q')) return `bitcoincash:${address.toLowerCase()}`
 
   return address

--- a/node/coinstacks/bitcoincash/api/src/controller.ts
+++ b/node/coinstacks/bitcoincash/api/src/controller.ts
@@ -18,7 +18,13 @@ const isXpub = (pubkey: string): boolean => {
 }
 
 export const formatAddress = (address: string): string => {
-  if (bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc') return address.toLowerCase()
+  // Bitcoin Cash addresses can actually be prefixed with the network and still be addresses as part of the CashAddr spec
+  // These look just like your regular URIs, prefixed with the network
+  // but are different from `bitcoin:`, `litecoin:` etc prefixed strings, which are actually BIP-21 URIs, see:
+  // Bitcoin BIP21 URIs: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki#abnf-grammar
+  // Bitcoin Cash CashAddr addresses: https://reference.cash/protocol/blockchain/encoding/cashaddr
+  if (address.startsWith('bitcoincash') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc')
+    return address.toLowerCase()
 
   // Slap the prefix in if it isn't present, blockbook only understands prefixed CashAddrs
   // https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#prefix

--- a/node/coinstacks/bitcoincash/api/src/controller.ts
+++ b/node/coinstacks/bitcoincash/api/src/controller.ts
@@ -2,7 +2,6 @@ import { bech32 } from 'bech32'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Service } from '../../../common/api/src/utxo/service'
 import { UTXO } from '../../../common/api/src/utxo/controller'
-import { AddressFormatter } from '@shapeshiftoss/common-api'
 
 const INDEXER_URL = process.env.INDEXER_URL
 const INDEXER_WS_URL = process.env.INDEXER_WS_URL
@@ -27,9 +26,7 @@ export const formatAddress = (address: string): string => {
   return address
 }
 
-const addressFormatter: AddressFormatter = (address) => formatAddress(address)
-
-export const service = new Service({ addressFormatter, blockbook, rpcUrl: RPC_URL, isXpub })
+export const service = new Service({ addressFormatter: formatAddress, blockbook, rpcUrl: RPC_URL, isXpub })
 
 // assign service to be used for all instances of UTXO
 UTXO.service = service

--- a/node/coinstacks/bitcoincash/api/src/controller.ts
+++ b/node/coinstacks/bitcoincash/api/src/controller.ts
@@ -2,6 +2,7 @@ import { bech32 } from 'bech32'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Service } from '../../../common/api/src/utxo/service'
 import { UTXO } from '../../../common/api/src/utxo/controller'
+import { AddressFormatter } from '@shapeshiftoss/common-api'
 
 const INDEXER_URL = process.env.INDEXER_URL
 const INDEXER_WS_URL = process.env.INDEXER_WS_URL
@@ -26,7 +27,9 @@ export const formatAddress = (address: string): string => {
   return address
 }
 
-export const service = new Service({ blockbook, rpcUrl: RPC_URL, isXpub })
+const addressFormatter: AddressFormatter = (address) => formatAddress(address)
+
+export const service = new Service({ addressFormatter, blockbook, rpcUrl: RPC_URL, isXpub })
 
 // assign service to be used for all instances of UTXO
 UTXO.service = service

--- a/node/coinstacks/bitcoincash/api/src/controller.ts
+++ b/node/coinstacks/bitcoincash/api/src/controller.ts
@@ -18,8 +18,11 @@ const isXpub = (pubkey: string): boolean => {
 }
 
 export const formatAddress = (address: string): string => {
-  if (address.startsWith('bitcoincash') || address.startsWith('q')) return address.toLowerCase()
-  if (bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc') return address.toLowerCase()
+  if (address.startsWith('bitcoincash') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'bc')
+    return address.toLowerCase()
+
+  if (address.startsWith('q')) return `bitcoincash:${address.toLowerCase()}`
+
   return address
 }
 

--- a/node/coinstacks/common/api/src/utxo/service.ts
+++ b/node/coinstacks/common/api/src/utxo/service.ts
@@ -23,7 +23,7 @@ export interface ServiceArgs {
   blockbook: Blockbook
   rpcUrl: string
   isXpub: (pubkey: string) => boolean
-  addressFormatter: AddressFormatter
+  addressFormatter?: AddressFormatter
 }
 
 export class Service implements Omit<BaseAPI, 'getInfo'>, API {

--- a/node/coinstacks/common/api/src/utxo/service.ts
+++ b/node/coinstacks/common/api/src/utxo/service.ts
@@ -107,7 +107,8 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
           return this.blockbook.getXpub(pubkey, curCursor.page, pageSize, undefined, undefined, 'txs')
         }
 
-        return this.blockbook.getAddress(pubkey, curCursor.page, pageSize, undefined, undefined, 'txs')
+        const address = this.formatAddress(pubkey)
+        return this.blockbook.getAddress(address, curCursor.page, pageSize, undefined, undefined, 'txs')
       })()
 
       curCursor.page++

--- a/node/coinstacks/ethereum/api/src/app.ts
+++ b/node/coinstacks/ethereum/api/src/app.ts
@@ -8,7 +8,6 @@ import {
   middleware,
   ConnectionHandler,
   Registry,
-  AddressFormatter,
   BlockHandler,
   TransactionHandler,
 } from '@shapeshiftoss/common-api'
@@ -56,8 +55,6 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler)
 app.use(middleware.notFoundHandler)
 
-const addressFormatter: AddressFormatter = (address) => evm.formatAddress(address)
-
 const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
   const txs = await service.handleBlock(block.hash)
   return { txs }
@@ -71,7 +68,7 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
   return { addresses, tx }
 }
 
-const registry = new Registry({ addressFormatter, blockHandler, transactionHandler })
+const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })

--- a/node/coinstacks/litecoin/api/src/app.ts
+++ b/node/coinstacks/litecoin/api/src/app.ts
@@ -4,14 +4,7 @@ import { join } from 'path'
 import { Server } from 'ws'
 import swaggerUi from 'swagger-ui-express'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  middleware,
-  ConnectionHandler,
-  Registry,
-  AddressFormatter,
-  BlockHandler,
-  TransactionHandler,
-} from '@shapeshiftoss/common-api'
+import { middleware, ConnectionHandler, Registry, BlockHandler, TransactionHandler } from '@shapeshiftoss/common-api'
 import { getAddresses, NewBlock, Tx as BlockbookTx, WebsocketClient } from '@shapeshiftoss/blockbook'
 import { utxo } from '@shapeshiftoss/common-api'
 import { service, formatAddress } from './controller'
@@ -58,8 +51,6 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler)
 app.use(middleware.notFoundHandler)
 
-const addressFormatter: AddressFormatter = (address) => formatAddress(address)
-
 const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
   const txs = await service.handleBlock(block.hash)
   return { txs }
@@ -71,7 +62,7 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
   return { addresses, tx }
 }
 
-const registry = new Registry({ addressFormatter, blockHandler, transactionHandler })
+const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })

--- a/node/coinstacks/litecoin/api/src/controller.ts
+++ b/node/coinstacks/litecoin/api/src/controller.ts
@@ -18,8 +18,7 @@ const isXpub = (pubkey: string): boolean => {
 }
 
 export const formatAddress = (address: string): string => {
-  if (address.startsWith('litecoin') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'ltc')
-    return address.toLowerCase()
+  if (bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'ltc') return address.toLowerCase()
 
   return address
 }

--- a/node/coinstacks/litecoin/api/src/controller.ts
+++ b/node/coinstacks/litecoin/api/src/controller.ts
@@ -18,7 +18,9 @@ const isXpub = (pubkey: string): boolean => {
 }
 
 export const formatAddress = (address: string): string => {
-  if (bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'ltc') return address.toLowerCase()
+  if (address.startsWith('litecoin') || bech32.decodeUnsafe(address.toLowerCase())?.prefix === 'ltc')
+    return address.toLowerCase()
+
   return address
 }
 


### PR DESCRIPTION
#### Description

Untested with WS, tested with API endpoints which use the same underlying implementation so we should be 👜.

This PR makes sure we always prefix bitcoincash addresses. Current implementation assumes `bc` or `bitcoincash` prefixes, and simply returns the unparsed address if none of these two prefixes are present, however, blockbook actually requires a prefix.

While at it, also removes the BIP32 / URL Scheme prefix checks for addresses in `formatAddress`. `formatAddress` should take an address as input, if we pass an URL scheme in a method supposed to parse addresses, we have bigger problems. 

#### Issue

- closes https://github.com/shapeshift/unchained/issues/469

#### Screenshots

##### This diff

<img width="325" alt="image" src="https://user-images.githubusercontent.com/17035424/206034627-3b5de3ad-eed6-4940-a8dd-acfda6953921.png">

#### Prod endpoint

<img width="1391" alt="image" src="https://user-images.githubusercontent.com/17035424/206034795-6969f172-4d4c-47ac-9030-a365571fe8c1.png">