### PR TITLE
feat: biweekly backups for the bad kids

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -603,6 +603,9 @@ aliases:
     api-cpu-limit: 300m
     api-memory-limit: 250Mi
     stateful-service-replicas: 1
+    stateful-service-backup: true
+    stateful-service-backup-schedule: "0 4 * * 3,6"
+    stateful-service-backup-count: 2
 
   - &polygon
     assetName: polygon
@@ -651,6 +654,9 @@ aliases:
     api-cpu-limit: 300m
     api-memory-limit: 250Mi
     stateful-service-replicas: 1
+    stateful-service-backup: true
+    stateful-service-backup-schedule: "0 4 * * 3,6"
+    stateful-service-backup-count: 2
 
 commands:
   precheck:


### PR DESCRIPTION
Because both polygon and bnb are more likely to fail than other chains, it would be wise to snapshot them more often and keep 2 backups instead of one. Sat and wed seem like good dates, as we're unlikely to not notice broken chains over a week's period