### PR TITLE
feat: naming unification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -841,41 +841,41 @@ jobs:
           working_directory: node/<< parameters.pulumi-dir >>
           command: |
             pulumi stack select $<< parameters.organization >>_PULUMI_ORG/<< parameters.pulumi-stack >>
-            pulumi config set --path unchained.coinstack.assetName << parameters.assetName >>
-            pulumi config set --path unchained.coinstack.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
-            [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained.coinstack.environment << parameters.environment >>
-            pulumi config set --path unchained.coinstack.network << parameters.network >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.enabled << parameters.api-autoscaling >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.cpuLimit << parameters.api-cpu-limit >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.cpuRequest << parameters.api-cpu-request >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.memoryLimit << parameters.api-memory-limit >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.replicas << parameters.api-replicas >>
-            [ "<< parameters.stateful-service-backup >>" = true ] && pulumi config set --path unchained.coinstack.statefulService.backup.count << parameters.stateful-service-backup-count >>
-            [ "<< parameters.stateful-service-backup >>" = true ] && pulumi config set --path unchained.coinstack.statefulService.backup.schedule << parameters.stateful-service-backup-schedule >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && pulumi config set --path unchained.coinstack.statefulService.replicas << parameters.stateful-service-replicas >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].name << parameters.service-name-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].image << parameters.service-image-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].cpuLimit << parameters.service-cpu-limit-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].cpuRequest << parameters.service-cpu-request-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].name << parameters.service-name-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].image << parameters.service-image-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].cpuRequest << parameters.service-cpu-request-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].name << parameters.service-name-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].image << parameters.service-image-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].cpuRequest << parameters.service-cpu-request-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
+            pulumi config set --path unchained:coinstack.assetName << parameters.assetName >>
+            pulumi config set --path unchained:coinstack.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
+            [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained:coinstack.environment << parameters.environment >>
+            pulumi config set --path unchained:coinstack.network << parameters.network >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.autoscaling.enabled << parameters.api-autoscaling >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.cpuLimit << parameters.api-cpu-limit >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.cpuRequest << parameters.api-cpu-request >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.memoryLimit << parameters.api-memory-limit >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.replicas << parameters.api-replicas >>
+            [ "<< parameters.stateful-service-backup >>" = true ] && pulumi config set --path unchained:coinstack.statefulService.backup.count << parameters.stateful-service-backup-count >>
+            [ "<< parameters.stateful-service-backup >>" = true ] && pulumi config set --path unchained:coinstack.statefulService.backup.schedule << parameters.stateful-service-backup-schedule >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && pulumi config set --path unchained:coinstack.statefulService.replicas << parameters.stateful-service-replicas >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].name << parameters.service-name-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].image << parameters.service-image-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].cpuLimit << parameters.service-cpu-limit-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].cpuRequest << parameters.service-cpu-request-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].name << parameters.service-name-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].image << parameters.service-image-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].cpuRequest << parameters.service-cpu-request-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].name << parameters.service-name-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].image << parameters.service-image-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].cpuRequest << parameters.service-cpu-request-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
             pulumi << parameters.pulumi-command >> --suppress-outputs
 
   deploy-coinstack-go:
@@ -914,39 +914,39 @@ jobs:
           command: |
             yarn install --immutable
             pulumi stack select $<< parameters.organization >>_PULUMI_ORG/<< parameters.pulumi-stack >>
-            pulumi config set --path unchained.coinstack.assetName << parameters.assetName >>
-            pulumi config set --path unchained.coinstack.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
-            [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained.coinstack.environment << parameters.environment >>
-            pulumi config set --path unchained.coinstack.network << parameters.network >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.enabled << parameters.api-autoscaling >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.cpuLimit << parameters.api-cpu-limit >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.cpuRequest << parameters.api-cpu-request >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.memoryLimit << parameters.api-memory-limit >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.replicas << parameters.api-replicas >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && pulumi config set --path unchained.coinstack.statefulService.replicas << parameters.stateful-service-replicas >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].name << parameters.service-name-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].image << parameters.service-image-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].cpuLimit << parameters.service-cpu-limit-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].cpuRequest << parameters.service-cpu-request-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].name << parameters.service-name-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].image << parameters.service-image-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].cpuRequest << parameters.service-cpu-request-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].name << parameters.service-name-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].image << parameters.service-image-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].cpuRequest << parameters.service-cpu-request-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
+            pulumi config set --path unchained:coinstack.assetName << parameters.assetName >>
+            pulumi config set --path unchained:coinstack.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
+            [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained:coinstack.environment << parameters.environment >>
+            pulumi config set --path unchained:coinstack.network << parameters.network >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.autoscaling.enabled << parameters.api-autoscaling >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.cpuLimit << parameters.api-cpu-limit >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.cpuRequest << parameters.api-cpu-request >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.memoryLimit << parameters.api-memory-limit >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:coinstack.api.replicas << parameters.api-replicas >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && pulumi config set --path unchained:coinstack.statefulService.replicas << parameters.stateful-service-replicas >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].name << parameters.service-name-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].image << parameters.service-image-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].cpuLimit << parameters.service-cpu-limit-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].cpuRequest << parameters.service-cpu-request-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].name << parameters.service-name-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].image << parameters.service-image-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].cpuRequest << parameters.service-cpu-request-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].name << parameters.service-name-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].image << parameters.service-image-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].cpuRequest << parameters.service-cpu-request-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
             pulumi << parameters.pulumi-command >> --suppress-outputs
 
   deploy-monitoring:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -841,7 +841,7 @@ jobs:
           working_directory: node/<< parameters.pulumi-dir >>
           command: |
             pulumi stack select $<< parameters.organization >>_PULUMI_ORG/<< parameters.pulumi-stack >>
-            pulumi config set --path unchained.coinstack.assetname << parameters.assetName >>
+            pulumi config set --path unchained.coinstack.assetName << parameters.assetName >>
             pulumi config set --path unchained.coinstack.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
             [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained.coinstack.environment << parameters.environment >>
             pulumi config set --path unchained.coinstack.network << parameters.network >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ aliases:
   - &params
     organization:
       type: string
-    coinstack:
-      description: coinstack name
+    assetName:
+      description: the k8s asset name
       type: string
     environment:
       description: environment to deploy into. empty string ('') is our prod
@@ -141,7 +141,7 @@ aliases:
       default: ""
 
   - &bitcoin
-    coinstack: bitcoin
+    assetName: bitcoin
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/bitcoin/pulumi
     rpc-url: http://user:password@bitcoin-svc.unchained.svc.cluster.local:8332
@@ -182,7 +182,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &ethereum
-    coinstack: ethereum
+    assetName: ethereum
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/ethereum/pulumi
     rpc-url: http://ethereum-svc.unchained.svc.cluster.local:8332
@@ -229,7 +229,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &cosmos
-    coinstack: cosmos
+    assetName: cosmos
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/cosmos/pulumi
     lcd-url: http://cosmos-svc.unchained.svc.cluster.local:1317
@@ -266,7 +266,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &osmosis
-    coinstack: osmosis
+    assetName: osmosis
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/osmosis/pulumi
     lcd-url: http://osmosis-svc.unchained.svc.cluster.local:1317
@@ -301,7 +301,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &avalanche
-    coinstack: avalanche
+    assetName: avalanche
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/avalanche/pulumi
     rpc-url: http://avalanche-svc.unchained.svc.cluster.local:9650/ext/bc/C/rpc
@@ -342,7 +342,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &dogecoin
-    coinstack: dogecoin
+    assetName: dogecoin
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/dogecoin/pulumi
     rpc-url: http://user:password@dogecoin-svc.unchained.svc.cluster.local:8332
@@ -383,7 +383,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &litecoin
-    coinstack: litecoin
+    assetName: litecoin
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/litecoin/pulumi
     rpc-url: http://user:password@litecoin-svc.unchained.svc.cluster.local:8332
@@ -424,7 +424,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &bitcoincash
-    coinstack: bitcoincash
+    assetName: bitcoincash
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/bitcoincash/pulumi
     rpc-url: http://user:password@bitcoincash-svc.unchained.svc.cluster.local:8332
@@ -465,7 +465,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &thorchain
-    coinstack: thorchain
+    assetName: thorchain
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/thorchain/pulumi
     lcd-url: http://thorchain-svc.unchained.svc.cluster.local:1317
@@ -512,7 +512,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &optimism
-    coinstack: optimism
+    assetName: optimism
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/optimism/pulumi
     rpc-url: http://optimism-svc.unchained.svc.cluster.local:8545
@@ -559,7 +559,7 @@ aliases:
     stateful-service-replicas: 1
 
   - &bnbsmartchain
-    coinstack: bnbsmartchain
+    assetName: bnbsmartchain
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/bnbsmartchain/pulumi
     rpc-url: http://bnbsmartchain-svc.unchained.svc.cluster.local:8545
@@ -841,40 +841,41 @@ jobs:
           working_directory: node/<< parameters.pulumi-dir >>
           command: |
             pulumi stack select $<< parameters.organization >>_PULUMI_ORG/<< parameters.pulumi-stack >>
-            pulumi config set --path unchained:<< parameters.coinstack >>.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
-            [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.environment << parameters.environment >>
-            pulumi config set --path unchained:<< parameters.coinstack >>.network << parameters.network >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.enabled << parameters.api-autoscaling >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.cpuLimit << parameters.api-cpu-limit >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.cpuRequest << parameters.api-cpu-request >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.memoryLimit << parameters.api-memory-limit >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.replicas << parameters.api-replicas >>
-            [ "<< parameters.stateful-service-backup >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.backup.count << parameters.stateful-service-backup-count >>
-            [ "<< parameters.stateful-service-backup >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.backup.schedule << parameters.stateful-service-backup-schedule >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.replicas << parameters.stateful-service-replicas >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].name << parameters.service-name-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].image << parameters.service-image-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].cpuLimit << parameters.service-cpu-limit-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].cpuRequest << parameters.service-cpu-request-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].name << parameters.service-name-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].image << parameters.service-image-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].cpuRequest << parameters.service-cpu-request-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].name << parameters.service-name-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].image << parameters.service-image-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].cpuRequest << parameters.service-cpu-request-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
+            pulumi config set --path unchained.coinstack.assetname << parameters.assetName >>
+            pulumi config set --path unchained.coinstack.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
+            [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained.coinstack.environment << parameters.environment >>
+            pulumi config set --path unchained.coinstack.network << parameters.network >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.enabled << parameters.api-autoscaling >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.cpuLimit << parameters.api-cpu-limit >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.cpuRequest << parameters.api-cpu-request >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.memoryLimit << parameters.api-memory-limit >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.replicas << parameters.api-replicas >>
+            [ "<< parameters.stateful-service-backup >>" = true ] && pulumi config set --path unchained.coinstack.statefulService.backup.count << parameters.stateful-service-backup-count >>
+            [ "<< parameters.stateful-service-backup >>" = true ] && pulumi config set --path unchained.coinstack.statefulService.backup.schedule << parameters.stateful-service-backup-schedule >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && pulumi config set --path unchained.coinstack.statefulService.replicas << parameters.stateful-service-replicas >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].name << parameters.service-name-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].image << parameters.service-image-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].cpuLimit << parameters.service-cpu-limit-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].cpuRequest << parameters.service-cpu-request-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].name << parameters.service-name-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].image << parameters.service-image-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].cpuRequest << parameters.service-cpu-request-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].name << parameters.service-name-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].image << parameters.service-image-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].cpuRequest << parameters.service-cpu-request-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
             pulumi << parameters.pulumi-command >> --suppress-outputs
 
   deploy-coinstack-go:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,38 +914,39 @@ jobs:
           command: |
             yarn install --immutable
             pulumi stack select $<< parameters.organization >>_PULUMI_ORG/<< parameters.pulumi-stack >>
-            pulumi config set --path unchained:<< parameters.coinstack >>.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
-            [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.environment << parameters.environment >>
-            pulumi config set --path unchained:<< parameters.coinstack >>.network << parameters.network >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.enabled << parameters.api-autoscaling >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.cpuLimit << parameters.api-cpu-limit >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.cpuRequest << parameters.api-cpu-request >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.memoryLimit << parameters.api-memory-limit >>
-            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained:<< parameters.coinstack >>.api.replicas << parameters.api-replicas >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.replicas << parameters.stateful-service-replicas >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].name << parameters.service-name-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].image << parameters.service-image-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].cpuLimit << parameters.service-cpu-limit-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].cpuRequest << parameters.service-cpu-request-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].name << parameters.service-name-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].image << parameters.service-image-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].cpuRequest << parameters.service-cpu-request-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].name << parameters.service-name-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].image << parameters.service-image-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].cpuRequest << parameters.service-cpu-request-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
-            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained:<< parameters.coinstack >>.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
+            pulumi config set --path unchained.coinstack.assetName << parameters.assetName >>
+            pulumi config set --path unchained.coinstack.stack $<< parameters.organization >>_PULUMI_ORG/common/dependencies-us-east-2
+            [ -n "<< parameters.environment >>" ] && pulumi config set --path unchained.coinstack.environment << parameters.environment >>
+            pulumi config set --path unchained.coinstack.network << parameters.network >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.enabled << parameters.api-autoscaling >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.cpuThreshold << parameters.api-cpu-threshold >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.autoscaling.maxReplicas << parameters.api-max-replicas >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.cpuLimit << parameters.api-cpu-limit >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.cpuRequest << parameters.api-cpu-request >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.memoryLimit << parameters.api-memory-limit >>
+            [ "<< parameters.api >>" = true ] && pulumi config set --path unchained.coinstack.api.replicas << parameters.api-replicas >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && pulumi config set --path unchained.coinstack.statefulService.replicas << parameters.stateful-service-replicas >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].name << parameters.service-name-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].image << parameters.service-image-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].cpuLimit << parameters.service-cpu-limit-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].cpuRequest << parameters.service-cpu-request-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].name << parameters.service-name-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].image << parameters.service-image-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].cpuRequest << parameters.service-cpu-request-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].name << parameters.service-name-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].image << parameters.service-image-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-request-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].cpuRequest << parameters.service-cpu-request-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained.coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
             pulumi << parameters.pulumi-command >> --suppress-outputs
 
   deploy-monitoring:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ aliases:
     api-memory-limit: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: avaplatform/avalanchego:v1.9.14
+    service-image-1: avaplatform/avalanchego:v1.9.16
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 12Gi

--- a/go/coinstacks/cosmos/pulumi/index.ts
+++ b/go/coinstacks/cosmos/pulumi/index.ts
@@ -16,7 +16,7 @@ export = async (): Promise<Outputs> => {
 
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync(`../../../cmd/${coinstack}/sample.env`))).reduce((prev, key) => {

--- a/go/coinstacks/cosmos/pulumi/index.ts
+++ b/go/coinstacks/cosmos/pulumi/index.ts
@@ -8,12 +8,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'cosmos'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
+  const assetName = config.network !== 'mainnet' ? `${config.assetName}-${config.network}` : config.assetName
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
 
@@ -33,11 +33,12 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     buildAndPushImageArgs: { context: '../../../../go', dockerFile: '../../../build/Dockerfile' },
     config,
     container: { args: ['-swagger', 'swagger.json'] },
@@ -51,7 +52,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           dataDir: '/root',
           ports: {
@@ -64,7 +65,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(name, asset, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/go/coinstacks/osmosis/pulumi/index.ts
+++ b/go/coinstacks/osmosis/pulumi/index.ts
@@ -8,12 +8,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'osmosis'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
+  const assetName = config.network !== 'mainnet' ? `${config.assetName}-${config.network}` : config.assetName
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
 
@@ -33,11 +33,12 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     buildAndPushImageArgs: { context: '../../../../go', dockerFile: '../../../build/Dockerfile' },
     config,
     container: { args: ['-swagger', 'swagger.json'] },
@@ -51,7 +52,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           dataDir: '/root',
           ports: {
@@ -64,7 +65,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(name, asset, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/go/coinstacks/osmosis/pulumi/index.ts
+++ b/go/coinstacks/osmosis/pulumi/index.ts
@@ -16,7 +16,7 @@ export = async (): Promise<Outputs> => {
   const assetName = config.network !== 'mainnet' ? `${config.assetName}-${config.network}` : config.assetName
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync(`../../../cmd/${coinstack}/sample.env`))).reduce((prev, key) => {

--- a/go/coinstacks/thorchain/pulumi/index.ts
+++ b/go/coinstacks/thorchain/pulumi/index.ts
@@ -8,12 +8,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'thorchain'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
+  const assetName = config.network !== 'mainnet' ? `${config.assetName}-${config.network}` : config.assetName
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
   const outputs: Outputs = {}
 
@@ -33,11 +33,12 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     buildAndPushImageArgs: { context: '../../../../go', dockerFile: '../../../build/Dockerfile' },
     config,
     container: { args: ['-swagger', 'swagger.json'] },
@@ -51,7 +52,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           dataDir: '/root',
           env: { 'CHAIN_ID': `${coinstack}-${config.network}-v1`, 'NET': config.network },
@@ -64,7 +65,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'indexer') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           dataDir: '/blockstore',
           env: { 'MIDGARD_BLOCKSTORE_LOCAL': '/blockstore' },
@@ -76,7 +77,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'timescaledb') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           dataDir: '/var/lib/postgresql/data',
           env: {
@@ -95,7 +96,7 @@ export = async (): Promise<Outputs> => {
 
     const volumes = [{ name: 'dshm', emptyDir: { medium: 'Memory', sizeLimit: '1Gi' } }]
 
-    await deployStatefulService(name, asset, provider, namespace, config, services, volumes)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services, volumes)
   }
 
   return outputs

--- a/go/coinstacks/thorchain/pulumi/index.ts
+++ b/go/coinstacks/thorchain/pulumi/index.ts
@@ -15,7 +15,7 @@ export = async (): Promise<Outputs> => {
 
   const assetName = config.network !== 'mainnet' ? `${config.assetName}-${config.network}` : config.assetName
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
   const outputs: Outputs = {}
 
   const missingKeys: Array<string> = []

--- a/node/coinstacks/avalanche/pulumi/index.ts
+++ b/node/coinstacks/avalanche/pulumi/index.ts
@@ -24,7 +24,7 @@ export = async (): Promise<Outputs> => {
   const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync('../sample.env'))).reduce((prev, key) => {

--- a/node/coinstacks/avalanche/pulumi/index.ts
+++ b/node/coinstacks/avalanche/pulumi/index.ts
@@ -9,12 +9,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'avalanche'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
+  const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
 
@@ -34,13 +34,14 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   const baseImageName = 'shapeshiftdao/unchained-base:latest'
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     baseImageName,
     buildAndPushImageArgs: { context: '../api' },
     config,
@@ -55,7 +56,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           ports: { 'daemon-rpc': { port: 9650 } },
           configMapData: { 'c-chain-config.json': readFileSync('../daemon/config.json').toString() },
@@ -67,7 +68,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'indexer') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           command: [
             '/bin/blockbook',
@@ -90,7 +91,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(name, asset, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/node/coinstacks/bitcoin/pulumi/index.ts
+++ b/node/coinstacks/bitcoin/pulumi/index.ts
@@ -24,7 +24,7 @@ export = async (): Promise<Outputs> => {
   const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync('../sample.env'))).reduce((prev, key) => {

--- a/node/coinstacks/bitcoin/pulumi/index.ts
+++ b/node/coinstacks/bitcoin/pulumi/index.ts
@@ -9,12 +9,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'bitcoin'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
+  const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
 
@@ -34,13 +34,14 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   const baseImageName = 'shapeshiftdao/unchained-base:latest'
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     baseImageName,
     buildAndPushImageArgs: { context: '../api' },
     config,
@@ -55,7 +56,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           env: { NETWORK: config.network },
           ports: { 'daemon-rpc': { port: 8332 } },
@@ -64,7 +65,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'indexer') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           command: [
             '/bin/blockbook',
@@ -87,7 +88,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(name, asset, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/node/coinstacks/bitcoincash/pulumi/index.ts
+++ b/node/coinstacks/bitcoincash/pulumi/index.ts
@@ -24,7 +24,7 @@ export = async (): Promise<Outputs> => {
   const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync('../sample.env'))).reduce((prev, key) => {

--- a/node/coinstacks/bitcoincash/pulumi/index.ts
+++ b/node/coinstacks/bitcoincash/pulumi/index.ts
@@ -9,12 +9,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'bitcoincash'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
+  const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
 
@@ -34,13 +34,14 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   const baseImageName = 'shapeshiftdao/unchained-base:latest'
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     baseImageName,
     buildAndPushImageArgs: { context: '../api' },
     config,
@@ -55,7 +56,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           env: { NETWORK: config.network },
           ports: { 'daemon-rpc': { port: 8332 } },
@@ -64,7 +65,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'indexer') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           command: [
             '/bin/blockbook',
@@ -87,7 +88,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(name, asset, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/node/coinstacks/bnbsmartchain/pulumi/index.ts
+++ b/node/coinstacks/bnbsmartchain/pulumi/index.ts
@@ -24,7 +24,7 @@ export = async (): Promise<Outputs> => {
   const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync('../sample.env'))).reduce((prev, key) => {

--- a/node/coinstacks/bnbsmartchain/pulumi/index.ts
+++ b/node/coinstacks/bnbsmartchain/pulumi/index.ts
@@ -9,12 +9,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'bnbsmartchain'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
+  const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
 
@@ -34,13 +34,14 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   const baseImageName = 'shapeshiftdao/unchained-base:latest'
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     baseImageName,
     buildAndPushImageArgs: { context: '../api' },
     config,
@@ -55,7 +56,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           ports: {
             'daemon-rpc': { port: 8545 },
@@ -67,7 +68,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'indexer') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           command: [
             '/bin/blockbook',
@@ -90,7 +91,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(name, asset, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/node/coinstacks/dogecoin/pulumi/index.ts
+++ b/node/coinstacks/dogecoin/pulumi/index.ts
@@ -9,12 +9,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'dogecoin'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
+  const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
 
@@ -34,13 +34,14 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   const baseImageName = 'shapeshiftdao/unchained-base:latest'
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     baseImageName,
     buildAndPushImageArgs: { context: '../api' },
     config,
@@ -55,7 +56,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           env: { NETWORK: config.network },
           ports: { 'daemon-rpc': { port: 8332 } },
@@ -64,7 +65,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'indexer') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           command: [
             '/bin/blockbook',
@@ -87,7 +88,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(name, asset, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/node/coinstacks/dogecoin/pulumi/index.ts
+++ b/node/coinstacks/dogecoin/pulumi/index.ts
@@ -24,7 +24,7 @@ export = async (): Promise<Outputs> => {
   const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync('../sample.env'))).reduce((prev, key) => {

--- a/node/coinstacks/ethereum/pulumi/index.ts
+++ b/node/coinstacks/ethereum/pulumi/index.ts
@@ -24,7 +24,7 @@ export = async (): Promise<Outputs> => {
   const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync('../sample.env'))).reduce((prev, key) => {

--- a/node/coinstacks/litecoin/pulumi/index.ts
+++ b/node/coinstacks/litecoin/pulumi/index.ts
@@ -57,7 +57,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          assetName: assetName,
+          assetName,
           config: service,
           env: { NETWORK: config.network },
           ports: { 'daemon-rpc': { port: 8332 } },
@@ -66,7 +66,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'indexer') {
         prev[service.name] = createService({
-          assetName: assetName,
+          assetName,
           config: service,
           command: [
             '/bin/blockbook',

--- a/node/coinstacks/litecoin/pulumi/index.ts
+++ b/node/coinstacks/litecoin/pulumi/index.ts
@@ -89,7 +89,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(appName, config.assetName, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/node/coinstacks/litecoin/pulumi/index.ts
+++ b/node/coinstacks/litecoin/pulumi/index.ts
@@ -20,12 +20,11 @@ export = async (): Promise<Outputs> => {
   const coinstack = 'litecoin'
 
   const { kubeconfig, config, namespace } = await getConfig()
+  const assetName = config.network !== 'mainnet' ? `${config.assetName}-${config.network}` : config.assetName
 
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
-
-  const assetName = config.network !== 'mainnet' ? `${config.assetName}-${config.network}` : config.assetName
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync('../sample.env'))).reduce((prev, key) => {

--- a/node/coinstacks/optimism/pulumi/index.ts
+++ b/node/coinstacks/optimism/pulumi/index.ts
@@ -9,12 +9,12 @@ type Outputs = Record<string, any>
 
 //https://www.pulumi.com/docs/intro/languages/javascript/#entrypoint
 export = async (): Promise<Outputs> => {
-  const name = 'unchained'
+  const appName = 'unchained'
   const coinstack = 'optimism'
 
-  const { kubeconfig, config, namespace } = await getConfig(coinstack)
+  const { kubeconfig, config, namespace } = await getConfig()
 
-  const asset = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
+  const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
 
@@ -34,13 +34,14 @@ export = async (): Promise<Outputs> => {
     throw new Error(`Missing the following required environment variables: ${missingKeys.join(', ')}`)
   }
 
-  new k8s.core.v1.Secret(asset, { metadata: { name: asset, namespace }, stringData }, { provider })
+  new k8s.core.v1.Secret(assetName, { metadata: { name: assetName, namespace }, stringData }, { provider })
 
   const baseImageName = 'shapeshiftdao/unchained-base:latest'
 
   await deployApi({
-    app: name,
-    asset,
+    appName,
+    assetName,
+    coinstack,
     baseImageName,
     buildAndPushImageArgs: { context: '../api' },
     config,
@@ -55,7 +56,7 @@ export = async (): Promise<Outputs> => {
     const services = config.statefulService.services.reduce<Record<string, Service>>((prev, service) => {
       if (service.name === 'daemon') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           ports: {
             'daemon-rpc': { port: 8545 },
@@ -67,7 +68,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'dtl') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           env: { L1_RPC_ENDPOINT: `http://ethereum-svc.${namespace}.svc.cluster.local:8332` },
           ports: { http: { port: 7878 } },
@@ -76,7 +77,7 @@ export = async (): Promise<Outputs> => {
 
       if (service.name === 'indexer') {
         prev[service.name] = createService({
-          asset,
+          assetName,
           config: service,
           command: [
             '/bin/blockbook',
@@ -99,7 +100,7 @@ export = async (): Promise<Outputs> => {
       return prev
     }, {})
 
-    await deployStatefulService(name, asset, provider, namespace, config, services)
+    await deployStatefulService(appName, assetName, provider, namespace, config, services)
   }
 
   return outputs

--- a/node/coinstacks/optimism/pulumi/index.ts
+++ b/node/coinstacks/optimism/pulumi/index.ts
@@ -24,7 +24,7 @@ export = async (): Promise<Outputs> => {
   const assetName = config.network !== 'mainnet' ? `${coinstack}-${config.network}` : coinstack
   const outputs: Outputs = {}
   const provider = new k8s.Provider('kube-provider', { kubeconfig })
-  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(asset)
+  const snapshots = await new VolumeSnapshotClient(kubeconfig, namespace).getVolumeSnapshots(assetName)
 
   const missingKeys: Array<string> = []
   const stringData = Object.keys(parse(readFileSync('../sample.env'))).reduce((prev, key) => {

--- a/pulumi/src/api.ts
+++ b/pulumi/src/api.ts
@@ -18,10 +18,10 @@ export interface ApiConfig {
 
 export interface DeployApiArgs {
   app: string
-  asset: string
+  coinstack: string
   baseImageName?: string
   buildAndPushImageArgs: Pick<BuildAndPushImageArgs, 'context' | 'dockerFile'>
-  config: Pick<Config, 'api' | 'dockerhub' | 'rootDomainName' | 'environment'>
+  config: Pick<Config, 'api' | 'dockerhub' | 'rootDomainName' | 'environment' | 'assetName'>
   container: Partial<Pick<k8s.types.input.core.v1.Container, 'args' | 'command'>>
   deployDependencies?: Input<Array<Resource>>
   getHash: (coinstack: string, buildArgs: Record<string, string>) => Promise<string>
@@ -33,7 +33,7 @@ export interface DeployApiArgs {
 export async function deployApi(args: DeployApiArgs): Promise<k8s.apps.v1.Deployment | undefined> {
   const {
     app,
-    asset,
+    coinstack,
     baseImageName,
     buildAndPushImageArgs,
     config,
@@ -48,9 +48,9 @@ export async function deployApi(args: DeployApiArgs): Promise<k8s.apps.v1.Deploy
   if (config.api === undefined) return
 
   const tier = 'api'
-  const labels = { app, asset, tier }
+  const asset = config.assetName
+  const labels = { coinstack, asset, tier }
   const name = `${asset}-${tier}`
-  const [coinstack] = asset.split('-')
 
   const buildArgs: Record<string, string> = { BUILDKIT_INLINE_CACHE: '1', COINSTACK: coinstack }
   if (baseImageName) buildArgs.BASE_IMAGE = baseImageName

--- a/pulumi/src/api.ts
+++ b/pulumi/src/api.ts
@@ -22,7 +22,7 @@ export interface DeployApiArgs {
   assetName: string
   baseImageName?: string
   buildAndPushImageArgs: Pick<BuildAndPushImageArgs, 'context' | 'dockerFile'>
-  config: Pick<Config, 'api' | 'dockerhub' | 'rootDomainName' | 'environment' | 'assetName'>
+  config: Pick<Config, 'api' | 'dockerhub' | 'rootDomainName' | 'environment'>
   container: Partial<Pick<k8s.types.input.core.v1.Container, 'args' | 'command'>>
   deployDependencies?: Input<Array<Resource>>
   getHash: (coinstack: string, buildArgs: Record<string, string>) => Promise<string>

--- a/pulumi/src/api.ts
+++ b/pulumi/src/api.ts
@@ -204,7 +204,7 @@ export async function deployApi(args: DeployApiArgs): Promise<k8s.apps.v1.Deploy
           name: tier,
           image: imageName,
           ports: [{ containerPort: 3000, name: 'http' }],
-          env: [...secretEnvs(coinstack, asset)],
+          env: [...secretEnvs(coinstack, assetName)],
           resources: {
             limits: {
               cpu: config.api.cpuLimit,

--- a/pulumi/src/api.ts
+++ b/pulumi/src/api.ts
@@ -50,7 +50,7 @@ export async function deployApi(args: DeployApiArgs): Promise<k8s.apps.v1.Deploy
   if (config.api === undefined) return
 
   const tier = 'api'
-  const labels = { coinstack, assetName, tier }
+  const labels = { app: appName, coinstack, asset: assetName, tier }
   const name = `${assetName}-${tier}`
 
   const buildArgs: Record<string, string> = { BUILDKIT_INLINE_CACHE: '1', COINSTACK: coinstack }

--- a/pulumi/src/config.ts
+++ b/pulumi/src/config.ts
@@ -9,10 +9,10 @@ export interface Config {
   namespace: string
 }
 
-export const getConfig = async (coinstack: string): Promise<Config> => {
+export const getConfig = async (): Promise<Config> => {
   const config = (() => {
     try {
-      return new pulumi.Config('unchained').requireObject<BaseConfig>(coinstack)
+      return new pulumi.Config('unchained').requireObject<BaseConfig>('coinstack')
     } catch (e) {
       throw new pulumi.RunError('Could not find required configuration file')
     }
@@ -34,6 +34,8 @@ export const getConfig = async (coinstack: string): Promise<Config> => {
   config.rootDomainName = (await stackReference.getOutputValue('rootDomainName')) as string
 
   const missingRequiredConfig: Array<string> = []
+
+  if (!config.assetName) missingRequiredConfig.push('assetName')
 
   if (!config.stack) missingRequiredConfig.push('stack')
 

--- a/pulumi/src/index.ts
+++ b/pulumi/src/index.ts
@@ -40,6 +40,7 @@ export interface StatefulService {
 
 export interface Config extends BaseConfig {
   stack: string
+  assetName: string
   network: string
   environment?: string
   api?: ApiConfig

--- a/pulumi/src/statefulService.ts
+++ b/pulumi/src/statefulService.ts
@@ -1,7 +1,9 @@
 import * as k8s from '@pulumi/kubernetes'
 import { readFileSync } from 'fs'
 import { Config, Service, ServiceConfig } from '.'
+import { getVolumeClaimTemplates } from './pvcResolver'
 import { deployReaperCron } from './reaperCron'
+import { VolumeSnapshot } from './volumeSnapshotClient'
 
 interface Port {
   port: number
@@ -11,7 +13,7 @@ interface Port {
 }
 
 export interface ServiceArgs {
-  asset: string
+  assetName: string
   config: ServiceConfig
   ports: Record<string, Port>
   command?: Array<string>
@@ -21,11 +23,12 @@ export interface ServiceArgs {
   configMapData?: Record<string, string>
   volumeMounts?: Array<k8s.types.input.core.v1.VolumeMount>
   readinessProbe?: k8s.types.input.core.v1.Probe
-  livenessProbe?: k8s.types.input.core.v1.Probe
+  livenessProbe?: k8s.types.input.core.v1.Probe,
+  snapshots?: VolumeSnapshot[]
 }
 
 export function createService(args: ServiceArgs): Service {
-  const name = `${args.asset}-${args.config.name}`
+  const name = `${args.assetName}-${args.config.name}`
   const ports = Object.entries(args.ports).map(([name, port]) => ({ name, ...port }))
   const env = Object.entries(args.env ?? []).map(([name, value]) => ({ name, value }))
 
@@ -149,22 +152,7 @@ export function createService(args: ServiceArgs): Service {
     containers.push(monitorContainer)
   }
 
-  const volumeClaimTemplates = [
-    {
-      metadata: {
-        name: `data-${args.config.name}`,
-      },
-      spec: {
-        accessModes: ['ReadWriteOnce'],
-        storageClassName: 'ebs-csi-gp2',
-        resources: {
-          requests: {
-            storage: args.config.storageSize,
-          },
-        },
-      },
-    },
-  ]
+  const volumeClaimTemplates = getVolumeClaimTemplates(args.config.name, args.config.storageSize, args.snapshots)
 
   return {
     configMapData,

--- a/pulumi/src/statefulService.ts
+++ b/pulumi/src/statefulService.ts
@@ -1,9 +1,7 @@
 import * as k8s from '@pulumi/kubernetes'
 import { readFileSync } from 'fs'
 import { Config, Service, ServiceConfig } from '.'
-import { getVolumeClaimTemplates } from './pvcResolver'
 import { deployReaperCron } from './reaperCron'
-import { VolumeSnapshot } from './volumeSnapshotClient'
 
 interface Port {
   port: number
@@ -23,8 +21,7 @@ export interface ServiceArgs {
   configMapData?: Record<string, string>
   volumeMounts?: Array<k8s.types.input.core.v1.VolumeMount>
   readinessProbe?: k8s.types.input.core.v1.Probe
-  livenessProbe?: k8s.types.input.core.v1.Probe,
-  snapshots?: VolumeSnapshot[]
+  livenessProbe?: k8s.types.input.core.v1.Probe
 }
 
 export function createService(args: ServiceArgs): Service {
@@ -152,7 +149,22 @@ export function createService(args: ServiceArgs): Service {
     containers.push(monitorContainer)
   }
 
-  const volumeClaimTemplates = getVolumeClaimTemplates(args.config.name, args.config.storageSize, args.snapshots)
+  const volumeClaimTemplates = [
+    {
+      metadata: {
+        name: `data-${args.config.name}`,
+      },
+      spec: {
+        accessModes: ['ReadWriteOnce'],
+        storageClassName: 'ebs-csi-gp2',
+        resources: {
+          requests: {
+            storage: args.config.storageSize,
+          },
+        },
+      },
+    },
+  ]
 
   return {
     configMapData,

--- a/pulumi/src/statefulService.ts
+++ b/pulumi/src/statefulService.ts
@@ -163,8 +163,8 @@ export function createService(args: ServiceArgs): Service {
 }
 
 export async function deployStatefulService(
-  app: string,
-  asset: string,
+  appName: string,
+  assetName: string,
   provider: k8s.Provider,
   namespace: string,
   config: Pick<Config, 'rootDomainName' | 'environment' | 'statefulService'>,
@@ -175,7 +175,7 @@ export async function deployStatefulService(
   if (config.statefulService.replicas <= 0) return
   if (!Object.keys(services).length) return
 
-  const labels = { app, asset, tier: 'statefulservice' }
+  const labels = { app: appName, asset: assetName, tier: 'statefulservice' }
 
   const ports = Object.values(services).reduce<Array<k8s.types.input.core.v1.ServicePort>>(
     (prev, { ports }) => [...prev, ...ports.map(({ name, port }) => ({ name, port }))],
@@ -198,10 +198,10 @@ export async function deployStatefulService(
   )
 
   const svc = new k8s.core.v1.Service(
-    `${asset}-svc`,
+    `${assetName}-svc`,
     {
       metadata: {
-        name: `${asset}-svc`,
+        name: `${assetName}-svc`,
         namespace: namespace,
         labels: labels,
       },
@@ -215,7 +215,7 @@ export async function deployStatefulService(
   )
 
   const configMap = new k8s.core.v1.ConfigMap(
-    `${asset}-cm`,
+    `${assetName}-cm`,
     {
       metadata: {
         namespace: namespace,
@@ -248,16 +248,16 @@ export async function deployStatefulService(
   }
 
   new k8s.apps.v1.StatefulSet(
-    `${asset}-sts`,
+    `${assetName}-sts`,
     {
       metadata: {
-        name: `${asset}-sts`,
+        name: `${assetName}-sts`,
         namespace: namespace,
         annotations: { 'pulumi.com/skipAwait': 'true' },
       },
       spec: {
         selector: { matchLabels: labels },
-        serviceName: `${asset}-svc`,
+        serviceName: `${assetName}-svc`,
         replicas: config.statefulService.replicas,
         podManagementPolicy: 'Parallel',
         updateStrategy: {
@@ -272,14 +272,14 @@ export async function deployStatefulService(
 
   if (config.rootDomainName) {
     const domain = (service: string) => {
-      const baseDomain = `${service}.${asset}.${config.rootDomainName}`
+      const baseDomain = `${service}.${assetName}.${config.rootDomainName}`
       return config.environment ? `${config.environment}.${baseDomain}` : baseDomain
     }
 
-    const secretName = `${asset}-cert-secret`
+    const secretName = `${assetName}-cert-secret`
 
     new k8s.apiextensions.CustomResource(
-      `${asset}-cert`,
+      `${assetName}-cert`,
       {
         apiVersion: 'cert-manager.io/v1',
         kind: 'Certificate',
@@ -315,12 +315,12 @@ export async function deployStatefulService(
       const hostMatch = `(Host(\`${domain(`${service}`)}\`)${pathPrefixMatch})`
       const additionalHostMatch = `(Host(\`${
         config.environment ? `${config.environment}-${service}` : service
-      }.${asset}.${additionalRootDomainName}\`)${pathPrefixMatch})`
+      }.${assetName}.${additionalRootDomainName}\`)${pathPrefixMatch})`
       return additionalRootDomainName ? `${hostMatch} || ${additionalHostMatch}` : hostMatch
     }
 
     const middleware = new k8s.apiextensions.CustomResource(
-      `${asset}-middleware`,
+      `${assetName}-middleware`,
       {
         apiVersion: 'traefik.containo.us/v1alpha1',
         kind: 'Middleware',
@@ -344,7 +344,7 @@ export async function deployStatefulService(
     )
 
     new k8s.apiextensions.CustomResource(
-      `${asset}-ingressroute`,
+      `${assetName}-ingressroute`,
       {
         apiVersion: 'traefik.containo.us/v1alpha1',
         kind: 'IngressRoute',
@@ -385,7 +385,7 @@ export async function deployStatefulService(
     )
 
     new k8s.networking.v1.Ingress(
-      `${asset}-ingress`,
+      `${assetName}-ingress`,
       {
         metadata: {
           namespace: namespace,
@@ -400,6 +400,6 @@ export async function deployStatefulService(
   }
 
   if (namespace == 'unchained-dev') {
-    deployReaperCron(asset, config.statefulService, namespace, provider)
+    deployReaperCron(assetName, config.statefulService, namespace, provider)
   }
 }

--- a/pulumi/volumeReaper/src/volumeReaper.ts
+++ b/pulumi/volumeReaper/src/volumeReaper.ts
@@ -66,9 +66,9 @@ export class VolumeReaper {
       const pvcList = this.services.split(',').map((svc) => `data-${svc}-${this.asset}-sts-${replicas - 1}`)
       const retainCount = pvcList.length * this.backupCount
 
-      await this.scaleStatefulSet(sts, replicas - 1, false)
+      await this.scaleStatefulSet(replicas - 1, false)
       await this.takeSnapshots(pvcList)
-      await this.scaleStatefulSet(sts, replicas, true)
+      await this.scaleStatefulSet(replicas, true)
       await this.removeSnapshots(retainCount)
     } catch (err) {
       if (err instanceof k8s.HttpError) {
@@ -92,10 +92,10 @@ export class VolumeReaper {
     return sts
   }
 
-  private async scaleStatefulSet(_sts: StatefulSet, count: number, skipAwait: boolean): Promise<void> {
+  private async scaleStatefulSet(count: number, skipAwait: boolean): Promise<void> {
     console.log(`Scaling StatefulSet ${this.namespace}.${this.name} to ${count} replicas`)
 
-    const sts = { ..._sts }
+    const sts = await this.getStatefulSet()
     sts.spec.replicas = count
 
     await this.k8sAppsApi.replaceNamespacedStatefulSet(this.name, this.namespace, sts)


### PR DESCRIPTION
The problem:

It is currently impossible to reliably test non-default coinstack configuration, as the some names are propagated downstream in multiple ways and require certain values to be set to defaults in order to work. 

Examples include:

`const [coinstack] = asset.split('-')`
`const { hash: apiHash } = await hashElement(`../../${coinstack}/api`, `
`const name = `${args.asset}-${args.config.name}`

The combination of these makes it impossible to change the name of deployed resources. Also the terms `name`, `asset`, `service` are used inconsitently, i.e. a parameter passed down as `name` is received as `app` downstream, further complicating debugging of naming issues.

I'd like to introduce a shared top-down naming scheme that will make it obvious which resources will be referenced, where, and under what name. 

Sample updated config:

```
config:
  unchained:coinstack:
    assetName: litecointest
    environment: dev
    stack: unchained/common/dependencies-us-east-2
    network: mainnet
```

The hierarchy would be as follows (top to bottom):

`appName -> assetName -> serviceName`
