### PR TITLE
chore: update optimism to blockbook v0.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,7 +530,7 @@ aliases:
     service-memory-limit-2: 2Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
-    service-image-3: shapeshiftdao/unchained-blockbook:evm-3b46e4d
+    service-image-3: shapeshiftdao/unchained-blockbook:optimism-7d3ea9a
     service-cpu-limit-3: "2"
     service-cpu-request-3: "1"
     service-memory-limit-3: 6Gi

--- a/node/coinstacks/avalanche/api/package.json
+++ b/node/coinstacks/avalanche/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/avalanche-api",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "files": [
@@ -12,8 +12,8 @@
     "generate": "tsoa spec-and-routes"
   },
   "dependencies": {
-    "@shapeshiftoss/blockbook": "^8.2.0",
-    "@shapeshiftoss/common-api": "^8.2.0",
+    "@shapeshiftoss/blockbook": "^8.3.0",
+    "@shapeshiftoss/common-api": "^8.3.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "cors": "^2.8.5",
     "ethers": "^5.7.0"

--- a/node/coinstacks/avalanche/pulumi/package.json
+++ b/node/coinstacks/avalanche/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/avalanche-pulumi",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/node/coinstacks/bitcoin/api/package.json
+++ b/node/coinstacks/bitcoin/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/bitcoin-api",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "files": [
@@ -12,8 +12,8 @@
     "generate": "tsoa spec-and-routes"
   },
   "dependencies": {
-    "@shapeshiftoss/blockbook": "^8.2.0",
-    "@shapeshiftoss/common-api": "^8.2.0",
+    "@shapeshiftoss/blockbook": "^8.3.0",
+    "@shapeshiftoss/common-api": "^8.3.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "bech32": "^2.0.0",
     "cors": "^2.8.5"

--- a/node/coinstacks/bitcoin/pulumi/package.json
+++ b/node/coinstacks/bitcoin/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/bitcoin-pulumi",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/node/coinstacks/bitcoincash/api/package.json
+++ b/node/coinstacks/bitcoincash/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/bitcoincash-api",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "files": [
@@ -12,8 +12,8 @@
     "generate": "tsoa spec-and-routes"
   },
   "dependencies": {
-    "@shapeshiftoss/blockbook": "^8.2.0",
-    "@shapeshiftoss/common-api": "^8.2.0",
+    "@shapeshiftoss/blockbook": "^8.3.0",
+    "@shapeshiftoss/common-api": "^8.3.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "bech32": "^2.0.0",
     "cors": "^2.8.5"

--- a/node/coinstacks/bitcoincash/pulumi/package.json
+++ b/node/coinstacks/bitcoincash/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/bitcoincash-pulumi",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/node/coinstacks/common/api/package.json
+++ b/node/coinstacks/common/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/common-api",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "source": "src/index.ts",
@@ -14,7 +14,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@shapeshiftoss/blockbook": "^8.2.0",
+    "@shapeshiftoss/blockbook": "^8.3.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "axios": "^0.27.2",
     "axios-retry": "^3.2.5",

--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -275,7 +275,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       gasPrice: tx.ethereumSpecific.gasPrice.toString(),
       inputData: inputData && inputData !== '0x' && inputData !== '0x0' ? inputData : undefined,
       tokenTransfers: tx.tokenTransfers?.map((tt) => ({
-        contract: 'token' in tt ? tt.token : tt.contract,
+        contract: tt.contract,
         decimals: tt.decimals,
         name: tt.name,
         symbol: tt.symbol,

--- a/node/coinstacks/dogecoin/api/package.json
+++ b/node/coinstacks/dogecoin/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/dogecoin-api",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "files": [
@@ -12,8 +12,8 @@
     "generate": "tsoa spec-and-routes"
   },
   "dependencies": {
-    "@shapeshiftoss/blockbook": "^8.2.0",
-    "@shapeshiftoss/common-api": "^8.2.0",
+    "@shapeshiftoss/blockbook": "^8.3.0",
+    "@shapeshiftoss/common-api": "^8.3.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "bech32": "^2.0.0",
     "cors": "^2.8.5"

--- a/node/coinstacks/dogecoin/pulumi/package.json
+++ b/node/coinstacks/dogecoin/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/dogecoin-pulumi",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/node/coinstacks/ethereum/api/package.json
+++ b/node/coinstacks/ethereum/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/ethereum-api",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "files": [
@@ -12,8 +12,8 @@
     "generate": "tsoa spec-and-routes"
   },
   "dependencies": {
-    "@shapeshiftoss/blockbook": "^8.2.0",
-    "@shapeshiftoss/common-api": "^8.2.0",
+    "@shapeshiftoss/blockbook": "^8.3.0",
+    "@shapeshiftoss/common-api": "^8.3.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "cors": "^2.8.5",
     "ethers": "^5.7.0"

--- a/node/coinstacks/ethereum/pulumi/package.json
+++ b/node/coinstacks/ethereum/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/ethereum-pulumi",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/node/coinstacks/litecoin/api/package.json
+++ b/node/coinstacks/litecoin/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/litecoin-api",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "files": [
@@ -12,8 +12,8 @@
     "generate": "tsoa spec-and-routes"
   },
   "dependencies": {
-    "@shapeshiftoss/blockbook": "^8.2.0",
-    "@shapeshiftoss/common-api": "^8.2.0",
+    "@shapeshiftoss/blockbook": "^8.3.0",
+    "@shapeshiftoss/common-api": "^8.3.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "bech32": "^2.0.0",
     "cors": "^2.8.5"

--- a/node/coinstacks/litecoin/pulumi/package.json
+++ b/node/coinstacks/litecoin/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/litecoin-pulumi",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/node/coinstacks/optimism/api/package.json
+++ b/node/coinstacks/optimism/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/optimism-api",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "files": [
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@eth-optimism/contracts": "^0.5.40",
-    "@shapeshiftoss/blockbook": "^8.2.0",
-    "@shapeshiftoss/common-api": "^8.2.0",
+    "@shapeshiftoss/blockbook": "^8.3.0",
+    "@shapeshiftoss/common-api": "^8.3.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "bignumber.js": "^9.1.1",
     "cors": "^2.8.5",

--- a/node/coinstacks/optimism/indexer/config.json
+++ b/node/coinstacks/optimism/indexer/config.json
@@ -1,6 +1,7 @@
 {
   "fiat_rates": "coingecko",
-  "fiat_rates_params": "{\"url\": \"https://api.coingecko.com/api/v3\", \"coin\": \"ethereum\", \"periodSeconds\": 60}",
+  "fiat_rates_vs_currencies": "AED,ARS,AUD,BDT,BHD,BMD,BRL,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,HUF,IDR,ILS,INR,JPY,KRW,KWD,LKR,MMK,MXN,MYR,NGN,NOK,NZD,PHP,PKR,PLN,RUB,SAR,SEK,SGD,THB,TRY,TWD,UAH,USD,VEF,VND,ZAR,BTC,ETH",
+  "fiat_rates_params": "{\"url\": \"https://api.coingecko.com/api/v3\", \"coin\": \"ethereum\",\"platformIdentifier\": \"ethereum\",\"platformVsCurrency \": \"eth\",\"periodSeconds\": 900}",
   "mempoolTxTimeoutHours": 24,
   "queryBackendOnMempoolResync": false,
   "coin_name": "Optimism",

--- a/node/coinstacks/optimism/pulumi/package.json
+++ b/node/coinstacks/optimism/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/optimism-pulumi",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/node/lerna.json
+++ b/node/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.2.0",
+  "version": "8.3.0",
   "npmClient": "yarn",
   "command": {
     "publish": {

--- a/node/packages/blockbook/package.json
+++ b/node/packages/blockbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/blockbook",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/node/packages/blockbook/src/controller.ts
+++ b/node/packages/blockbook/src/controller.ts
@@ -215,7 +215,7 @@ export class Blockbook extends Controller {
         type: 'ERC20',
         from: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
         to: '0xa64D0b5ccFdaB0e4D8Ec7C65862Aac1c78A5666c',
-        token: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+        contract: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
         name: 'Tether USD',
         symbol: 'USDT',
         decimals: 6,

--- a/node/packages/blockbook/src/models.ts
+++ b/node/packages/blockbook/src/models.ts
@@ -183,30 +183,17 @@ export interface Token {
 }
 
 /**
- * Contains info about a token transfer done in a transaction
+ * Contains info about a token transfer in a transaction
  */
 export interface TokenTransfer {
   type: string
   from: string
   to: string
+  contract: string
   name: string
   symbol: string
   decimals: number
   value: string
-}
-
-/**
- * Contains info about a token transfer with legacy `token` key for contract address
- */
-export interface TokenTransferWithToken extends TokenTransfer {
-  token: string
-}
-
-/**
- * Contains info about a token transfer with new `contract` key for contract address
- */
-export interface TokenTransferWithContract extends TokenTransfer {
-  contract: string
 }
 
 /**
@@ -228,7 +215,7 @@ export interface Tx {
   fees?: string
   hex?: string
   rbf?: boolean
-  tokenTransfers?: Array<TokenTransferWithToken | TokenTransferWithContract>
+  tokenTransfers?: Array<TokenTransfer>
   coinSpecificData?: unknown
   ethereumSpecific?: EthereumSpecific
 }

--- a/node/packages/blockbook/src/swagger.json
+++ b/node/packages/blockbook/src/swagger.json
@@ -268,8 +268,8 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"TokenTransferWithToken": {
-				"description": "Contains info about a token transfer with legacy `token` key for contract address",
+			"TokenTransfer": {
+				"description": "Contains info about a token transfer in a transaction",
 				"properties": {
 					"type": {
 						"type": "string"
@@ -278,76 +278,34 @@
 						"type": "string"
 					},
 					"to": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"symbol": {
-						"type": "string"
-					},
-					"decimals": {
-						"type": "number",
-						"format": "double"
-					},
-					"value": {
-						"type": "string"
-					},
-					"token": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"type",
-					"from",
-					"to",
-					"name",
-					"symbol",
-					"decimals",
-					"value",
-					"token"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenTransferWithContract": {
-				"description": "Contains info about a token transfer with new `contract` key for contract address",
-				"properties": {
-					"type": {
-						"type": "string"
-					},
-					"from": {
-						"type": "string"
-					},
-					"to": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"symbol": {
-						"type": "string"
-					},
-					"decimals": {
-						"type": "number",
-						"format": "double"
-					},
-					"value": {
 						"type": "string"
 					},
 					"contract": {
 						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"symbol": {
+						"type": "string"
+					},
+					"decimals": {
+						"type": "number",
+						"format": "double"
+					},
+					"value": {
+						"type": "string"
 					}
 				},
 				"required": [
 					"type",
 					"from",
 					"to",
+					"contract",
 					"name",
 					"symbol",
 					"decimals",
-					"value",
-					"contract"
+					"value"
 				],
 				"type": "object",
 				"additionalProperties": false
@@ -451,14 +409,7 @@
 					},
 					"tokenTransfers": {
 						"items": {
-							"anyOf": [
-								{
-									"$ref": "#/components/schemas/TokenTransferWithToken"
-								},
-								{
-									"$ref": "#/components/schemas/TokenTransferWithContract"
-								}
-							]
+							"$ref": "#/components/schemas/TokenTransfer"
 						},
 						"type": "array"
 					},
@@ -1058,7 +1009,7 @@
 													"type": "ERC20",
 													"from": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
 													"to": "0xa64D0b5ccFdaB0e4D8Ec7C65862Aac1c78A5666c",
-													"token": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+													"contract": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
 													"name": "Tether USD",
 													"symbol": "USDT",
 													"decimals": 6,

--- a/node/pulumi/package.json
+++ b/node/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/common-pulumi",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "license": "MIT",
   "private": true,
   "main": "src/index.ts",


### PR DESCRIPTION
- blockbook image build from: https://github.com/kaladinlight/blockbook/commit/7d3ea9a97bdb2e946acdc200a6d2911685a5adee
- remove legacy `token` field
- bump package versions