### PR TITLE
chore: increase bsc memory and update cosmos peering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,7 +567,7 @@ aliases:
     service-image-1: shapeshiftdao/bnb-smart-chain:v1.3.7
     service-cpu-limit-1: "16"
     service-cpu-request-1: "8"
-    service-memory-limit-1: 48Gi
+    service-memory-limit-1: 64Gi
     service-storage-size-1: 2500Gi
     service-name-2: indexer
     service-image-2: shapeshiftdao/unchained-blockbook:559cfbc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,7 +567,7 @@ aliases:
     service-image-1: shapeshiftdao/bnb-smart-chain:v1.3.7
     service-cpu-limit-1: "16"
     service-cpu-request-1: "8"
-    service-memory-limit-1: 64Gi
+    service-memory-limit-1: 72Gi
     service-storage-size-1: 2500Gi
     service-name-2: indexer
     service-image-2: shapeshiftdao/unchained-blockbook:559cfbc
@@ -608,7 +608,7 @@ aliases:
     service-image-1: 0xpolygon/bor:1.2.0
     service-cpu-limit-1: "8"
     service-cpu-request-1: "4"
-    service-memory-limit-1: 48Gi
+    service-memory-limit-1: 64Gi
     service-storage-size-1: 4000Gi
     service-storage-iops-1: "6000"
     service-storage-throughput-1: "300"

--- a/go/coinstacks/cosmos/daemon/init.sh
+++ b/go/coinstacks/cosmos/daemon/init.sh
@@ -6,7 +6,7 @@ start() {
   MONIKER=unchained \
   CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/chain.json \
   MAX_NUM_OUTBOUND_PEERS=200 \
-  P2P_SEEDS="ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:14956" \
+  P2P_SEEDS="ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:14956,8542cd7e6bf9d260fef543bc49e59be5a3fa9074@seed.publicnode.com:26656" \
   P2P_PERSISTENT_PEERS="" \
   OVERWRITE_SEEDS=1 \
   POLKACHU_NETWORK=cosmos \

--- a/go/coinstacks/cosmos/daemon/init.sh
+++ b/go/coinstacks/cosmos/daemon/init.sh
@@ -6,6 +6,8 @@ start() {
   MONIKER=unchained \
   CHAIN_JSON=https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/chain.json \
   MAX_NUM_OUTBOUND_PEERS=200 \
+  P2P_SEEDS="ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:14956" \
+  P2P_PERSISTENT_PEERS="" \
   OVERWRITE_SEEDS=1 \
   POLKACHU_NETWORK=cosmos \
   run.sh gaiad start \


### PR DESCRIPTION
- bsc was OOM killing. increase memory to prevent this
- cosmos has been having issues staying synced. do not use persistent peers and just use a single stable polkachu peer