### PR TITLE
chore: update avalanche explorer api

### DIFF
--- a/node/coinstacks/avalanche/api/src/controller.ts
+++ b/node/coinstacks/avalanche/api/src/controller.ts
@@ -45,7 +45,7 @@ export const gasOracle = new GasOracle({ logger, provider, coinstack: 'avalanche
 export const service = new Service({
   blockbook,
   gasOracle,
-  explorerApiUrl: 'https://api.snowtrace.io/api',
+  explorerApiUrl: 'https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan/api',
   provider,
   logger,
   rpcUrl: RPC_URL,

--- a/node/coinstacks/common/api/src/evm/types.ts
+++ b/node/coinstacks/common/api/src/evm/types.ts
@@ -86,7 +86,23 @@ export interface ExplorerApiResponse<T> {
   result: T
 }
 
-export interface ExplorerInternalTx {
+export interface ExplorerInternalTxByHash {
+  index?: number
+  blockNumber: string
+  timeStamp: string
+  from: string
+  to: string
+  value: string
+  contractAddress: string
+  input: string
+  type: string
+  gas: string
+  gasUsed: string
+  isError: string
+  errCode: string
+}
+
+export interface ExplorerInternalTxByAddress {
   blockNumber: string
   timeStamp: string
   hash: string


### PR DESCRIPTION
api.snowtrace.io is being sunset on November 30th, use the routescan replacement for avalanche.

- internal tx types were updated to distinguish internal txs by address or tx hash
- additional filtering was added to remove non internal txs that were being returned from routescan...
- we will not need to update block explorer urls client side as https://snowtrace.io will be redirected to the new backend being hosted by Avascan on November 30th (https://twitter.com/avax/status/1719005686196322525)