### PR TITLE
feat: ebs gp3 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1200,7 +1200,7 @@ workflows:
       - deploy-dependencies:
           name: deploy dependencies
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - lint and test project (persist to workspace)
           <<: *only-develop
@@ -1208,7 +1208,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy bitcoin develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *bitcoin-dev
@@ -1217,7 +1217,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy dogecoin develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *dogecoin-dev
@@ -1226,7 +1226,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy litecoin develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *litecoin-dev
@@ -1235,7 +1235,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy bitcoincash develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *bitcoincash-dev
@@ -1244,7 +1244,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy ethereum develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *ethereum-dev
@@ -1253,7 +1253,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy avalanche develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *avalanche-dev
@@ -1262,7 +1262,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy optimism develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           etherscan-env-var: ETHERSCAN_API_KEY_OPTIMISM
           requires:
             - deploy dependencies
@@ -1272,7 +1272,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy bnbsmartchain develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           etherscan-env-var: ETHERSCAN_API_KEY_BSC
           requires:
             - deploy dependencies
@@ -1282,7 +1282,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy polygon develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           etherscan-env-var: ETHERSCAN_API_KEY_POLYGON
           requires:
             - deploy dependencies
@@ -1292,7 +1292,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy gnosis develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           etherscan-env-var: ETHERSCAN_API_KEY_GNOSIS
           requires:
             - deploy dependencies
@@ -1302,7 +1302,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy arbitrum develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           etherscan-env-var: ETHERSCAN_API_KEY_ARBITRUM
           requires:
             - deploy dependencies
@@ -1312,7 +1312,7 @@ workflows:
       - deploy-coinstack-node:
           name: deploy arbitrum nova develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           etherscan-env-var: ETHERSCAN_API_KEY_ARBITRUM_NOVA
           requires:
             - deploy dependencies
@@ -1322,7 +1322,7 @@ workflows:
       - deploy-coinstack-go:
           name: deploy cosmos develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *cosmos-dev
@@ -1331,7 +1331,7 @@ workflows:
       - deploy-coinstack-go:
           name: deploy thorchain develop
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *thorchain-dev
@@ -1340,7 +1340,7 @@ workflows:
       - deploy-monitoring-pulumi:
           name: deploy monitoring pulumi
           organization: TAXISTAKE
-          pulumi-command: up -f --yes
+          pulumi-command: preview
           requires:
             - deploy dependencies
           <<: *only-develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,15 @@ aliases:
     service-storage-size-1:
       type: string
       default: ""
+    service-storage-class-1:
+      type: string
+      default: "gp3"
+    service-storage-iops-1:
+      type: string
+      default: "3000"
+    service-storage-throughput-1:
+      type: string
+      default: "125"
     service-name-2:
       type: string
       default: ""
@@ -122,6 +131,15 @@ aliases:
     service-storage-size-2:
       type: string
       default: ""
+    service-storage-class-2:
+      type: string
+      default: "gp3"
+    service-storage-iops-2:
+      type: string
+      default: "3000"
+    service-storage-throughput-2:
+      type: string
+      default: "125"
     service-name-3:
       type: string
       default: ""
@@ -143,6 +161,15 @@ aliases:
     service-storage-size-3:
       type: string
       default: ""
+    service-storage-class-3:
+      type: string
+      default: "gp3"
+    service-storage-iops-3:
+      type: string
+      default: "3000"
+    service-storage-throughput-3:
+      type: string
+      default: "125"
 
   - &bitcoin
     assetName: bitcoin
@@ -250,11 +277,13 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: shapeshiftdao/cosmoshub:v13.0.1
+    service-image-1: shapeshiftdao/cosmoshub:v13.0.2
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 40Gi
     service-storage-size-1: 4000Gi
+    service-storage-iops-1: "12000"
+    service-storage-throughput-1: "250"
 
   - &cosmos-dev
     <<: *cosmos
@@ -291,6 +320,7 @@ aliases:
     service-cpu-request-1: "1"
     service-memory-limit-1: 8Gi
     service-storage-size-1: 5500Gi
+    service-storage-iops-1: "8000"
     service-name-2: indexer
     service-image-2: shapeshiftdao/unchained-blockbook:95ee9b5
     service-cpu-limit-2: "2"
@@ -455,6 +485,7 @@ aliases:
     service-cpu-request-1: "1"
     service-memory-limit-1: 12Gi
     service-storage-size-1: 3000Gi
+    service-storage-iops-1: "4500"
     service-name-2: timescaledb
     service-image-2: timescale/timescaledb:2.2.0-pg13
     service-cpu-request-2: "1"
@@ -497,13 +528,13 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101301.1
+    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101304.1
     service-cpu-limit-1: "4"
     service-cpu-request-1: "2"
     service-memory-limit-1: 24Gi
     service-storage-size-1: 1000Gi
     service-name-2: op-node
-    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.2.0
+    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.3.0
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 2Gi
@@ -544,12 +575,14 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: shapeshiftdao/bnb-smart-chain:v1.2.12
+    service-image-1: shapeshiftdao/bnb-smart-chain:v1.2.13
     service-cpu-limit-1: "8"
     service-cpu-request-1: "4"
     service-memory-limit-1: 72Gi
     service-memory-request-1: 48Gi
     service-storage-size-1: 5000Gi
+    service-storage-iops-1: "16000"
+    service-storage-throughput-1: "250"
     service-name-2: indexer
     service-image-2: shapeshiftdao/unchained-blockbook:95ee9b5
     service-cpu-limit-2: "4"
@@ -593,8 +626,10 @@ aliases:
     service-memory-request-1: 32Gi
     service-memory-limit-1: 48Gi
     service-storage-size-1: 4000Gi
+    service-storage-iops-1: "12000"
+    service-storage-throughput-1: "250"
     service-name-2: heimdall
-    service-image-2: 0xpolygon/heimdall:1.0.2
+    service-image-2: 0xpolygon/heimdall:1.0.3
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 2Gi
@@ -636,7 +671,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: nethermind/nethermind:1.21.1
+    service-image-1: nethermind/nethermind:1.22.0
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 6Gi
@@ -683,7 +718,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: offchainlabs/nitro-node:v2.1.2-4c55843
+    service-image-1: offchainlabs/nitro-node:v2.1.3-e815395
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 24Gi
@@ -724,7 +759,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: offchainlabs/nitro-node:v2.1.2-4c55843
+    service-image-1: offchainlabs/nitro-node:v2.1.3-e815395
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 16Gi
@@ -988,6 +1023,9 @@ jobs:
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-class-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageClassName << parameters.service-storage-class-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-iops-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageIops << parameters.service-storage-iops-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-throughput-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageThroughput << parameters.service-storage-throughput-1 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].name << parameters.service-name-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].image << parameters.service-image-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
@@ -995,6 +1033,9 @@ jobs:
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-class-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageClassName << parameters.service-storage-class-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-iops-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageIops << parameters.service-storage-iops-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-throughput-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageThroughput << parameters.service-storage-throughput-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].name << parameters.service-name-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].image << parameters.service-image-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
@@ -1002,6 +1043,9 @@ jobs:
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-class-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageClassName << parameters.service-storage-class-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-iops-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageIops << parameters.service-storage-iops-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-throughput-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageThroughput << parameters.service-storage-throughput-3 >>
             pulumi << parameters.pulumi-command >> --suppress-outputs
 
   deploy-coinstack-go:
@@ -1062,6 +1106,9 @@ jobs:
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].memoryLimit << parameters.service-memory-limit-1 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].memoryRequest << parameters.service-memory-request-1 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageSize << parameters.service-storage-size-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-class-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageClassName << parameters.service-storage-class-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-iops-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageIops << parameters.service-storage-iops-1 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-throughput-1 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[0].storageThroughput << parameters.service-storage-throughput-1 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].name << parameters.service-name-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].image << parameters.service-image-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].cpuLimit << parameters.service-cpu-limit-2 >>
@@ -1069,6 +1116,9 @@ jobs:
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].memoryLimit << parameters.service-memory-limit-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].memoryRequest << parameters.service-memory-request-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageSize << parameters.service-storage-size-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-class-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageClassName << parameters.service-storage-class-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-iops-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageIops << parameters.service-storage-iops-2 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-throughput-2 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[1].storageThroughput << parameters.service-storage-throughput-2 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-name-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].name << parameters.service-name-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-image-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].image << parameters.service-image-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-cpu-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].cpuLimit << parameters.service-cpu-limit-3 >>
@@ -1076,6 +1126,9 @@ jobs:
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-limit-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryLimit << parameters.service-memory-limit-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-memory-request-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].memoryRequest << parameters.service-memory-request-3 >>
             [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-size-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageSize << parameters.service-storage-size-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-class-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageClassName << parameters.service-storage-class-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-iops-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageIops << parameters.service-storage-iops-3 >>
+            [ << parameters.stateful-service-replicas >> -gt 0 ] && [ -n "<< parameters.service-storage-throughput-3 >>" ] && pulumi config set --path unchained:coinstack.statefulService.services[2].storageThroughput << parameters.service-storage-throughput-3 >>
             pulumi << parameters.pulumi-command >> --suppress-outputs
 
   deploy-monitoring-pulumi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,8 +571,8 @@ aliases:
     api-cpu-limit: "1"
     api-cpu-request: 500m
     api-cpu-threshold: 75
-    api-memory-limit: 500Mi
-    api-memory-request: 250Mi
+    api-memory-limit: 1Gi
+    api-memory-request: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
     service-image-1: shapeshiftdao/bnb-smart-chain:v1.2.13
@@ -616,8 +616,8 @@ aliases:
     api-cpu-limit: "1"
     api-cpu-request: 500m
     api-cpu-threshold: 75
-    api-memory-limit: 500Mi
-    api-memory-request: 250Mi
+    api-memory-limit: 1Gi
+    api-memory-request: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
     service-image-1: 0xpolygon/bor:1.0.6

--- a/docs/restore-pvc.yaml
+++ b/docs/restore-pvc.yaml
@@ -23,13 +23,16 @@ spec:
           values:
           - <us-east-2x>
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: ebs-csi-gp2
+  storageClassName: gp3
   volumeMode: Filesystem
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: <data-xxx-sts-0>
+  annotations:
+    ebs.csi.aws.com/iops: "<3000>"
+    ebs.csi.aws.com/throughput: "<125>"
   namespace: <namespace>
   labels:
     app: unchained
@@ -41,5 +44,5 @@ spec:
   resources:
     requests:
       storage: <200Gi>
-  storageClassName: ebs-csi-gp2
+  storageClassName: gp3
   volumeName: <data-xxx-sts-0-pv-dev>

--- a/go/coinstacks/thorchain/daemon/readiness.sh
+++ b/go/coinstacks/thorchain/daemon/readiness.sh
@@ -19,10 +19,16 @@ IS_SYNCING=$(echo $SYNCING | jq -r '.syncing')
 CATCHING_UP=$(echo $STATUS | jq -r '.result.sync_info.catching_up')
 NUM_PEERS=$(echo $NET_INFO | jq -r '.result.n_peers')
 
+status_curls=(
+  "curl -sf -m 3 https://rpc.ninerealms.com/status"
+  # referer header now required to avoid being blocked
+  "curl -sf -m 3 -H \"Referer: https://app.thorswap.finance\" https://rpc.thorswap.net/status"
+)
+
 if [[ $IS_SYNCING == false && $CATCHING_UP == false ]]; then
   if (( $NUM_PEERS > 0 )); then
     latest_block_height=$(echo $STATUS | jq -r '.result.sync_info.latest_block_height')
-    best_reference_block_height=$(get_best_reference_block_height https://rpc.ninerealms.com https://rpc.thorswap.net https://rpc.thorchain.liquify.com)
+    best_reference_block_height=$(get_best_reference_block_height_eval "${status_curls[@]}")
 
     # if node is reporting synced, double check against reference nodes
     reference_validation $latest_block_height $best_reference_block_height $BLOCK_HEIGHT_TOLERANCE

--- a/go/scripts/tendermint.sh
+++ b/go/scripts/tendermint.sh
@@ -4,7 +4,25 @@ get_best_reference_block_height() {
   local best_reference_block_height=0
 
   for reference_url in "$@"; do
-    local status=$(curl -sf $reference_url/status)
+    local status=$(curl -sf -m 3 $reference_url/status)
+
+    if [[ $status != "" ]]; then
+      local latest_block_height=$(echo $status | jq -r '.result.sync_info.latest_block_height')
+
+      if (( $latest_block_height > $best_reference_block_height )); then
+        best_reference_block_height=$latest_block_height
+      fi
+    fi
+  done
+
+  echo $best_reference_block_height
+}
+
+get_best_reference_block_height_eval() {
+  local best_reference_block_height=0
+
+  for status_curl in "$@"; do
+    local status=$(eval "$status_curl")
 
     if [[ $status != "" ]]; then
       local latest_block_height=$(echo $status | jq -r '.result.sync_info.latest_block_height')

--- a/monitoring/src/index.ts
+++ b/monitoring/src/index.ts
@@ -37,9 +37,9 @@ export = async (): Promise<Outputs> => {
             storageSpec: {
               volumeClaimTemplate: {
                 spec: {
-                  storageClassName: 'ebs-csi-gp2',
+                  storageClassName: 'gp3',
                   accessModes: ['ReadWriteOnce'],
-                  resources: { requests: { storage: '100Gi' } },
+                  resources: { requests: { storage: '500Gi' } },
                 },
               },
             },
@@ -48,7 +48,7 @@ export = async (): Promise<Outputs> => {
         grafana: {
           adminPassword: process.env.GRAFANA_ADMIN_PASSWORD ?? 'unchained',
           deploymentStrategy: { type: 'Recreate' },
-          persistence: { enabled: true, size: '10Gi', storageClassName: 'ebs-csi-gp2' },
+          persistence: { enabled: true, size: '10Gi', storageClassName: 'gp3' },
           dashboardProviders: {
             'dashboardProviders.yaml': {
               apiVersion: 1,
@@ -92,7 +92,7 @@ export = async (): Promise<Outputs> => {
             storage: {
               volumeClaimTemplate: {
                 spec: {
-                  storageClassName: 'ebs-csi-gp2',
+                  storageClassName: 'gp3',
                   accessModes: ['ReadWriteOnce'],
                   resources: { requests: { storage: '50Gi' } },
                 },

--- a/monitoring/src/index.ts
+++ b/monitoring/src/index.ts
@@ -36,10 +36,16 @@ export = async (): Promise<Outputs> => {
             retention: '60d',
             storageSpec: {
               volumeClaimTemplate: {
+                metadata: {
+                  annotations: {
+                    'ebs.csi.aws.com/iops': '3000',
+                    'ebs.csi.aws.com/throughput': '125',
+                  },
+                },
                 spec: {
                   storageClassName: 'gp3',
                   accessModes: ['ReadWriteOnce'],
-                  resources: { requests: { storage: '500Gi' } },
+                  resources: { requests: { storage: '1000Gi' } },
                 },
               },
             },
@@ -91,6 +97,12 @@ export = async (): Promise<Outputs> => {
           alertmanagerSpec: {
             storage: {
               volumeClaimTemplate: {
+                metadata: {
+                  annotations: {
+                    'ebs.csi.aws.com/iops': '3000',
+                    'ebs.csi.aws.com/throughput': '125',
+                  },
+                },
                 spec: {
                   storageClassName: 'gp3',
                   accessModes: ['ReadWriteOnce'],

--- a/node/scripts/evm.sh
+++ b/node/scripts/evm.sh
@@ -4,7 +4,7 @@ get_best_reference_block_number() {
   local best_reference_block_number=0
 
   for reference_url in "$@"; do
-    local eth_blockNumber=$(curl -sf -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' -H 'Content-Type: application/json' $reference_url)
+    local eth_blockNumber=$(curl -sf -m 3 -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' -H 'Content-Type: application/json' $reference_url)
 
     if [[ $eth_blockNumber != "" ]]; then
       local current_block_number_hex=$(echo $eth_blockNumber | jq -r '.result')

--- a/pulumi/package.json
+++ b/pulumi/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
-    "@shapeshiftoss/cluster-launcher": "^0.19.0",
+    "@shapeshiftoss/cluster-launcher": "^0.20.1",
     "commander": "^10.0.0",
     "figlet": "^1.5.2"
   },

--- a/pulumi/src/index.ts
+++ b/pulumi/src/index.ts
@@ -54,6 +54,8 @@ export interface Port extends k8s.types.input.core.v1.ServicePort {
   stripPathPrefix?: boolean
 }
 
+export type StorageClass = 'gp2' | 'gp3'
+
 export interface ServiceConfig {
   cpuLimit: string
   cpuRequest?: string
@@ -62,6 +64,27 @@ export interface ServiceConfig {
   memoryRequest?: string
   name: string
   storageSize: string
+  /**
+   * **Only applicable for gp3 volumes**
+   *
+   * - Baseline: 3000 IOPS
+   * - Max: 16000 IOPS
+   * - Additional provision ratio: 500 IOPS per GiB max (ex. 500 IOPS per GiB × 32 GiB = 16000 IOPS)
+   *
+   * _if no value is specified, the gp2 equivalent will be used_
+   **/
+  storageIops?: string
+  /**
+   * **Only applicable for gp3 volumes**
+   *
+   * - Baseline: 125 MiB/s
+   * - Max: 1000 MiB/s
+   * - Additional provision ratio: 0.25 MiB/s per IOPS max (ex. 4000 IOPS × 0.25 MiB/s per IOPS = 1,000 MiB/s)
+   *
+   * _if no value is specified, the gp2 max burstable equivalent will be used_
+   **/
+  storageThroughput?: string
+  storageClassName?: StorageClass
 }
 
 export interface CoinServiceArgs extends ServiceConfig {

--- a/pulumi/src/ipfs/ipfs.ts
+++ b/pulumi/src/ipfs/ipfs.ts
@@ -187,7 +187,13 @@ export function deployIpfs({ namespace, provider, domain, additionalDomain }: Ip
         template: podSpec,
         volumeClaimTemplates: [
           {
-            metadata: { name: 'cluster-storage' },
+            metadata: {
+              name: 'cluster-storage',
+              annotations: {
+                'ebs.csi.aws.com/iops': '3000',
+                'ebs.csi.aws.com/throughput': '125',
+              },
+            },
             spec: {
               accessModes: ['ReadWriteOnce'],
               storageClassName: 'gp3',
@@ -197,7 +203,13 @@ export function deployIpfs({ namespace, provider, domain, additionalDomain }: Ip
             },
           },
           {
-            metadata: { name: 'ipfs-storage' },
+            metadata: {
+              name: 'ipfs-storage',
+              annotations: {
+                'ebs.csi.aws.com/iops': '3000',
+                'ebs.csi.aws.com/throughput': '125',
+              },
+            },
             spec: {
               accessModes: ['ReadWriteOnce'],
               storageClassName: 'gp3',

--- a/pulumi/src/ipfs/ipfs.ts
+++ b/pulumi/src/ipfs/ipfs.ts
@@ -190,7 +190,7 @@ export function deployIpfs({ namespace, provider, domain, additionalDomain }: Ip
             metadata: { name: 'cluster-storage' },
             spec: {
               accessModes: ['ReadWriteOnce'],
-              storageClassName: 'ebs-csi-gp2',
+              storageClassName: 'gp3',
               resources: {
                 requests: { storage: '5Gi' },
               },
@@ -200,7 +200,7 @@ export function deployIpfs({ namespace, provider, domain, additionalDomain }: Ip
             metadata: { name: 'ipfs-storage' },
             spec: {
               accessModes: ['ReadWriteOnce'],
-              storageClassName: 'ebs-csi-gp2',
+              storageClassName: 'gp3',
               resources: {
                 requests: { storage: '200Gi' },
               },

--- a/pulumi/src/statefulService.ts
+++ b/pulumi/src/statefulService.ts
@@ -171,14 +171,26 @@ export function createCoinService(args: CoinServiceArgs, assetName: string): Ser
     containers.push(monitorContainer)
   }
 
+  const storageClassName = args.storageClassName ?? 'gp3'
+
   const volumeClaimTemplates = [
     {
       metadata: {
         name: `data-${args.name}`,
+        annotations: {
+          ...(storageClassName === 'gp3' &&
+            args.storageIops && {
+              'ebs.csi.aws.com/iops': args.storageIops,
+            }),
+          ...(storageClassName === 'gp3' &&
+            args.storageThroughput && {
+              'ebs.csi.aws.com/throughput': args.storageThroughput,
+            }),
+        },
       },
       spec: {
         accessModes: ['ReadWriteOnce'],
-        storageClassName: 'ebs-csi-gp2',
+        storageClassName,
         resources: {
           requests: {
             storage: args.storageSize,


### PR DESCRIPTION
In an effort to reduce the cost of the unchained infra, update all volumes from `gp2` to `gp3` which should result in a ~10% cost reduction across the board. This will also provide optional configuration for tuning iops and throughput parameters for nodes that struggle to stay in sync.

- update cluster launcher to support `gp3` volume types with newest version of `ebs-csi-driver`
- update all coinstacks to use `gp3` volumes with baseline defaults (coinstacks that struggle to stay in sync are using comparable iops/throughput as the `gp2` counterpart and will allow for further fine tuning)
- update any out of date nodes
- update volume restore yaml with `gp3` volume type