### PR TITLE
fix(blockbook): handle l1FeeScalar as string versus hex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,7 +530,7 @@ aliases:
     service-memory-limit-2: 2Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
-    service-image-3: shapeshiftdao/unchained-blockbook:optimism-7d3ea9a
+    service-image-3: shapeshiftdao/unchained-blockbook:optimism-b0f2fc9
     service-cpu-limit-3: "2"
     service-cpu-request-3: "1"
     service-memory-limit-3: 6Gi


### PR DESCRIPTION
- there were errors with blockbook tx cache with trying to handle `l1FeeScalar` as hex instead of string