### PR TITLE
chore: increase eks worker node volume size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,6 +737,7 @@ jobs:
             pulumi config set --path unchained:common.eks.traefik.whitelist[20] $AWS_TAXISTAKE_NAT_ADDRESS_0
             pulumi config set --path unchained:common.eks.traefik.whitelist[21] $AWS_TAXISTAKE_NAT_ADDRESS_1
             pulumi config set --path unchained:common.eks.traefik.whitelist[22] $AWS_TAXISTAKE_NAT_ADDRESS_2
+            pulumi config set --path unchained:common.eks.volumeSize 100
             pulumi config set --path unchained:common.dockerhub.username $DOCKERHUB_USERNAME
             pulumi config set --path unchained:common.dockerhub.password $DOCKERHUB_PASSWORD --plaintext
             pulumi config set --path unchained:common.dockerhub.server docker.io

--- a/pulumi/package.json
+++ b/pulumi/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@pulumi/kubernetes": "3.23.1",
     "@pulumi/pulumi": "3.50.2",
-    "@shapeshiftoss/cluster-launcher": "^0.12.0",
+    "@shapeshiftoss/cluster-launcher": "^0.13.0",
     "@types/folder-hash": "^4.0.1",
     "axios": "^0.27.2",
     "folder-hash": "^4.0.2"

--- a/pulumi/src/cluster/index.ts
+++ b/pulumi/src/cluster/index.ts
@@ -55,6 +55,7 @@ export = async (): Promise<Outputs> => {
     region: config.eks.region,
     rootDomainName: config.rootDomainName,
     traefik: config.eks.traefik,
+    volumeSize: config.eks.volumeSize,
   })
 
   outputs.kubeconfig = cluster.kubeconfig

--- a/pulumi/yarn.lock
+++ b/pulumi/yarn.lock
@@ -376,10 +376,10 @@
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
 
-"@shapeshiftoss/cluster-launcher@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/cluster-launcher/-/cluster-launcher-0.12.0.tgz#b6ead3965dd0cf4c534d31ccc5db77ddea233a07"
-  integrity sha512-sskMUmuK/HiiVxSllVCESLgaBD/0m8sFzEeuXrENqLLUqVunKIEMnGxAgLz9Bqc0zHmag1cvr7aUq/1P9j3x8A==
+"@shapeshiftoss/cluster-launcher@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/cluster-launcher/-/cluster-launcher-0.13.0.tgz#d40cc4c4321211c3c4dd1d19dc3ccd39aa463858"
+  integrity sha512-VDy2zhN0GrXrBjyWOdJPbyDlQwCchc9Dsm4rGVYTrmxlOdme2k+NNKAUSfknkadkUgE1m5kl925BVcGwElp5Ow==
   dependencies:
     "@pulumi/aws" "5.29.1"
     "@pulumi/awsx" "1.0.2"


### PR DESCRIPTION
- with multiple blockbook images for different coin support until upstreamed, we are running out of volume size to pull the images causing pods to roll trying to look for available space. increase node worker volume size to give plenty of room and stabilize image pulls