### PR TITLE
fix: handle 0 decimal tokens

### DIFF
--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -55,13 +55,13 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       const data = await this.blockbook.getAddress(pubkey, undefined, undefined, undefined, undefined, 'tokenBalances')
 
       const tokens = (data.tokens ?? []).reduce<Array<TokenBalance>>((prev, token) => {
-        if (token.balance && token.contract && token.decimals && token.symbol) {
+        if (token.balance && token.contract) {
           prev.push({
             balance: token.balance,
             contract: token.contract,
-            decimals: token.decimals,
+            decimals: token.decimals ?? 0,
             name: token.name,
-            symbol: token.symbol,
+            symbol: token.symbol ?? '',
             type: token.type,
           })
         }


### PR DESCRIPTION
Various ERC20 tokens like [Atari](https://etherscan.io/token/0xdacD69347dE42baBfAEcD09dC88958378780FB62) actually have decimals set to 0 which were being filtered out. This change now returns any tokens that have at minimum, a balance and contract address.

Closes https://github.com/shapeshift/web/issues/3167