### PR TITLE
feat: evm block trace

### DIFF
--- a/node/coinstacks/arbitrum/api/src/app.ts
+++ b/node/coinstacks/arbitrum/api/src/app.ts
@@ -60,8 +60,20 @@ app.get('/', async (_, res) => {
 
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
-const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
-  const txs = await service.handleBlock(block.hash)
+const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
+  const blockbookTxs = await service.handleBlock(block.hash)
+  const internalTxs = await service.fetchInternalTxsByBlockDebug(block.hash)
+
+  const txs = blockbookTxs.map((t) => {
+    const tx = service.handleTransaction(t)
+    tx.internalTxs = internalTxs[t.txid]
+
+    const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
+    const addresses = [...new Set([...getAddresses(t), ...internalAddresses])]
+
+    return { addresses, tx }
+  })
+
   return { txs }
 }
 

--- a/node/coinstacks/arbitrum/api/src/app.ts
+++ b/node/coinstacks/arbitrum/api/src/app.ts
@@ -61,8 +61,10 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
 const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
-  const blockbookTxs = await service.handleBlock(block.hash)
-  const internalTxs = await service.fetchInternalTxsByBlockDebug(block.hash)
+  const [blockbookTxs, internalTxs] = await Promise.all([
+    service.handleBlock(block.hash),
+    service.fetchInternalTxsByBlockDebug(block.hash),
+  ])
 
   const txs = blockbookTxs.map((t) => {
     const tx = service.handleTransaction(t)

--- a/node/coinstacks/bnbsmartchain/api/src/app.ts
+++ b/node/coinstacks/bnbsmartchain/api/src/app.ts
@@ -63,8 +63,10 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
 const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
-  const blockbookTxs = await service.handleBlock(block.hash)
-  const internalTxs = await service.fetchInternalTxsByBlockDebug(block.hash)
+  const [blockbookTxs, internalTxs] = await Promise.all([
+    service.handleBlock(block.hash),
+    service.fetchInternalTxsByBlockDebug(block.hash),
+  ])
 
   const txs = blockbookTxs.map((t) => {
     const tx = service.handleTransaction(t)

--- a/node/coinstacks/bnbsmartchain/api/src/app.ts
+++ b/node/coinstacks/bnbsmartchain/api/src/app.ts
@@ -62,8 +62,20 @@ app.get('/', async (_, res) => {
 
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
-const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
-  const txs = await service.handleBlock(block.hash)
+const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
+  const blockbookTxs = await service.handleBlock(block.hash)
+  const internalTxs = await service.fetchInternalTxsByBlockDebug(block.hash)
+
+  const txs = blockbookTxs.map((t) => {
+    const tx = service.handleTransaction(t)
+    tx.internalTxs = internalTxs[t.txid]
+
+    const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
+    const addresses = [...new Set([...getAddresses(t), ...internalAddresses])]
+
+    return { addresses, tx }
+  })
+
   return { txs }
 }
 

--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -551,7 +551,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   }
 
   private processCallStackDebug = (calls?: Array<DebugCallStack>, txs: Array<InternalTx> = []): Array<InternalTx> => {
-    ;(calls ?? []).forEach((call) => {
+    calls?.forEach((call) => {
       const value = new BigNumber(call.value ?? 0)
       const gas = new BigNumber(call.gas)
 

--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -352,6 +352,61 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     }
   }
 
+  async fetchInternalTxsByBlockDebug(
+    blockHash: string,
+    retryCount = 0
+  ): Promise<Record<string, Array<InternalTx> | undefined>> {
+    const request: RPCRequest = {
+      jsonrpc: '2.0',
+      id: `debug_traceBlockByHash${blockHash}`,
+      method: 'debug_traceBlockByHash',
+      params: [blockHash, { tracer: 'callTracer' }],
+    }
+
+    const config = this.rpcApiKey ? { headers: { 'api-key': this.rpcApiKey } } : undefined
+    const { data } = await axiosWithRetry.post<RPCResponse>(this.rpcUrl, request, config)
+
+    if (!data.result) {
+      if (++retryCount >= 5)
+        throw new Error(`failed to get internalTransactions for block: ${blockHash}: ${data.error?.message}`)
+      await exponentialDelay(retryCount)
+      return this.fetchInternalTxsByBlockDebug(blockHash, retryCount)
+    }
+
+    const txs = data.result as Array<{ txHash: string; result: DebugCallStack }>
+
+    return txs.reduce<Record<string, Array<InternalTx> | undefined>>((prev, tx) => {
+      prev[tx.txHash] = this.processCallStackDebug(tx.result.calls)
+      return prev
+    }, {})
+  }
+
+  async fetchInternalTxsByBlockTrace(
+    blockHash: string,
+    retryCount = 0
+  ): Promise<Record<string, Array<InternalTx> | undefined>> {
+    const request: RPCRequest = {
+      jsonrpc: '2.0',
+      id: `trace_block${blockHash}`,
+      method: 'trace_block',
+      params: [blockHash],
+    }
+
+    const config = this.rpcApiKey ? { headers: { 'api-key': this.rpcApiKey } } : undefined
+    const { data } = await axiosWithRetry.post<RPCResponse>(this.rpcUrl, request, config)
+
+    if (!data.result) {
+      if (++retryCount >= 5)
+        throw new Error(`failed to get internalTransactions for block: ${blockHash}: ${data.error?.message}`)
+      await exponentialDelay(retryCount)
+      return this.fetchInternalTxsByBlockTrace(blockHash, retryCount)
+    }
+
+    const callStack = data.result as Array<TraceCall>
+
+    return this.processCallStackTrace(callStack)
+  }
+
   handleTransaction(tx: BlockbookTx): Tx {
     if (!tx.ethereumSpecific) throw new Error(`invalid blockbook evm transaction: ${tx.txid}`)
 
@@ -433,9 +488,9 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     const internalTxs = await (async () => {
       try {
         if (internalTxMethod === 'trace_transaction') {
-          return await this.fetchInternalTxsTrace(tx.txid)
+          return await this.fetchInternalTxsByTxTrace(tx.txid)
         } else {
-          return await this.fetchInternalTxsDebug(tx.txid)
+          return await this.fetchInternalTxsByTxDebug(tx.txid)
         }
       } catch (err) {
         return undefined
@@ -447,7 +502,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     return t
   }
 
-  private async fetchInternalTxsTrace(txid: string, retryCount = 0): Promise<Array<InternalTx> | undefined> {
+  private async fetchInternalTxsByTxTrace(txid: string, retryCount = 0): Promise<Array<InternalTx> | undefined> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
       id: `trace_transaction${txid}`,
@@ -458,36 +513,20 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     const config = this.rpcApiKey ? { headers: { 'api-key': this.rpcApiKey } } : undefined
     const { data } = await axiosWithRetry.post<RPCResponse>(this.rpcUrl, request, config)
 
-    if (data.error) throw new Error(`failed to get internalTransactions for txid: ${txid}: ${data.error.message}`)
-
-    // retry if no results are returned, this typically means we queried a node that hasn't indexed the data yet
     if (!data.result) {
-      if (++retryCount >= 5) throw new Error(`failed to get internalTransactions for txid: ${txid}`)
+      if (++retryCount >= 5)
+        throw new Error(`failed to get internalTransactions for txid: ${txid}: ${data.error?.message}`)
       await exponentialDelay(retryCount)
-      return this.fetchInternalTxsTrace(txid, retryCount)
+      return this.fetchInternalTxsByTxTrace(txid, retryCount)
     }
 
     const callStack = data.result as Array<TraceCall>
+    const txs = this.processCallStackTrace(callStack)[txid]
 
-    const txs = callStack.reduce<Array<InternalTx>>((prev, call) => {
-      const value = new BigNumber(call.action.value ?? 0)
-      const gas = new BigNumber(call.action.gas)
-
-      if (value.gt(0) && gas.gt(0)) {
-        prev.push({
-          from: formatAddress(call.action.from),
-          to: formatAddress(call.action.to),
-          value: value.toString(),
-        })
-      }
-
-      return prev
-    }, [])
-
-    return txs.length ? txs : undefined
+    return txs?.length ? txs : undefined
   }
 
-  private async fetchInternalTxsDebug(txid: string, retryCount = 0): Promise<Array<InternalTx> | undefined> {
+  private async fetchInternalTxsByTxDebug(txid: string, retryCount = 0): Promise<Array<InternalTx> | undefined> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
       id: `debug_traceTransaction${txid}`,
@@ -498,42 +537,55 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     const config = this.rpcApiKey ? { headers: { 'api-key': this.rpcApiKey } } : undefined
     const { data } = await axiosWithRetry.post<RPCResponse>(this.rpcUrl, request, config)
 
-    if (data.error) throw new Error(`failed to get internalTransactions for txid: ${txid}: ${data.error.message}`)
-
-    // retry if no results are returned, this typically means we queried a node that hasn't indexed the data yet
     if (!data.result) {
-      if (++retryCount >= 5) throw new Error(`failed to get internalTransactions for txid: ${txid}`)
+      if (++retryCount >= 5)
+        throw new Error(`failed to get internalTransactions for txid: ${txid}: ${data.error?.message}`)
       await exponentialDelay(retryCount)
-      return this.fetchInternalTxsDebug(txid, retryCount)
+      return this.fetchInternalTxsByTxDebug(txid, retryCount)
     }
 
     const callStack = data.result as DebugCallStack
+    const txs = this.processCallStackDebug(callStack.calls)
 
-    const processCallStack = (
-      calls?: Array<DebugCallStack>,
-      txs: Array<InternalTx> = []
-    ): Array<InternalTx> | undefined => {
-      if (!calls) return
+    return txs.length ? txs : undefined
+  }
 
-      calls.forEach((call) => {
-        const value = new BigNumber(call.value ?? 0)
-        const gas = new BigNumber(call.gas)
+  private processCallStackDebug = (calls?: Array<DebugCallStack>, txs: Array<InternalTx> = []): Array<InternalTx> => {
+    ;(calls ?? []).forEach((call) => {
+      const value = new BigNumber(call.value ?? 0)
+      const gas = new BigNumber(call.gas)
 
-        if (value.gt(0) && gas.gt(0)) {
-          txs.push({
-            from: formatAddress(call.from),
-            to: formatAddress(call.to),
-            value: value.toString(),
-          })
-        }
+      if (value.gt(0) && gas.gt(0)) {
+        txs.push({
+          from: formatAddress(call.from),
+          to: formatAddress(call.to),
+          value: value.toString(),
+        })
+      }
 
-        processCallStack(call.calls, txs)
+      this.processCallStackDebug(call.calls, txs)
+    })
+
+    return txs
+  }
+
+  private processCallStackTrace(callStack: Array<TraceCall>): Record<string, Array<InternalTx> | undefined> {
+    return callStack.reduce<Record<string, Array<InternalTx>>>((prev, call) => {
+      if (!prev[call.transactionHash]) prev[call.transactionHash] = []
+
+      const value = new BigNumber(call.action.value ?? 0)
+      const gas = new BigNumber(call.action.gas)
+
+      if (!(value.gt(0) && gas.gt(0))) return prev
+
+      prev[call.transactionHash].push({
+        from: formatAddress(call.action.from),
+        to: formatAddress(call.action.to),
+        value: value.toString(),
       })
 
-      return txs.length ? txs : undefined
-    }
-
-    return processCallStack(callStack.calls)
+      return prev
+    }, {})
   }
 
   /**

--- a/node/coinstacks/common/api/src/registry.ts
+++ b/node/coinstacks/common/api/src/registry.ts
@@ -1,16 +1,19 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Logger } from '@shapeshiftoss/logger'
 import { ConnectionHandler } from './websocket'
 
 export type AddressFormatter = (address: string) => string
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export type BlockHandler<T = any, T2 = any> = (block: T) => Promise<{ txs: T2 }>
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export type TransactionHandler<T = any, T2 = any> = (tx: T) => Promise<{ addresses: Array<string>; tx: T2 }>
 
 export interface RegistryArgs {
   addressFormatter?: AddressFormatter
   blockHandler: BlockHandler
   transactionHandler: TransactionHandler
+}
+
+const isTxWithAddresses = (tx: unknown): tx is { addresses: Array<string>; tx: any } => {
+  return 'addresses' in (tx as { addresses: string; tx: any })
 }
 
 /**
@@ -117,7 +120,13 @@ export class Registry {
     try {
       const { txs } = await this.handleBlock(msg)
 
-      txs.forEach((tx: unknown) => this.onTransaction(tx))
+      txs.forEach((tx: unknown) => {
+        if (isTxWithAddresses(tx)) {
+          this.publishTransaction(tx.addresses, tx.tx)
+        } else {
+          this.onTransaction(tx)
+        }
+      })
     } catch (err) {
       this.logger.error(err, 'failed to handle block')
     }
@@ -128,19 +137,22 @@ export class Registry {
 
     try {
       const { addresses, tx } = await this.handleTransaction(msg)
-
-      addresses.forEach((address) => {
-        address = this.formatAddress(address)
-
-        if (!this.addresses[address]) return
-
-        for (const [id, connection] of this.addresses[address].entries()) {
-          const { subscriptionId } = Registry.fromId(id)
-          connection.publish(subscriptionId, address, tx)
-        }
-      })
+      this.publishTransaction(addresses, tx)
     } catch (err) {
       this.logger.error(err, 'failed to handle transaction')
     }
+  }
+
+  private publishTransaction(addresses: string[], tx: any) {
+    addresses.forEach((address) => {
+      address = this.formatAddress(address)
+
+      if (!this.addresses[address]) return
+
+      for (const [id, connection] of this.addresses[address].entries()) {
+        const { subscriptionId } = Registry.fromId(id)
+        connection.publish(subscriptionId, address, tx)
+      }
+    })
   }
 }

--- a/node/coinstacks/common/api/src/registry.ts
+++ b/node/coinstacks/common/api/src/registry.ts
@@ -1,19 +1,20 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Logger } from '@shapeshiftoss/logger'
 import { ConnectionHandler } from './websocket'
 
 export type AddressFormatter = (address: string) => string
-export type BlockHandler<T = any, T2 = any> = (block: T) => Promise<{ txs: T2 }>
-export type TransactionHandler<T = any, T2 = any> = (tx: T) => Promise<{ addresses: Array<string>; tx: T2 }>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type BlockHandler<T = any, T2 = Array<unknown>> = (block: T) => Promise<{ txs: T2 }>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TransactionHandler<T = any, T2 = unknown> = (tx: T) => Promise<{ addresses: Array<string>; tx: T2 }>
+
+const isTxWithAddresses = (tx: unknown): tx is { addresses: Array<string>; tx: unknown } => {
+  return 'addresses' in (tx as { addresses: string; tx: unknown })
+}
 
 export interface RegistryArgs {
   addressFormatter?: AddressFormatter
   blockHandler: BlockHandler
   transactionHandler: TransactionHandler
-}
-
-const isTxWithAddresses = (tx: unknown): tx is { addresses: Array<string>; tx: any } => {
-  return 'addresses' in (tx as { addresses: string; tx: any })
 }
 
 /**
@@ -143,7 +144,7 @@ export class Registry {
     }
   }
 
-  private publishTransaction(addresses: string[], tx: any) {
+  private publishTransaction(addresses: string[], tx: unknown) {
     addresses.forEach((address) => {
       address = this.formatAddress(address)
 

--- a/node/coinstacks/common/api/src/websocket.ts
+++ b/node/coinstacks/common/api/src/websocket.ts
@@ -25,7 +25,7 @@ export interface TxsTopicData {
 
 export interface MessageResponse {
   address: string
-  data: string
+  data: unknown
   subscriptionId: string
 }
 
@@ -161,7 +161,7 @@ export class ConnectionHandler {
     this.registry.unsubscribe(this.clientId, subscriptionId, data?.addresses ?? [])
   }
 
-  publish(subscriptionId: string, address: string, data: string): void {
+  publish(subscriptionId: string, address: string, data: unknown): void {
     const message: MessageResponse = { address, data, subscriptionId }
     this.websocket.send(JSON.stringify(message))
   }

--- a/node/coinstacks/ethereum/api/src/app.ts
+++ b/node/coinstacks/ethereum/api/src/app.ts
@@ -60,8 +60,20 @@ app.get('/', async (_, res) => {
 
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
-const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
-  const txs = await service.handleBlock(block.hash)
+const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
+  const blockbookTxs = await service.handleBlock(block.hash)
+  const internalTxs = await service.fetchInternalTxsByBlockDebug(block.hash)
+
+  const txs = blockbookTxs.map((t) => {
+    const tx = service.handleTransaction(t)
+    tx.internalTxs = internalTxs[t.txid]
+
+    const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
+    const addresses = [...new Set([...getAddresses(t), ...internalAddresses])]
+
+    return { addresses, tx }
+  })
+
   return { txs }
 }
 

--- a/node/coinstacks/ethereum/api/src/app.ts
+++ b/node/coinstacks/ethereum/api/src/app.ts
@@ -61,8 +61,10 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
 const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
-  const blockbookTxs = await service.handleBlock(block.hash)
-  const internalTxs = await service.fetchInternalTxsByBlockDebug(block.hash)
+  const [blockbookTxs, internalTxs] = await Promise.all([
+    service.handleBlock(block.hash),
+    service.fetchInternalTxsByBlockDebug(block.hash),
+  ])
 
   const txs = blockbookTxs.map((t) => {
     const tx = service.handleTransaction(t)

--- a/node/coinstacks/polygon/api/src/app.ts
+++ b/node/coinstacks/polygon/api/src/app.ts
@@ -60,8 +60,20 @@ app.get('/', async (_, res) => {
 
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
-const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
-  const txs = await service.handleBlock(block.hash)
+const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
+  const blockbookTxs = await service.handleBlock(block.hash)
+  const internalTxs = await service.fetchInternalTxsByBlockDebug(block.hash)
+
+  const txs = blockbookTxs.map((t) => {
+    const tx = service.handleTransaction(t)
+    tx.internalTxs = internalTxs[t.txid]
+
+    const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
+    const addresses = [...new Set([...getAddresses(t), ...internalAddresses])]
+
+    return { addresses, tx }
+  })
+
   return { txs }
 }
 

--- a/node/coinstacks/polygon/api/src/app.ts
+++ b/node/coinstacks/polygon/api/src/app.ts
@@ -61,8 +61,10 @@ app.get('/', async (_, res) => {
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
 const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
-  const blockbookTxs = await service.handleBlock(block.hash)
-  const internalTxs = await service.fetchInternalTxsByBlockDebug(block.hash)
+  const [blockbookTxs, internalTxs] = await Promise.all([
+    service.handleBlock(block.hash),
+    service.fetchInternalTxsByBlockDebug(block.hash),
+  ])
 
   const txs = blockbookTxs.map((t) => {
     const tx = service.handleTransaction(t)


### PR DESCRIPTION
Our current trace transaction setup requires way too many requests for use against nownodes endpoints. Add trace block functionality and use for currently supported nownodes coinstacks.