### PR TITLE
chore: increase prysm memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ aliases:
     service-image-2: gcr.io/prysmaticlabs/prysm/beacon-chain:v4.0.3
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
-    service-memory-limit-2: 8Gi
+    service-memory-limit-2: 12Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
     service-image-3: shapeshiftdao/unchained-blockbook:fdc2b86


### PR DESCRIPTION
if prysm falls behind, it pulls in copious amounts of data into memory to spin back up. increase mem to buffer and avoid OOM kill