### PR TITLE
chore: upgrade prysm v3.2.2 -> v4.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ aliases:
     service-memory-limit-1: 32Gi
     service-storage-size-1: 2500Gi
     service-name-2: daemon-beacon
-    service-image-2: gcr.io/prysmaticlabs/prysm/beacon-chain:v3.2.2
+    service-image-2: gcr.io/prysmaticlabs/prysm/beacon-chain:v4.0.0
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 8Gi


### PR DESCRIPTION
https://github.com/prysmaticlabs/prysm/releases/tag/v4.0.0

**This release is mandatory for all mainnet Prsym beacon nodes and validators. The release enables Capella upgrade, scheduled on April 12, 2023, 10:27:35pm UTC and epoch 194048. Failure to upgrade will result in your node forking off the chain and the validator losing rewards and getting penalized for being offline.**