### PR TITLE
chore: infra updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ aliases:
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 32Gi
-    service-storage-size-1: 1000Gi
+    service-storage-size-1: 1250Gi
     service-name-2: daemon-beacon
     service-image-2: gcr.io/prysmaticlabs/prysm/beacon-chain:v4.1.1
     service-cpu-limit-2: "2"
@@ -278,9 +278,9 @@ aliases:
     stateful-service-replicas: 2
     service-name-1: daemon
     service-image-1: shapeshiftdao/cosmoshub:v13.0.2
-    service-cpu-limit-1: "2"
-    service-cpu-request-1: "1"
-    service-memory-limit-1: 42Gi
+    service-cpu-limit-1: "4"
+    service-cpu-request-1: "2"
+    service-memory-limit-1: 48Gi
     service-storage-size-1: 4500Gi
     service-storage-iops-1: "16000"
     service-storage-throughput-1: "300"
@@ -315,10 +315,10 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: avaplatform/avalanchego:v1.10.16
+    service-image-1: avaplatform/avalanchego:v1.10.17
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
-    service-memory-limit-1: 8Gi
+    service-memory-limit-1: 10Gi
     service-storage-size-1: 5500Gi
     service-storage-iops-1: "8000"
     service-name-2: indexer
@@ -484,7 +484,7 @@ aliases:
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 12Gi
-    service-storage-size-1: 3000Gi
+    service-storage-size-1: 3250Gi
     service-storage-iops-1: "4500"
     service-name-2: timescaledb
     service-image-2: timescale/timescaledb:2.2.0-pg13
@@ -575,7 +575,7 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: shapeshiftdao/bnb-smart-chain:v1.2.13
+    service-image-1: shapeshiftdao/bnb-smart-chain:v1.3.4
     service-cpu-limit-1: "8"
     service-cpu-request-1: "4"
     service-memory-limit-1: 72Gi
@@ -620,11 +620,11 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: 0xpolygon/bor:1.1.0
-    service-cpu-limit-1: "8"
-    service-cpu-request-1: "4"
-    service-memory-request-1: 32Gi
-    service-memory-limit-1: 52Gi
+    service-image-1: 0xpolygon/bor:1.2.0
+    service-cpu-limit-1: "16"
+    service-cpu-request-1: "8"
+    service-memory-request-1: 48Gi
+    service-memory-limit-1: 72Gi
     service-storage-size-1: 4000Gi
     service-storage-iops-1: "16000"
     service-storage-throughput-1: "300"
@@ -671,7 +671,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: nethermind/nethermind:1.22.0
+    service-image-1: nethermind/nethermind:1.23.0
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 6Gi
@@ -680,7 +680,7 @@ aliases:
     service-image-2: sigp/lighthouse:v4.5.0
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
-    service-memory-limit-2: 2Gi
+    service-memory-limit-2: 4Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
     service-image-3: shapeshiftdao/unchained-blockbook:gnosis-f21acf1

--- a/node/coinstacks/bitcoin/pulumi/index.ts
+++ b/node/coinstacks/bitcoin/pulumi/index.ts
@@ -25,7 +25,6 @@ export = async (): Promise<Outputs> => {
         return {
           ...service,
           ...defaultBlockbookServiceArgs,
-          command: [...defaultBlockbookServiceArgs.command, '-workers=1'],
           configMapData: { 'indexer-config.json': readFileSync('../indexer/config.json').toString() },
         }
       default:

--- a/node/coinstacks/bitcoincash/pulumi/index.ts
+++ b/node/coinstacks/bitcoincash/pulumi/index.ts
@@ -25,7 +25,6 @@ export = async (): Promise<Outputs> => {
         return {
           ...service,
           ...defaultBlockbookServiceArgs,
-          command: [...defaultBlockbookServiceArgs.command, '-workers=1'],
           configMapData: { 'indexer-config.json': readFileSync('../indexer/config.json').toString() },
         }
       default:

--- a/node/coinstacks/bnbsmartchain/daemon/init.sh
+++ b/node/coinstacks/bnbsmartchain/daemon/init.sh
@@ -78,7 +78,7 @@ start() {
     --maxpeers 200 \
     --rpc.allow-unprotected-txs \
     --txpool.pricelimit 1 \
-    --txlookuplimit 0 \
+    --history.transactions 0 \
     --cache 8000 \
     --nat none &
   PID="$!"

--- a/node/coinstacks/dogecoin/pulumi/index.ts
+++ b/node/coinstacks/dogecoin/pulumi/index.ts
@@ -25,7 +25,6 @@ export = async (): Promise<Outputs> => {
         return {
           ...service,
           ...defaultBlockbookServiceArgs,
-          command: [...defaultBlockbookServiceArgs.command, '-workers=1'],
           configMapData: { 'indexer-config.json': readFileSync('../indexer/config.json').toString() },
         }
       default:

--- a/node/coinstacks/ethereum/pulumi/index.ts
+++ b/node/coinstacks/ethereum/pulumi/index.ts
@@ -55,7 +55,6 @@ export = async (): Promise<Outputs> => {
         return {
           ...service,
           ...defaultBlockbookServiceArgs,
-          command: [...defaultBlockbookServiceArgs.command, '-workers=1'],
           configMapData: { 'indexer-config.json': readFileSync('../indexer/config.json').toString() },
         }
       default:

--- a/node/coinstacks/litecoin/pulumi/index.ts
+++ b/node/coinstacks/litecoin/pulumi/index.ts
@@ -22,7 +22,6 @@ export = async (): Promise<Outputs> => {
         return {
           ...service,
           ...defaultBlockbookServiceArgs,
-          command: [...defaultBlockbookServiceArgs.command, '-workers=1'],
           configMapData: { 'indexer-config.json': readFileSync('../indexer/config.json').toString() },
         }
       default:

--- a/node/coinstacks/polygon/daemon/init.sh
+++ b/node/coinstacks/polygon/daemon/init.sh
@@ -16,10 +16,8 @@ if [ -n "$SNAPSHOT" ] && [ ! -d "$CHAINDATA_DIR" ]; then
   curl -L $SNAPSHOT | bash -s -- --network mainnet --client bor --extract-dir $CHAINDATA_DIR --validate-checksum true
 fi
 
-if [ ! -f "$DATA_DIR/bor/genesis.json" ]; then
-  # copy genesis file
-  cp /var/lib/bor/genesis-mainnet-v1.json $DATA_DIR/bor/genesis.json
-fi
+# copy genesis file
+cp /var/lib/bor/genesis-mainnet-v1.json $DATA_DIR/bor/genesis.json
 
 start() {
   bor server \

--- a/node/coinstacks/polygon/pulumi/index.ts
+++ b/node/coinstacks/polygon/pulumi/index.ts
@@ -49,7 +49,6 @@ export = async (): Promise<Outputs> => {
         return {
           ...service,
           ...defaultBlockbookServiceArgs,
-          command: [...defaultBlockbookServiceArgs.command, '-workers=1'],
           configMapData: { 'indexer-config.json': readFileSync('../indexer/config.json').toString() },
         }
       default:

--- a/node/packages/blockbook/src/constants.ts
+++ b/node/packages/blockbook/src/constants.ts
@@ -7,6 +7,7 @@ export const defaultBlockbookServiceArgs = {
     '-public=:8001',
     '-enablesubnewtx',
     '-logtostderr',
+    '-dbcache=268435456',
   ],
   ports: { public: { port: 8001 } },
   volumeMounts: [{ name: 'config-map', mountPath: '/config.json', subPath: 'indexer-config.json' }],


### PR DESCRIPTION
Updates:
- https://github.com/bnb-chain/bsc/releases/tag/v1.3.4
  - supports hardfork
  - replace `-txlookuplimit` with `-history.transactions`
- https://github.com/maticnetwork/bor/releases/tag/v1.2.0
- https://github.com/ava-labs/avalanchego/releases/tag/v1.10.17
- https://github.com/NethermindEth/nethermind/releases/tag/1.23.0

Polygon:
- increase memory (bor is just turning into a bloated pig that makes bsc look stable and lean :sob:)
- always pull in genesis file so we don't halt for the next hard fork

Blockbook:
- remove `-workers` flag because it turns out it has no effect on stay sync mode
- add `-dbcache` in an attempt to reduce memory footprint (seeing more and more OOM kills on blockbook instances)

Misc:
- right size resources and volumes