### PR TITLE
chore: trace method for internal tx

### DIFF
--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -531,11 +531,10 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
             to: formatAddress(call.action.to),
             value: value.toString(),
           }
-        } else return undefined
+        }
+        return null
       })
-      .filter((tx) => tx !== undefined) as InternalTx[]
-
-    console.log(`Internal txs:`, txs)
+      .filter((tx): tx is InternalTx => tx !== null)
 
     return txs
   }
@@ -563,8 +562,6 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       return this.fetchInternalTxsDebug(txid, retryCount)
     }
 
-    console.log(`Internal txs:`, data.result)
-
     const callStack = data.result as DebugCallStack
 
     const processCallStack = (
@@ -576,9 +573,6 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       calls.forEach((call) => {
         const value = new BigNumber(call.value ?? 0)
         const gas = new BigNumber(call.gas)
-
-        console.log(`Call values:`)
-        console.log(call.from, call.to, value.toString(), gas.toString())
 
         if (value.gt(0) && gas.gt(0)) {
           txs.push({
@@ -593,9 +587,6 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
 
       return txs.length ? txs : undefined
     }
-
-    console.log(`Call stack:`, callStack.calls?.length)
-
     return processCallStack(callStack.calls)
   }
 

--- a/node/coinstacks/common/api/src/evm/types.ts
+++ b/node/coinstacks/common/api/src/evm/types.ts
@@ -29,27 +29,6 @@ export interface NodeBlock {
   uncles: Array<string>
 }
 
-// action: {
-//   callType: 'call',
-//   from: '0xd7f1dd5d49206349cae8b585fcb0ce3d96f1696f',
-//   gas: '0xcb07',
-//   input: '0xa9059cbb0000000000000000000000003728eca61872179220b806cb8c819ed6eefeb42500000000000000000000000000000000000000000000000000000000000003e2',
-//   to: '0xddafbb505ad214d7b80b1f830fccc89b60fb7a83',
-//   value: '0x0'
-// },
-// blockHash: '0x1946bbe1192c9af842a15871d18da5ef510ae19636bb2a7143e79e5f5d2d6642',
-// blockNumber: 28254455,
-// result: {
-//   gasUsed: '0x25f3',
-//   output: '0x0000000000000000000000000000000000000000000000000000000000000001'
-// },
-// subtraces: 1,
-// traceAddress: [ 4 ],
-// transactionHash: '0x7a418a4567e3d9a97aa8c7a93c8daa988b85cd12a174db94811cbf3dd1e660a4',
-// transactionPosition: 1,
-// type: 'call'
-// },
-
 export interface TraceCall {
   action: {
     callType: string

--- a/node/coinstacks/common/api/src/evm/types.ts
+++ b/node/coinstacks/common/api/src/evm/types.ts
@@ -29,7 +29,50 @@ export interface NodeBlock {
   uncles: Array<string>
 }
 
-export interface CallStack {
+// action: {
+//   callType: 'call',
+//   from: '0xd7f1dd5d49206349cae8b585fcb0ce3d96f1696f',
+//   gas: '0xcb07',
+//   input: '0xa9059cbb0000000000000000000000003728eca61872179220b806cb8c819ed6eefeb42500000000000000000000000000000000000000000000000000000000000003e2',
+//   to: '0xddafbb505ad214d7b80b1f830fccc89b60fb7a83',
+//   value: '0x0'
+// },
+// blockHash: '0x1946bbe1192c9af842a15871d18da5ef510ae19636bb2a7143e79e5f5d2d6642',
+// blockNumber: 28254455,
+// result: {
+//   gasUsed: '0x25f3',
+//   output: '0x0000000000000000000000000000000000000000000000000000000000000001'
+// },
+// subtraces: 1,
+// traceAddress: [ 4 ],
+// transactionHash: '0x7a418a4567e3d9a97aa8c7a93c8daa988b85cd12a174db94811cbf3dd1e660a4',
+// transactionPosition: 1,
+// type: 'call'
+// },
+
+export interface TraceCall {
+  action: {
+    callType: string
+    from: string
+    gas: string
+    input: string
+    to: string
+    value: string
+  }
+  blockHash: string
+  blockNumber: number
+  result: {
+    gasUsed: string
+    output: string
+  }
+  subtraces: number
+  traceAddress: Array<number>
+  transactionHash: string
+  transactionPosition: number
+  type: string
+}
+
+export interface DebugCallStack {
   type: string
   from: string
   to: string
@@ -38,7 +81,7 @@ export interface CallStack {
   gasUsed: string
   input: string
   output: string
-  calls?: Array<CallStack>
+  calls?: Array<DebugCallStack>
 }
 
 export interface ExplorerApiResponse<T> {

--- a/node/coinstacks/gnosis/api/src/app.ts
+++ b/node/coinstacks/gnosis/api/src/app.ts
@@ -61,7 +61,7 @@ const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) =
 }
 
 const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (blockbookTx) => {
-  const tx = await service.handleTransactionWithInternalTrace(blockbookTx)
+  const tx = await service.handleTransactionWithInternalTrace(blockbookTx, 'trace_transaction')
   const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
   const addresses = [...new Set([...getAddresses(blockbookTx), ...internalAddresses])]
 


### PR DESCRIPTION
Introduces an additional RPC method for fetching internal tx's. By default all existing transactions use the `debug` mode, while for `gnosis` we use the new `trace` mode to address current performance problems.

The trace module has been confirm to be much less resource heavy. The memory usage never spiked over 1 MB after the change. 

Local test result with Gnosis:
![Zrzut ekranu 2023-06-2 o 18 29 22](https://github.com/shapeshift/unchained/assets/5132069/96bfbdf6-c2a1-4744-907e-780599cb2a7d)

