### PR TITLE
fix: Always build x64 docker images

### DIFF
--- a/k6/Makefile
+++ b/k6/Makefile
@@ -3,4 +3,4 @@ USER=$(shell id -u):$(shell id -g)
 TEST_FILE="test.js"
 
 test:
-	- docker run --rm -it --user ${USER} -v "$(CURDIR):/out" $(IMAGE) run /out/$(TEST_FILE)
+	- docker run --platform linux/amd64 --rm -it --user ${USER} -v "$(CURDIR):/out" $(IMAGE) run /out/$(TEST_FILE)

--- a/node/coinstacks/avalanche/indexer/Makefile
+++ b/node/coinstacks/avalanche/indexer/Makefile
@@ -2,8 +2,8 @@ IMAGE = blockbook
 PACKAGER = $(shell id -u):$(shell id -g)
 
 gen-config:
-	- docker run --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh avalanche
+	- docker run --platform linux/amd64 --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh avalanche
 
 run:
 	- mkdir -p db
-	- docker run --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -logtostderror
+	- docker run --platform linux/amd64 --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -logtostderror

--- a/node/coinstacks/bitcoin/indexer/Makefile
+++ b/node/coinstacks/bitcoin/indexer/Makefile
@@ -2,9 +2,9 @@ IMAGE = blockbook
 PACKAGER = $(shell id -u):$(shell id -g)
 
 gen-config:
-	- docker run --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh bitcoin
+	- docker run --platform linux/amd64 --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh bitcoin
 
 run:
 	- mkdir -p db
 	- mkdir -p logs
-	- docker run --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs
+	- docker run --platform linux/amd64 --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs

--- a/node/coinstacks/bitcoincash/indexer/Makefile
+++ b/node/coinstacks/bitcoincash/indexer/Makefile
@@ -2,9 +2,9 @@ IMAGE = blockbook
 PACKAGER = $(shell id -u):$(shell id -g)
 
 gen-config:
-	- docker run --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh bitcoincash
+	- docker run --platform linux/amd64 --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh bitcoincash
 
 run:
 	- mkdir -p db
 	- mkdir -p logs
-	- docker run --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs
+	- docker run --platform linux/amd64 --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs

--- a/node/coinstacks/bnbsmartchain/indexer/Makefile
+++ b/node/coinstacks/bnbsmartchain/indexer/Makefile
@@ -2,8 +2,8 @@ IMAGE = blockbook
 PACKAGER = $(shell id -u):$(shell id -g)
 
 gen-config:
-	- docker run --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh bnbsmartchain
+	- docker run --platform linux/amd64 --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh bnbsmartchain
 
 run:
 	- mkdir -p db
-	- docker run --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -logtostderror
+	- docker run --platform linux/amd64 --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -logtostderror

--- a/node/coinstacks/dogecoin/indexer/Makefile
+++ b/node/coinstacks/dogecoin/indexer/Makefile
@@ -2,9 +2,9 @@ IMAGE = blockbook
 PACKAGER = $(shell id -u):$(shell id -g)
 
 gen-config:
-	- docker run --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh dogecoin
+	- docker run --platform linux/amd64 --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh dogecoin
 
 run:
 	- mkdir -p db
 	- mkdir -p logs
-	- docker run --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs
+	- docker run --platform linux/amd64 --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs

--- a/node/coinstacks/ethereum/indexer/Makefile
+++ b/node/coinstacks/ethereum/indexer/Makefile
@@ -2,9 +2,9 @@ IMAGE = blockbook
 PACKAGER = $(shell id -u):$(shell id -g)
 
 gen-config:
-	- docker run --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh ethereum
+	- docker run --platform linux/amd64 --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh ethereum
 
 run:
 	- mkdir -p db
 	- mkdir -p logs
-	- docker run --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs
+	- docker run --platform linux/amd64 --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs

--- a/node/coinstacks/litecoin/indexer/Makefile
+++ b/node/coinstacks/litecoin/indexer/Makefile
@@ -2,9 +2,9 @@ IMAGE = blockbook
 PACKAGER = $(shell id -u):$(shell id -g)
 
 gen-config:
-	- docker run --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh litecoin
+	- docker run --platform linux/amd64 --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh litecoin
 
 run:
 	- mkdir -p db
 	- mkdir -p logs
-	- docker run --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs
+	- docker run --platform linux/amd64 --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -v "$(CURDIR)/logs:/logs" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -log_dir=/logs

--- a/node/coinstacks/optimism/indexer/Makefile
+++ b/node/coinstacks/optimism/indexer/Makefile
@@ -2,8 +2,8 @@ IMAGE = blockbook
 PACKAGER = $(shell id -u):$(shell id -g)
 
 gen-config:
-	- docker run --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh optimism
+	- docker run --platform linux/amd64 --rm -t -e PACKAGER=$(PACKAGER) -v "$(CURDIR):/out" $(IMAGE) ./generate-config.sh optimism
 
 run:
 	- mkdir -p db
-	- docker run --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -logtostderror
+	- docker run --platform linux/amd64 --rm -t -v "$(CURDIR)/config.json:/config.json" -v "$(CURDIR)/db:/db" -p 8000:8000 -p 8001:8001 $(IMAGE) /bin/blockbook -blockchaincfg=/config.json -datadir=/db -sync -internal=:8000 -public=:8001 -logtostderror

--- a/node/packages/blockbook/Makefile
+++ b/node/packages/blockbook/Makefile
@@ -3,7 +3,7 @@ GITCOMMIT = local
 BUILDTIME = local 
 
 build:
-	- docker build -t $(IMAGE) --build-arg GITCOMMIT=$(GITCOMMIT) --build-arg BUILDTIME=$(BUILDTIME) -f Dockerfile .
+	- docker build --platform linux/amd64 -t $(IMAGE) --build-arg GITCOMMIT=$(GITCOMMIT) --build-arg BUILDTIME=$(BUILDTIME) -f Dockerfile .
 
 clean:
 	- docker rmi $(IMAGE)

--- a/pulumi/src/docker.ts
+++ b/pulumi/src/docker.ts
@@ -59,7 +59,7 @@ export const buildAndPushImage = async (args: BuildAndPushImageArgs): Promise<vo
 
   dockerBuildArgs.push(args.context)
 
-  execSync(`${envs} docker build ${dockerBuildArgs.join(' ')}`, { stdio: 'inherit' })
+  execSync(`${envs} docker build --platform linux/amd64 ${dockerBuildArgs.join(' ')}`, { stdio: 'inherit' })
 
   if (!pulumi.runtime.isDryRun()) {
     dockerTags.forEach((tag) => execSync(`docker push ${tag}`))


### PR DESCRIPTION
When images are built locally on M1 macs, they're built and pushed with aarch64 architecture, which is incompatible with our nodes. This additional argument has no effect on x64 systems, but builds correct images when on a different architecture