### PR TITLE
chore: update polygon snapshot recovery

### DIFF
--- a/node/coinstacks/polygon/pulumi/index.ts
+++ b/node/coinstacks/polygon/pulumi/index.ts
@@ -17,7 +17,7 @@ export = async (): Promise<Outputs> => {
           ...service,
           env: {
             NETWORK: config.network,
-            SNAPSHOT: 'https://snapshot-download.polygon.technology/bor-mainnet-incremental-compiled-files.txt',
+            SNAPSHOT: 'https://snapshot-download.polygon.technology/snapdown.sh',
           },
           ports: {
             'daemon-rpc': { port: 8545 },
@@ -39,7 +39,7 @@ export = async (): Promise<Outputs> => {
           },
           env: {
             ETH_RPC_URL: `http://ethereum-svc.${namespace}.svc.cluster.local:8545`,
-            SNAPSHOT: 'https://snapshot-download.polygon.technology/heimdall-mainnet-incremental-compiled-files.txt',
+            SNAPSHOT: 'https://snapshot-download.polygon.technology/snapdown.sh',
           },
           startupProbe: { periodSeconds: 30, failureThreshold: 60, timeoutSeconds: 10 },
           livenessProbe: { periodSeconds: 30, failureThreshold: 5, timeoutSeconds: 10 },


### PR DESCRIPTION
Polygon has changed their snapshot recovery strategy yet again invalidating our previous logic. Conveniently, they have provided a script to manage this, however, it uses aria2c for downloading the incremental snapshots which requires increased volume size to keep the compressed files on disk before tarring them. I am hoping that we still have enough buffer for this to work, otherwise we have two options:
1. Increase the volume size to support snapshot recovery knowing it will be over provisioned and costing us more money. (we can always migrate the data to a smaller volume, but this will take a lot of extra time and be a PITA)
2. Build our own recovery script that attempts to chunk the download/extract to cut down on volume usage