### PR TITLE
fix: resolves issues when running in docker on mac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,10 @@ services:
       context: ./node
       dockerfile: Dockerfile.local
     working_dir: /app/node
-    command: sh -c "yarn lerna run watch --scope @shapeshiftoss/* --parallel"
+    # the additional yarn install here allows for platform specific packages to be install in the container
+    # previously this would fail when copying over node_modules from the host on macos due to 
+    # @nx/nx-linux-arm64-musl not being installed
+    command: sh -c "yarn install && yarn lerna run watch --scope @shapeshiftoss/* --parallel"
     volumes:
       - ./:/app
 


### PR DESCRIPTION
Attempting to run lerna watch locally in docker would fail due to how we copied over node_modules into the linux container if using a mac.  Adding yarn install to the compose enforces that the platform specific version of @nx/nx-linux-arm64-musl is installed and seems to fix the issues. 