### PR TITLE
chore: omit http metrics on non /api/v1 and 404 requests

### DIFF
--- a/go/pkg/api/middleware.go
+++ b/go/pkg/api/middleware.go
@@ -46,10 +46,11 @@ func Logger(prometheus *metrics.Prometheus) mux.MiddlewareFunc {
 
 			statusLogger := log.WithFields(log.Fields{"method": r.Method, "statusCode": sw.status, "responseTime": duration.String()})
 
-			labels := metrics.Labels{"method": r.Method, "route": r.RequestURI, "statusCode": strconv.Itoa(sw.status)}
-
-			prometheus.Metrics.HTTPRequestCounter.With(labels).Inc()
-			prometheus.Metrics.HTTPRequestDurationSeconds.With(labels).Observe(duration.Seconds())
+			if strings.HasPrefix(r.RequestURI, "/api/v1/") || sw.status != 404 {
+				labels := metrics.Labels{"method": r.Method, "route": r.RequestURI, "statusCode": strconv.Itoa(sw.status)}
+				prometheus.Metrics.HTTPRequestCounter.With(labels).Inc()
+				prometheus.Metrics.HTTPRequestDurationSeconds.With(labels).Observe(duration.Seconds())
+			}
 
 			if sw.status < http.StatusOK || sw.status >= http.StatusBadRequest {
 				statusLogger.Errorf("%s", r.RequestURI)

--- a/node/coinstacks/common/api/src/middleware.ts
+++ b/node/coinstacks/common/api/src/middleware.ts
@@ -57,12 +57,12 @@ export const metrics =
     const end = prometheus.metrics.httpRequestDurationSeconds.startTimer()
 
     res.on('finish', () => {
-      prometheus.metrics.httpRequestCounter.inc(
-        { method: req.method, route: req.originalUrl ?? req.url, statusCode: res.statusCode },
-        1
-      )
+      const route = req.originalUrl ?? req.url
 
-      end({ method: req.method, route: req.originalUrl ?? req.url, statusCode: res.statusCode })
+      if (!route.startsWith('/api/v1/') || res.statusCode === 404) return
+
+      prometheus.metrics.httpRequestCounter.inc({ method: req.method, route, statusCode: res.statusCode }, 1)
+      end({ method: req.method, route, statusCode: res.statusCode })
     })
 
     next()


### PR DESCRIPTION
- reduce metric cardinality