### PR TITLE
chore: adds page size validation to all UTXO and EVM coinstacks

### DIFF
--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -8,6 +8,7 @@ import { ApiError, BadRequestError, BaseAPI, RPCRequest, RPCResponse, SendTxBody
 import { Account, API, TokenBalance, Tx, TxHistory, GasFees, InternalTx, GasEstimate } from './models'
 import { Cursor, NodeBlock, CallStack, ExplorerApiResponse, ExplorerInternalTx } from './types'
 import { formatAddress } from './utils'
+import { validatePageSize } from '../utils'
 
 axiosRetry(axios, { retries: 5, retryDelay: axiosRetry.exponentialDelay })
 
@@ -81,7 +82,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   }
 
   async getTxHistory(pubkey: string, cursor?: string, pageSize = 10): Promise<TxHistory> {
-    if (pageSize <= 0) throw new ApiError('Bad Request', 422, 'page size must be greater than 0')
+    validatePageSize(pageSize)
 
     const curCursor = ((): Cursor => {
       try {

--- a/node/coinstacks/common/api/src/utils.ts
+++ b/node/coinstacks/common/api/src/utils.ts
@@ -1,0 +1,14 @@
+import { ApiError } from '.'
+
+const MAX_PAGE_SIZE = 100
+
+/**
+ * Validates page size is greater than 0 and less than or equal to MAX_PAGE_SIZE
+ * @param {number} pageSize
+ * @throws {ApiError} if page size is invalid
+ * @returns {void}
+ */
+export function validatePageSize(pageSize: number): void {
+  if (pageSize <= 0) throw new ApiError('Bad Request', 422, 'page size must be greater than 0')
+  if (pageSize > MAX_PAGE_SIZE) throw new ApiError('Bad Request', 422, `Max allowed page size is ${MAX_PAGE_SIZE}`)
+}

--- a/node/coinstacks/common/api/src/utils.ts
+++ b/node/coinstacks/common/api/src/utils.ts
@@ -2,12 +2,6 @@ import { ApiError } from '.'
 
 const MAX_PAGE_SIZE = 100
 
-/**
- * Validates page size is greater than 0 and less than or equal to MAX_PAGE_SIZE
- * @param {number} pageSize
- * @throws {ApiError} if page size is invalid
- * @returns {void}
- */
 export function validatePageSize(pageSize: number): void {
   if (pageSize <= 0) throw new ApiError('Bad Request', 422, 'page size must be greater than 0')
   if (pageSize > MAX_PAGE_SIZE) throw new ApiError('Bad Request', 422, `Max allowed page size is ${MAX_PAGE_SIZE}`)

--- a/node/coinstacks/common/api/src/utxo/service.ts
+++ b/node/coinstacks/common/api/src/utxo/service.ts
@@ -4,6 +4,7 @@ import { ApiError as BlockbookApiError, Blockbook, Tx as BlockbookTx } from '@sh
 import { AddressFormatter, ApiError, BadRequestError, BaseAPI, Cursor, RPCRequest, RPCResponse, SendTxBody } from '../'
 import { Account, Address, API, NetworkFee, NetworkFees, RawTx, Tx, TxHistory, Utxo } from './models'
 import { NodeBlock } from './types'
+import { validatePageSize } from '../utils'
 
 axiosRetry(axios, { retries: 5, retryDelay: axiosRetry.exponentialDelay })
 
@@ -88,7 +89,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   }
 
   async getTxHistory(pubkey: string, cursor?: string, pageSize = 10): Promise<TxHistory> {
-    if (pageSize <= 0) throw new ApiError('Bad Request', 422, 'page size must be greater than 0')
+    validatePageSize(pageSize)
 
     try {
       const curCursor = ((): Cursor => {


### PR DESCRIPTION
Adds basic validation to page size in UTXO and EVM coinstacks on transaction history endpoints

@kaladinlight - if you prefer to move the MAX_PAGE_SIZE var to somewhere else that could be modified without a code change, let me know. 