### PR TITLE
feat: add hard reset of static peers on node start

### DIFF
--- a/node/coinstacks/bnbsmartchain/daemon/init.sh
+++ b/node/coinstacks/bnbsmartchain/daemon/init.sh
@@ -24,6 +24,26 @@ if [[ -n "$PEERS" && "$PEERS" != "null" ]]; then
   sed -i -e "s|StaticNodes.*|StaticNodes = $PEERS|" config.toml
 fi
 
+# hard reset existing peers
+hard_reset_peers() {
+  while true; do
+    if [[ -e "/data/geth.ipc" ]]; then
+      geth --exec '
+        for (i=0; i<admin.peers.length; i++) {
+          const enode = admin.peers[i].enode
+          if (admin.removePeer(enode)) {
+            console.log("sucessfully removed peer: ", enode)
+          } else {
+            console.log("failed to remove peer: ", enode)
+          }
+        }' attach /data/geth.ipc
+      break
+    else
+      sleep 1
+    fi
+  done
+}
+
 start() {
   geth \
     --config config.toml \
@@ -43,9 +63,10 @@ start() {
     --rpc.allow-unprotected-txs \
     --txlookuplimit 0 \
     --cache 8000 \
-    --ipcdisable \
     --nat none &
   PID="$!"
+
+  hard_reset_peers &
 }
 
 stop() {


### PR DESCRIPTION
https://github.com/bnb-chain/bsc/issues/1437

nodes have been getting stuck and the current suggested fix is to manual reset all static peers for the node. add `hard_reset_peers` startup func so we get a fresh peer state on boot to help combat the buggy peering logic on bsc...