### PR TITLE
chore: preview coinstack changes to dev env on feature branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -935,7 +935,6 @@ jobs:
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
-            pulumi config
             pulumi << parameters.pulumi-command >> --suppress-outputs
 
   deploy-coinstack-go:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1131,6 +1131,32 @@ workflows:
           name: lint and test project
           <<: *only-feature
 
+
+  preview-development:
+    jobs:
+      ####### BITCOIN
+      - deploy-coinstack-node:
+          name: preview bitcoin-dev
+          organization: TAXISTAKE
+          pulumi-command: preview
+          <<: *bitcoin-dev
+          <<: *only-feature
+
+      ####### BITCOINCASH
+      - deploy-coinstack-node:
+          name: preview bitcoincash-dev
+          organization: TAXISTAKE
+          pulumi-command: preview
+          <<: *bitcoincash-dev
+          <<: *only-feature
+      ####### ETHEREUM
+      - deploy-coinstack-node:
+          name: preview ethereum-dev
+          organization: TAXISTAKE
+          pulumi-command: preview
+          <<: *ethereum-dev
+          <<: *only-feature
+
   deploy-development:
     jobs:
       - lint-and-test-persist:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1142,20 +1142,20 @@ workflows:
           <<: *bitcoin-dev
           <<: *only-feature
 
-      ####### BITCOINCASH
-      - deploy-coinstack-node:
-          name: preview bitcoincash-dev
-          organization: TAXISTAKE
-          pulumi-command: preview
-          <<: *bitcoincash-dev
-          <<: *only-feature
-      ####### ETHEREUM
-      - deploy-coinstack-node:
-          name: preview ethereum-dev
-          organization: TAXISTAKE
-          pulumi-command: preview
-          <<: *ethereum-dev
-          <<: *only-feature
+      # ####### BITCOINCASH
+      # - deploy-coinstack-node:
+      #     name: preview bitcoincash-dev
+      #     organization: TAXISTAKE
+      #     pulumi-command: preview
+      #     <<: *bitcoincash-dev
+      #     <<: *only-feature
+      # ####### ETHEREUM
+      # - deploy-coinstack-node:
+      #     name: preview ethereum-dev
+      #     organization: TAXISTAKE
+      #     pulumi-command: preview
+      #     <<: *ethereum-dev
+      #     <<: *only-feature
 
   deploy-development:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -935,6 +935,7 @@ jobs:
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
+            pulumi config
             pulumi << parameters.pulumi-command >> --suppress-outputs
 
   deploy-coinstack-go:


### PR DESCRIPTION
We currently only lint the config on our PR's - we could also add running `pulumi preview` against `dev` environment so that we can see what would the impact be after merging said changes. This should shorten our dev loop, reduce the amount of errors we introduce and doesn't add any additional cost. 