### PR TITLE
fix: omit 0 gas price and allow 1 gwei broadcast

### DIFF
--- a/node/coinstacks/bnbsmartchain/api/src/controller.ts
+++ b/node/coinstacks/bnbsmartchain/api/src/controller.ts
@@ -210,14 +210,22 @@ export class BNBSmartChain extends Controller implements BaseAPI, API {
    */
   @Example<GasFees>({
     gasPrice: '3000000000',
+    baseFeePerGas: '0',
+    maxPriorityFeePerGas: '3000000000',
     slow: {
-      gasPrice: '1950000000',
+      gasPrice: '1800000000',
+      maxFeePerGas: '2200000000',
+      maxPriorityFeePerGas: '2200000000',
     },
     average: {
-      gasPrice: '3005600001',
+      gasPrice: '3039050000',
+      maxFeePerGas: '2925000000',
+      maxPriorityFeePerGas: '2925000000',
     },
     fast: {
-      gasPrice: '6082233092',
+      gasPrice: '5187055981',
+      maxFeePerGas: '3524000000',
+      maxPriorityFeePerGas: '3524000000',
     },
   })
   @Response<InternalServerError>(500, 'Internal Server Error')

--- a/node/coinstacks/bnbsmartchain/api/src/swagger.json
+++ b/node/coinstacks/bnbsmartchain/api/src/swagger.json
@@ -856,14 +856,22 @@
 									"Example 1": {
 										"value": {
 											"gasPrice": "3000000000",
+											"baseFeePerGas": "0",
+											"maxPriorityFeePerGas": "3000000000",
 											"slow": {
-												"gasPrice": "1950000000"
+												"gasPrice": "1800000000",
+												"maxFeePerGas": "2200000000",
+												"maxPriorityFeePerGas": "2200000000"
 											},
 											"average": {
-												"gasPrice": "3005600001"
+												"gasPrice": "3039050000",
+												"maxFeePerGas": "2925000000",
+												"maxPriorityFeePerGas": "2925000000"
 											},
 											"fast": {
-												"gasPrice": "6082233092"
+												"gasPrice": "5187055981",
+												"maxFeePerGas": "3524000000",
+												"maxPriorityFeePerGas": "3524000000"
 											}
 										}
 									}

--- a/node/coinstacks/bnbsmartchain/daemon/init.sh
+++ b/node/coinstacks/bnbsmartchain/daemon/init.sh
@@ -76,6 +76,7 @@ start() {
     --syncmode full \
     --maxpeers 200 \
     --rpc.allow-unprotected-txs \
+    --txpool.pricelimit 1 \
     --txlookuplimit 0 \
     --cache 8000 \
     --nat none &

--- a/node/coinstacks/common/api/src/evm/gasOracle.ts
+++ b/node/coinstacks/common/api/src/evm/gasOracle.ts
@@ -177,8 +177,10 @@ export class GasOracle {
 
       const txFees = block.transactions.reduce<TxFees>(
         (txFees, tx) => {
-          tx.gasPrice && txFees.gasPrices.push(Number(tx.gasPrice))
-          tx.maxPriorityFeePerGas && txFees.maxPriorityFees.push(Number(tx.maxPriorityFeePerGas))
+          tx.gasPrice && Number(tx.gasPrice) && txFees.gasPrices.push(Number(tx.gasPrice))
+          tx.maxPriorityFeePerGas &&
+            Number(tx.maxPriorityFeePerGas) &&
+            txFees.maxPriorityFees.push(Number(tx.maxPriorityFeePerGas))
           return txFees
         },
         { gasPrices: [], maxPriorityFees: [] }


### PR DESCRIPTION
- validator txs don't cost any gas and throw off the gas oracle pricing
- new `config.toml` provided by bnb set min gas limit to 3 gwei, support 1 gwei min limit