### PR TITLE
fix: early return on bad page params for cosmos / osmosis

### DIFF
--- a/go/coinstacks/cosmos/api/api.go
+++ b/go/coinstacks/cosmos/api/api.go
@@ -135,7 +135,10 @@ func New(httpClient *cosmos.HTTPClient, grpcClient *cosmos.GRPCClient, wsClient 
 //	200: Validators
 //	500: InternalServerError
 func (a *API) GetValidators(w http.ResponseWriter, r *http.Request) {
-	cursor, pageSize := a.ValidatePagingParams(w, r, cosmos.DEFAULT_PAGE_SIZE_VALIDATORS, nil)
+	cursor, pageSize, err := a.ValidatePagingParams(w, r, cosmos.DEFAULT_PAGE_SIZE_VALIDATORS, nil)
+	if err != nil {
+		return
+	}
 
 	validators, err := a.handler.GetValidators(cursor, pageSize)
 	if err != nil {
@@ -180,7 +183,10 @@ func (a *API) ValidatorTxHistory(w http.ResponseWriter, r *http.Request) {
 	validatorAddr := mux.Vars(r)["pubkey"]
 
 	maxPageSize := cosmos.MAX_PAGE_SIZE_TX_HISTORY
-	cursor, pageSize := a.ValidatePagingParams(w, r, cosmos.DEFAULT_PAGE_SIZE_TX_HISTORY, &maxPageSize)
+	cursor, pageSize, err := a.ValidatePagingParams(w, r, cosmos.DEFAULT_PAGE_SIZE_TX_HISTORY, &maxPageSize)
+	if err != nil {
+		return
+	}
 
 	txHistory, err := a.handler.GetValidatorTxHistory(validatorAddr, cursor, pageSize)
 	if err != nil {

--- a/go/coinstacks/osmosis/api/api.go
+++ b/go/coinstacks/osmosis/api/api.go
@@ -136,7 +136,10 @@ func New(httpClient *osmosis.HTTPClient, wsClient *cosmos.WSClient, blockService
 //	200: Validators
 //	500: InternalServerError
 func (a *API) GetValidators(w http.ResponseWriter, r *http.Request) {
-	cursor, pageSize := a.ValidatePagingParams(w, r, cosmos.DEFAULT_PAGE_SIZE_VALIDATORS, nil)
+	cursor, pageSize, err := a.ValidatePagingParams(w, r, cosmos.DEFAULT_PAGE_SIZE_VALIDATORS, nil)
+	if err != nil {
+		return
+	}
 
 	validators, err := a.handler.GetValidators(cursor, pageSize)
 	if err != nil {
@@ -181,7 +184,10 @@ func (a *API) ValidatorTxHistory(w http.ResponseWriter, r *http.Request) {
 	validatorAddr := mux.Vars(r)["pubkey"]
 
 	maxPageSize := cosmos.MAX_PAGE_SIZE_TX_HISTORY
-	cursor, pageSize := a.ValidatePagingParams(w, r, cosmos.DEFAULT_PAGE_SIZE_TX_HISTORY, &maxPageSize)
+	cursor, pageSize, err := a.ValidatePagingParams(w, r, cosmos.DEFAULT_PAGE_SIZE_TX_HISTORY, &maxPageSize)
+	if err != nil {
+		return
+	}
 
 	txHistory, err := a.handler.GetValidatorTxHistory(validatorAddr, cursor, pageSize)
 	if err != nil {


### PR DESCRIPTION
Currently while we do validate the page params, if there is an issue, we continue to process the request. Some examples


https://dev-api.cosmos.shapeshift.com/api/v1/account/cosmos156gqf9837u7d4c4678yt3rl4ls9c5vuuxyhkw6/txs?pageSize=0
https://dev-api.cosmos.shapeshift.com/api/v1/account/cosmos156gqf9837u7d4c4678yt3rl4ls9c5vuuxyhkw6/txs?pageSize=101
https://dev-api.cosmos.shapeshift.com/api/v1/account/cosmos156gqf9837u7d4c4678yt3rl4ls9c5vuuxyhkw6/txs?pageSize=200

In all of these cases, the api does return an error, but still also proceeds to process (or attempt to process) the request with the given page size.

This PR fixes that issue with an early return to avoid attempting to process the request for cosmos and osmosis coin stacks.

It also appears this will fix thorchain as well