### PR TITLE
chore: remove cosmos deployment from develop and main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,45 +252,6 @@ aliases:
     api-max-replicas: 2
     stateful-service-replicas: 0
 
-  - &cosmos
-    assetName: cosmos
-    pulumi-stack: public-us-east-2
-    pulumi-dir: coinstacks/cosmos/pulumi
-    lcd-url: http://cosmos-svc.unchained.svc.cluster.local:1317
-    grpc-url: cosmos-svc.unchained.svc.cluster.local:9090
-    rpc-url: http://cosmos-svc.unchained.svc.cluster.local:26657
-    ws-url: ws://cosmos-svc.unchained.svc.cluster.local:26657
-    api-autoscaling: true
-    api-replicas: 2
-    api-max-replicas: 6
-    api-cpu-limit: 500m
-    api-cpu-request: 250m
-    api-cpu-threshold: 75
-    api-memory-limit: 1Gi
-    api-memory-request: 500Mi
-    stateful-service-replicas: 2
-    service-name-1: daemon
-    service-image-1: shapeshiftdao/cosmoshub:v14.2.0
-    service-cpu-limit-1: "4"
-    service-cpu-request-1: "2"
-    service-memory-limit-1: 64Gi
-    service-storage-size-1: 5000Gi
-    service-storage-iops-1: "6000"
-    service-storage-throughput-1: "300"
-
-  - &cosmos-dev
-    <<: *cosmos
-    environment: dev
-    pulumi-stack: public-dev-us-east-2
-    lcd-url: http://cosmos-svc.unchained-dev.svc.cluster.local:1317
-    grpc-url: cosmos-svc.unchained-dev.svc.cluster.local:9090
-    rpc-url: http://cosmos-svc.unchained-dev.svc.cluster.local:26657
-    ws-url: ws://cosmos-svc.unchained-dev.svc.cluster.local:26657
-    api-replicas: 1
-    api-max-replicas: 2
-    api-memory-limit: 500Mi
-    stateful-service-replicas: 1
-
   - &avalanche
     assetName: avalanche
     pulumi-stack: public-us-east-2
@@ -1314,15 +1275,6 @@ workflows:
           <<: *only-develop
 
       - deploy-coinstack-go:
-          name: deploy cosmos develop
-          organization: TAXISTAKE
-          pulumi-command: up -f --yes
-          requires:
-            - deploy dependencies
-          <<: *cosmos-dev
-          <<: *only-develop
-
-      - deploy-coinstack-go:
           name: deploy thorchain develop
           organization: TAXISTAKE
           pulumi-command: up -f --yes
@@ -1669,32 +1621,6 @@ workflows:
           requires:
             - approve arbitrum nova coinstack
           <<: *arbitrum-nova
-          <<: *only-main
-
-      ####### COSMOS
-      - deploy-coinstack-go:
-          name: preview cosmos
-          organization: TAXISTAKE
-          pulumi-command: preview
-          requires:
-            - validate dependencies
-          <<: *cosmos
-          <<: *only-main
-
-      - approve-coinstack:
-          name: approve cosmos coinstack
-          type: approval
-          requires:
-            - preview cosmos
-          <<: *only-main
-
-      - deploy-coinstack-go:
-          name: deploy cosmos
-          organization: TAXISTAKE
-          pulumi-command: up -f --yes
-          requires:
-            - approve cosmos coinstack
-          <<: *cosmos
           <<: *only-main
 
       ####### THORCHAIN


### PR DESCRIPTION
Cosmos is now managed from `cosmos` branch for the time being