### PR TITLE
fix: gnosis indexer patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -674,7 +674,7 @@ aliases:
     service-memory-limit-2: 4Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
-    service-image-3: shapeshiftdao/unchained-blockbook:gnosis-de1a23e
+    service-image-3: shapeshiftdao/unchained-blockbook:gnosis-patch-bf15e46
     service-cpu-limit-3: "2"
     service-cpu-request-3: "1"
     service-memory-limit-3: 16Gi

--- a/node/coinstacks/gnosis/pulumi/index.ts
+++ b/node/coinstacks/gnosis/pulumi/index.ts
@@ -43,7 +43,9 @@ export = async (): Promise<Outputs> => {
           configMapData: { 'jwt.hex': readFileSync('../daemon/jwt.hex').toString() },
           volumeMounts: [{ name: 'config-map', mountPath: '/jwt.hex', subPath: 'jwt.hex' }],
           useMonitorContainer: true,
-          readinessProbe: { periodSeconds: 30, failureThreshold: 10 },
+          // Disable readiness probe while for gnosis indexer patch
+          //readinessProbe: { periodSeconds: 30, failureThreshold: 10 },
+          readinessProbe: { exec: undefined },
         }
       case 'indexer':
         return {


### PR DESCRIPTION
Blockbook is struggling to stay in sync for gnosis. This temp fix disables the readiness probe and uses the patched blockbook image that will serve data even if not in sync (balances will still be accurate as they are fetched on chain, but tx history can be off/behind).