### PR TITLE
feat: improve thorchain deposit transaction parsing

### DIFF
--- a/go/coinstacks/thorchain/api/types.go
+++ b/go/coinstacks/thorchain/api/types.go
@@ -7,20 +7,21 @@ import (
 
 // ResultTx represents a tx_search ResultTx created from block_result block events
 type ResultTx struct {
-	Hash       string
-	Height     int64
-	Timestamp  int
-	Index      int
-	TxID       string
-	Fee        cosmos.Value
-	Events     cosmos.EventsByMsgIndex
-	Messages   []cosmos.Message
-	TypedEvent thorchain.TypedEvent
-	formatTx   func(tx *ResultTx) (*cosmos.Tx, error)
+	BlockHash   string
+	BlockHeight int64
+	Timestamp   int
+	Index       int
+	TxID        string
+	Memo        string
+	Fee         cosmos.Value
+	Events      cosmos.EventsByMsgIndex
+	Messages    []cosmos.Message
+	TypedEvent  thorchain.TypedEvent
+	formatTx    func(tx *ResultTx) (*cosmos.Tx, error)
 }
 
 func (r *ResultTx) GetHeight() int64 {
-	return r.Height
+	return r.BlockHeight
 }
 
 func (r *ResultTx) GetIndex() int {

--- a/go/coinstacks/thorchain/thorchain.go
+++ b/go/coinstacks/thorchain/thorchain.go
@@ -1,5 +1,9 @@
 package thorchain
 
+import "github.com/shapeshift/unchained/internal/log"
+
+var logger = log.WithoutFields()
+
 // map thorchain assets to native tendermint denoms
 var assetToDenom = map[string]string{
 	"THOR.RUNE": "rune",


### PR DESCRIPTION
- cleanup synthetic `ResultTx` fields for clarity
- use correct `to` address for deposit messages that result in a `withraw` or `refund` event
- add synthetic outbound messages for multi action transactions (ex. lp withdrawal contains the withdrawal request and the withdrawal outbound transfer)