### PR TITLE
fix: grafana svc route

### DIFF
--- a/monitoring/src/grafana.ts
+++ b/monitoring/src/grafana.ts
@@ -58,7 +58,7 @@ export class Ingress extends pulumi.ComponentResource {
               services: [
                 {
                   kind: 'Service',
-                  name: `${name}-grafana`,
+                  name: `grafana`,
                   port: 80,
                   namespace: `${name}-monitoring`,
                 },


### PR DESCRIPTION
The `ingressroute` currently points at `unchained-grafana`, whereas the `svc` name is `grafana`