### PR TITLE
chore: upgrade nodes to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: ethereum/client-go:v1.12.0
+    service-image-1: ethereum/client-go:v1.12.2
     service-cpu-limit-1: "4"
     service-cpu-request-1: "2"
     service-memory-limit-1: 32Gi
@@ -253,7 +253,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: shapeshiftdao/cosmoshub:v10.0.2
+    service-image-1: shapeshiftdao/cosmoshub:v11.0.0
     service-cpu-limit-1: "4"
     service-cpu-request-1: "2"
     service-memory-limit-1: 32Gi
@@ -325,7 +325,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: avaplatform/avalanchego:v1.10.7
+    service-image-1: avaplatform/avalanchego:v1.10.8
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 12Gi
@@ -501,7 +501,7 @@ aliases:
     service-memory-limit-2: 8Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
-    service-image-3: registry.gitlab.com/thorchain/midgard:2.16.1
+    service-image-3: registry.gitlab.com/thorchain/midgard:2.16.2
     service-cpu-limit-3: 500m
     service-cpu-request-3: 250m
     service-memory-limit-3: 1Gi
@@ -542,7 +542,7 @@ aliases:
     service-memory-limit-1: 24Gi
     service-storage-size-1: 500Gi
     service-name-2: op-node
-    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.1.1
+    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.1.2
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 2Gi


### PR DESCRIPTION
https://github.com/cosmos/gaia/releases/tag/v11.0.0
https://github.com/ethereum/go-ethereum/releases/tag/v1.12.2
https://github.com/ava-labs/avalanchego/releases/tag/v1.10.8
https://gitlab.com/thorchain/midgard/-/releases/2.16.2
https://github.com/ethereum-optimism/optimism/releases/tag/v1.1.2
