### PR TITLE
chore: infra updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,7 +569,7 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 1
     service-name-1: daemon
-    service-image-1: shapeshiftdao/bnb-smart-chain:v1.3.10
+    service-image-1: shapeshiftdao/bnb-smart-chain:v1.3.12
     service-cpu-limit-1: "16"
     service-cpu-request-1: "8"
     service-memory-limit-1: 72Gi
@@ -613,7 +613,7 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 1
     service-name-1: daemon
-    service-image-1: 0xpolygon/bor:1.2.7
+    service-image-1: 0xpolygon/bor:1.2.8
     service-cpu-limit-1: "8"
     service-cpu-request-1: "4"
     service-memory-limit-1: 64Gi
@@ -669,7 +669,7 @@ aliases:
     service-memory-limit-1: 6Gi
     service-storage-size-1: 1000Gi
     service-name-2: daemon-beacon
-    service-image-2: sigp/lighthouse:v5.1.0
+    service-image-2: sigp/lighthouse:v5.1.1
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 4Gi
@@ -712,7 +712,7 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 1
     service-name-1: daemon
-    service-image-1: offchainlabs/nitro-node:v2.3.0-3e14543
+    service-image-1: offchainlabs/nitro-node:v2.3.2-064fa11
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 24Gi
@@ -754,7 +754,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: offchainlabs/nitro-node:v2.3.0-3e14543
+    service-image-1: offchainlabs/nitro-node:v2.3.2-064fa11
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 16Gi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -917,9 +917,9 @@ jobs:
             pulumi config set --path unchained:common.eks.cidrBlock 10.0.0.0/16
             pulumi config set --path unchained:common.eks.nodeGroups[0].name spot
             pulumi config set --path unchained:common.eks.nodeGroups[0].type SPOT
-            pulumi config set --path unchained:common.eks.nodeGroups[0].desired 8
-            pulumi config set --path unchained:common.eks.nodeGroups[0].minSize 8
-            pulumi config set --path unchained:common.eks.nodeGroups[0].maxSize 8
+            pulumi config set --path unchained:common.eks.nodeGroups[0].desired 7
+            pulumi config set --path unchained:common.eks.nodeGroups[0].minSize 7
+            pulumi config set --path unchained:common.eks.nodeGroups[0].maxSize 7
             pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[0] r6in.4xlarge
             pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[1] r6idn.4xlarge
             pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[2] r6a.4xlarge


### PR DESCRIPTION
Node upgrades:
- https://github.com/bnb-chain/bsc/releases/tag/v1.3.12
- https://github.com/maticnetwork/bor/releases/tag/v1.2.8
- https://github.com/sigp/lighthouse/releases/tag/v5.1.1
- https://github.com/OffchainLabs/nitro/releases/tag/v2.3.2

Updates:
- Scale eks replicas