### PR TITLE
chore: upgrade bsc v1.1.20 -> v1.1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,7 +574,7 @@ aliases:
     api-memory-limit: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: shapeshiftdao/bnb-smart-chain:v1.1.20
+    service-image-1: shapeshiftdao/bnb-smart-chain:v1.1.21
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 24Gi


### PR DESCRIPTION
https://github.com/bnb-chain/bsc/releases/tag/v1.1.21

**The mainnet is expected to have a scheduled hardfork upgrade named Planck at block height 27,281,024. The current block generation speed forecasts this to occur around 12th April 2023 at 05:30 AM (UTC).**