### PR TITLE
chore: upgrade dogecoin v1.14.5 -> v1.14.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ aliases:
     api-memory-limit: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: greenbigfrog/dogecoin:1.14.5
+    service-image-1: shapeshiftdao/dogecoin:1.14.6
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 4Gi
@@ -373,7 +373,7 @@ aliases:
     service-image-2: shapeshiftdao/unchained-blockbook:fdc2b86
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
-    service-memory-limit-2: 12Gi
+    service-memory-limit-2: 16Gi
     service-storage-size-2: 250Gi
 
   - &dogecoin-dev

--- a/node/coinstacks/dogecoin/daemon/Dockerfile
+++ b/node/coinstacks/dogecoin/daemon/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:bullseye-slim
+
+RUN apt-get update -y \
+  	&& apt-get install -y curl jq wget \
+  	&& apt-get clean \
+  	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG VERSION
+
+RUN wget https://github.com/dogecoin/dogecoin/releases/download/v${VERSION}/dogecoin-${VERSION}-x86_64-linux-gnu.tar.gz \
+	&& tar -xzf dogecoin-${VERSION}-x86_64-linux-gnu.tar.gz \
+	&& mv dogecoin-${VERSION}/bin/dogecoind /usr/local/bin/dogecoind
+
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+
+ENTRYPOINT ["dogecoind"]


### PR DESCRIPTION
https://github.com/dogecoin/dogecoin/releases/tag/v1.14.6

- also increases blockbook memory more (still seeing OOM kills)