### PR TITLE
chore: prod cutover to nownodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,9 +166,9 @@ aliases:
     assetName: bitcoin
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/bitcoin/pulumi
-    rpc-url: http://user:password@bitcoin-svc.unchained.svc.cluster.local:8332
-    indexer-url: http://bitcoin-svc.unchained.svc.cluster.local:8001
-    indexer-ws-url: ws://bitcoin-svc.unchained.svc.cluster.local:8001/websocket
+    indexer-url: https://btcbook.nownodes.io
+    indexer-ws-url: wss://btcbook.nownodes.io/wss
+    indexer-api-key: $NOW_NODES_API_KEY
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 6
@@ -207,9 +207,11 @@ aliases:
     assetName: ethereum
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/ethereum/pulumi
-    rpc-url: http://ethereum-svc.unchained.svc.cluster.local:8545
-    indexer-url: http://ethereum-svc.unchained.svc.cluster.local:8001
-    indexer-ws-url: ws://ethereum-svc.unchained.svc.cluster.local:8001/websocket
+    indexer-url: https://eth-blockbook.nownodes.io
+    indexer-ws-url: wss://eth-blockbook.nownodes.io/wss
+    indexer-api-key: $NOW_NODES_API_KEY
+    rpc-url: https://eth.nownodes.io
+    rpc-api-key: $NOW_NODES_API_KEY
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 6
@@ -555,9 +557,11 @@ aliases:
     assetName: bnbsmartchain
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/bnbsmartchain/pulumi
-    rpc-url: http://bnbsmartchain-svc.unchained.svc.cluster.local:8545
-    indexer-url: http://bnbsmartchain-svc.unchained.svc.cluster.local:8001
-    indexer-ws-url: ws://bnbsmartchain-svc.unchained.svc.cluster.local:8001/websocket
+    indexer-url: https://bsc-blockbook.nownodes.io
+    indexer-ws-url: wss://bsc-blockbook.nownodes.io/wss
+    indexer-api-key: $NOW_NODES_API_KEY
+    rpc-url: https://bsc.nownodes.io
+    rpc-api-key: $NOW_NODES_API_KEY
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 6
@@ -698,9 +702,11 @@ aliases:
     assetName: arbitrum
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/arbitrum/pulumi
-    rpc-url: http://arbitrum-svc.unchained.svc.cluster.local:8547
-    indexer-url: http://arbitrum-svc.unchained.svc.cluster.local:8001
-    indexer-ws-url: ws://arbitrum-svc.unchained.svc.cluster.local:8001/websocket
+    indexer-url: https://arb-blockbook.nownodes.io
+    indexer-ws-url: wss://arb-blockbook.nownodes.io/wss
+    indexer-api-key: $NOW_NODES_API_KEY
+    rpc-url: https://arbitrum.nownodes.io
+    rpc-api-key: $NOW_NODES_API_KEY
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 6


### PR DESCRIPTION
Cut over remaining prod coinstacks to nownodes for currently supported chains