### PR TITLE
chore: use master for build and add ws read limit hack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ aliases:
     service-memory-limit-1: 8Gi
     service-storage-size-1: 650Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0
+    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 24Gi
@@ -200,7 +200,7 @@ aliases:
     service-memory-limit-2: 8Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
-    service-image-3: shapeshiftdao/unchained-blockbook:v0.4.0
+    service-image-3: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
     service-cpu-limit-3: "2"
     service-cpu-request-3: "1"
     service-memory-limit-3: 16Gi
@@ -313,7 +313,7 @@ aliases:
     service-memory-limit-1: 12Gi
     service-storage-size-1: 4000Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0
+    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 6Gi
@@ -354,7 +354,7 @@ aliases:
     service-memory-limit-1: 4Gi
     service-storage-size-1: 250Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0
+    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 6Gi
@@ -395,7 +395,7 @@ aliases:
     service-memory-limit-1: 4Gi
     service-storage-size-1: 250Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0
+    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 8Gi
@@ -436,7 +436,7 @@ aliases:
     service-memory-limit-1: 4Gi
     service-storage-size-1: 250Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0
+    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 8Gi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,7 +471,7 @@ aliases:
     api-memory-limit: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: registry.gitlab.com/thorchain/thornode:chaosnet-multichain-1.105.0
+    service-image-1: registry.gitlab.com/thorchain/thornode:chaosnet-multichain-1.106.0
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 8Gi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ aliases:
     service-memory-limit-1: 8Gi
     service-storage-size-1: 650Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
+    service-image-2: shapeshiftdao/unchained-blockbook:a83d073
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 24Gi
@@ -200,7 +200,7 @@ aliases:
     service-memory-limit-2: 8Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
-    service-image-3: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
+    service-image-3: shapeshiftdao/unchained-blockbook:a83d073
     service-cpu-limit-3: "2"
     service-cpu-request-3: "1"
     service-memory-limit-3: 16Gi
@@ -313,7 +313,7 @@ aliases:
     service-memory-limit-1: 12Gi
     service-storage-size-1: 4000Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
+    service-image-2: shapeshiftdao/unchained-blockbook:a83d073
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 6Gi
@@ -354,7 +354,7 @@ aliases:
     service-memory-limit-1: 4Gi
     service-storage-size-1: 250Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
+    service-image-2: shapeshiftdao/unchained-blockbook:a83d073
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 6Gi
@@ -395,7 +395,7 @@ aliases:
     service-memory-limit-1: 4Gi
     service-storage-size-1: 250Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
+    service-image-2: shapeshiftdao/unchained-blockbook:a83d073
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 8Gi
@@ -436,7 +436,7 @@ aliases:
     service-memory-limit-1: 4Gi
     service-storage-size-1: 250Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:v0.4.0-1bcdcc6
+    service-image-2: shapeshiftdao/unchained-blockbook:a83d073
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 8Gi

--- a/node/packages/blockbook/Dockerfile
+++ b/node/packages/blockbook/Dockerfile
@@ -24,7 +24,7 @@ ENV ROCKSDB_PORTABLE=0
 RUN cd /opt && git clone -b $ROCKSDB_VERSION --depth 1 https://github.com/facebook/rocksdb.git
 RUN cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC PORTABLE=$PORTABLE_ROCKSDB make -j 4 static_lib
 
-ENV BLOCKBOOK_VERSION=v0.4.0
+ENV BLOCKBOOK_VERSION=master
 ENV BLOCKBOOK_URL=https://github.com/trezor/blockbook.git
 
 # set up blockbook
@@ -33,6 +33,12 @@ WORKDIR /blockbook
 
 ENV CGO_CFLAGS="-I/opt/rocksdb/include"
 ENV CGO_LDFLAGS="-L/opt/rocksdb -ldl -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd"
+
+# download blockbook dependencies
+RUN go mod download
+
+# hack to increase read limit for go-ethereum websocket client
+RUN sed -i 's/wsMessageSizeLimit\ =\ 15\ \*\ 1024\ \*\ 1024/wsMessageSizeLimit = 50 * 1024 * 1024/g' $GOPATH/pkg/mod/github.com/ethereum/go-ethereum*/rpc/websocket.go 
 
 # build blockbook binary
 RUN go build -ldflags="-s -w -X github.com/trezor/blockbook/common.version=${BLOCKBOOK_VERSION}"

--- a/node/packages/blockbook/Dockerfile
+++ b/node/packages/blockbook/Dockerfile
@@ -24,13 +24,17 @@ ENV ROCKSDB_PORTABLE=0
 RUN cd /opt && git clone -b $ROCKSDB_VERSION --depth 1 https://github.com/facebook/rocksdb.git
 RUN cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC PORTABLE=$PORTABLE_ROCKSDB make -j 4 static_lib
 
-# commit: 1bcdcc6
 ENV BLOCKBOOK_VERSION=master
+ENV BLOCKBOOK_COMMIT=a83d073
 ENV BLOCKBOOK_URL=https://github.com/trezor/blockbook.git
 
 # set up blockbook
 RUN git clone -b $BLOCKBOOK_VERSION --depth 1 $BLOCKBOOK_URL
 WORKDIR /blockbook
+
+# verify matching commit
+RUN echo "HEAD=$(git rev-parse --short HEAD)"
+RUN [ "${BLOCKBOOK_COMMIT}" = $(git rev-parse --short HEAD) ]
 
 ENV CGO_CFLAGS="-I/opt/rocksdb/include"
 ENV CGO_LDFLAGS="-L/opt/rocksdb -ldl -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd"
@@ -38,12 +42,13 @@ ENV CGO_LDFLAGS="-L/opt/rocksdb -ldl -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -
 # download blockbook dependencies
 RUN go mod download
 
-# hack to increase read limit for go-ethereum websocket client
-RUN sed -i 's/wsMessageSizeLimit\ =\ 15\ \*\ 1024\ \*\ 1024/wsMessageSizeLimit = 50 * 1024 * 1024/g' $GOPATH/pkg/mod/github.com/ethereum/go-ethereum*/rpc/websocket.go 
-RUN sed -i 's/wsMessageSizeLimit\ =\ 15\ \*\ 1024\ \*\ 1024/wsMessageSizeLimit = 50 * 1024 * 1024/g' $GOPATH/pkg/mod/github.com/ava-labs/coreth*/rpc/websocket.go 
+# hack to increase read limit for evm websocket clients
+RUN sed -i 's/wsMessageSizeLimit\ =\ 15\ \*\ 1024\ \*\ 1024/wsMessageSizeLimit = 50 * 1024 * 1024/g' $GOPATH/pkg/mod/github.com/ethereum/go-ethereum*/rpc/websocket.go  2>&1 > /dev/null || exit 0
+RUN sed -i 's/wsMessageSizeLimit\ =\ 15\ \*\ 1024\ \*\ 1024/wsMessageSizeLimit = 50 * 1024 * 1024/g' $GOPATH/pkg/mod/github.com/ava-labs/coreth*/rpc/websocket.go  2>&1 > /dev/null || exit 0
+RUN sed -i 's/conn.SetReadLimit\(maxRequestContentLength\)/conn.SetReadLimit(50 * 1024 * 1024)/g' $GOPATH/pkg/mod/github.com/ethereum-optimism/optimism/l2geth*/rpc/websocket.go 2>&1 > /dev/null || exit 0
 
 # build blockbook binary
-RUN go build -ldflags="-s -w -X github.com/trezor/blockbook/common.version=${BLOCKBOOK_VERSION}"
+RUN go build -ldflags="-s -w -X github.com/trezor/blockbook/common.version=${BLOCKBOOK_VERSION} -X github.com/trezor/blockbook/common.gitcommit=${BLOCKBOOK_COMMIT}"
 RUN mv blockbook /bin
 
 # copy in generate config script

--- a/node/packages/blockbook/Dockerfile
+++ b/node/packages/blockbook/Dockerfile
@@ -24,6 +24,7 @@ ENV ROCKSDB_PORTABLE=0
 RUN cd /opt && git clone -b $ROCKSDB_VERSION --depth 1 https://github.com/facebook/rocksdb.git
 RUN cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC PORTABLE=$PORTABLE_ROCKSDB make -j 4 static_lib
 
+# commit: 1bcdcc6
 ENV BLOCKBOOK_VERSION=master
 ENV BLOCKBOOK_URL=https://github.com/trezor/blockbook.git
 
@@ -39,6 +40,7 @@ RUN go mod download
 
 # hack to increase read limit for go-ethereum websocket client
 RUN sed -i 's/wsMessageSizeLimit\ =\ 15\ \*\ 1024\ \*\ 1024/wsMessageSizeLimit = 50 * 1024 * 1024/g' $GOPATH/pkg/mod/github.com/ethereum/go-ethereum*/rpc/websocket.go 
+RUN sed -i 's/wsMessageSizeLimit\ =\ 15\ \*\ 1024\ \*\ 1024/wsMessageSizeLimit = 50 * 1024 * 1024/g' $GOPATH/pkg/mod/github.com/ava-labs/coreth*/rpc/websocket.go 
 
 # build blockbook binary
 RUN go build -ldflags="-s -w -X github.com/trezor/blockbook/common.version=${BLOCKBOOK_VERSION}"


### PR DESCRIPTION
- releases aren't cut often, update branch to master to build from tip
- monkey patch `go-ethereum` module to increase websocket read limit. proposed a less hacky upstream change, but this fixes the issue seen during bsc sync and will wait to hear if martin would like to change or just leave patch.