### PR TITLE
chore: update configs to resolve unchained alerts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -885,11 +885,11 @@ jobs:
             pulumi config set --path unchained:common.eks.traefik.autoscaling.enabled true
             pulumi config set --path unchained:common.eks.traefik.autoscaling.memoryThreshold 50
             pulumi config set --path unchained:common.eks.traefik.autoscaling.cpuThreshold 80
-            pulumi config set --path unchained:common.eks.traefik.autoscaling.maxReplicas 20
+            pulumi config set --path unchained:common.eks.traefik.autoscaling.maxReplicas 25
             pulumi config set --path unchained:common.eks.traefik.autoscaling.minReplicas 5
             pulumi config set --path unchained:common.eks.traefik.replicas 5
             pulumi config set --path unchained:common.eks.traefik.resources.cpu 300m
-            pulumi config set --path unchained:common.eks.traefik.resources.memory 512Mi
+            pulumi config set --path unchained:common.eks.traefik.resources.memory 1Gi
             pulumi config set --path unchained:common.eks.traefik.whitelist[0] 173.245.48.0/20
             pulumi config set --path unchained:common.eks.traefik.whitelist[1] 103.21.244.0/22
             pulumi config set --path unchained:common.eks.traefik.whitelist[2] 103.22.200.0/22

--- a/monitoring/my-kube-prometheus/unchained-kube-promstack.jsonnet
+++ b/monitoring/my-kube-prometheus/unchained-kube-promstack.jsonnet
@@ -52,6 +52,14 @@ local kp =
       ),
     },
     kubeStateMetrics+:: {
+      _config+: {
+        kubeRbacProxyMain:: {
+          resources+: {
+            limits+: { cpu: '100m' },
+            requests+: { cpu: '50m' },
+          }
+        }
+      },
       deployment+: {
         spec+: {
           template+: {

--- a/pulumi/src/ipfs/ipfs.ts
+++ b/pulumi/src/ipfs/ipfs.ts
@@ -94,8 +94,8 @@ export function deployIpfs({ namespace, provider, domain, additionalDomain }: Ip
           ],
           resources: {
             limits: {
-              cpu: '100m',
-              memory: '128Mi',
+              cpu: '250m',
+              memory: '512Mi',
             },
           },
         },


### PR DESCRIPTION
- traefik looks to be a bit overloaded, increase memory and allow further scaling if needed
- increase ipfs node resources
- increase kube state metrics proxy resources (configured via promstack.jsonnet)