### PR TITLE
fix: do not filter traceId 0

### DIFF
--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -647,8 +647,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
 
     if (data.status === '0') return []
 
-    // filter out all 0 index trace ids as these are the normal initiating tx calls that are returned by routescan.io for some reason
-    return data.result.filter((internalTx) => internalTx.traceId !== '0')
+    return data.result
   }
 
   private async getTxs(


### PR DESCRIPTION
routescan fixed their api response for internal transactions and filtering out `traceId` 0 was actually invalid as there are transactions with a single callstack that are valid internal transactions that we should be detecting (thorchain outbound).