### PR TITLE
feat: blockbook subscribe addresses

### DIFF
--- a/node/coinstacks/arbitrum-nova/api/src/app.ts
+++ b/node/coinstacks/arbitrum-nova/api/src/app.ts
@@ -61,8 +61,22 @@ app.get('/', async (_, res) => {
 
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
-const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
-  const txs = await service.handleBlock(block.hash)
+const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
+  const [blockbookTxs, internalTxs] = await Promise.all([
+    service.handleBlock(block.hash),
+    service.fetchInternalTxsByBlockDebug(block.hash),
+  ])
+
+  const txs = blockbookTxs.map((t) => {
+    const tx = service.handleTransaction(t)
+    tx.internalTxs = internalTxs[t.txid]
+
+    const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
+    const addresses = [...new Set([...getAddresses(t), ...internalAddresses])]
+
+    return { addresses, tx }
+  })
+
   return { txs }
 }
 
@@ -76,14 +90,14 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
 
 const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/arbitrum/api/src/app.ts
+++ b/node/coinstacks/arbitrum/api/src/app.ts
@@ -89,15 +89,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
 
 const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/avalanche/api/src/app.ts
+++ b/node/coinstacks/avalanche/api/src/app.ts
@@ -60,8 +60,22 @@ app.get('/', async (_, res) => {
 
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
-const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
-  const txs = await service.handleBlock(block.hash)
+const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
+  const [blockbookTxs, internalTxs] = await Promise.all([
+    service.handleBlock(block.hash),
+    service.fetchInternalTxsByBlockDebug(block.hash),
+  ])
+
+  const txs = blockbookTxs.map((t) => {
+    const tx = service.handleTransaction(t)
+    tx.internalTxs = internalTxs[t.txid]
+
+    const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
+    const addresses = [...new Set([...getAddresses(t), ...internalAddresses])]
+
+    return { addresses, tx }
+  })
+
   return { txs }
 }
 
@@ -75,15 +89,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
 
 const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/bitcoin/api/src/app.ts
+++ b/node/coinstacks/bitcoin/api/src/app.ts
@@ -73,15 +73,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: registry.onBlock.bind(registry),
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: registry.onBlock.bind(registry),
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/bitcoincash/api/src/app.ts
+++ b/node/coinstacks/bitcoincash/api/src/app.ts
@@ -75,15 +75,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: registry.onBlock.bind(registry),
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: registry.onBlock.bind(registry),
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/bnbsmartchain/api/src/app.ts
+++ b/node/coinstacks/bnbsmartchain/api/src/app.ts
@@ -91,15 +91,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
 
 const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/dogecoin/api/src/app.ts
+++ b/node/coinstacks/dogecoin/api/src/app.ts
@@ -75,15 +75,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: registry.onBlock.bind(registry),
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: registry.onBlock.bind(registry),
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/ethereum/api/src/app.ts
+++ b/node/coinstacks/ethereum/api/src/app.ts
@@ -89,15 +89,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
 
 const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/gnosis/api/src/app.ts
+++ b/node/coinstacks/gnosis/api/src/app.ts
@@ -59,8 +59,22 @@ app.get('/', async (_, res) => {
 
 app.use(middleware.errorHandler, middleware.notFoundHandler)
 
-const blockHandler: BlockHandler<NewBlock, Array<BlockbookTx>> = async (block) => {
-  const txs = await service.handleBlock(block.hash)
+const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx: evm.Tx }>> = async (block) => {
+  const [blockbookTxs, internalTxs] = await Promise.all([
+    service.handleBlock(block.hash),
+    service.fetchInternalTxsByBlockTrace(block.hash),
+  ])
+
+  const txs = blockbookTxs.map((t) => {
+    const tx = service.handleTransaction(t)
+    tx.internalTxs = internalTxs[t.txid]
+
+    const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
+    const addresses = [...new Set([...getAddresses(t), ...internalAddresses])]
+
+    return { addresses, tx }
+  })
+
   return { txs }
 }
 
@@ -74,14 +88,14 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
 
 const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/litecoin/api/src/app.ts
+++ b/node/coinstacks/litecoin/api/src/app.ts
@@ -75,15 +75,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: registry.onBlock.bind(registry),
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: registry.onBlock.bind(registry),
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/coinstacks/polygon/api/src/app.ts
+++ b/node/coinstacks/polygon/api/src/app.ts
@@ -89,15 +89,15 @@ const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (block
 
 const registry = new Registry({ addressFormatter: evm.formatAddress, blockHandler, transactionHandler })
 
+const blockbook = new WebsocketClient(INDEXER_WS_URL, {
+  apiKey: INDEXER_API_KEY,
+  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
+  transactionHandler: registry.onTransaction.bind(registry),
+})
+
 const server = app.listen(PORT, () => logger.info('Server started'))
 const wsServer = new Server({ server })
 
 wsServer.on('connection', (connection) => {
-  ConnectionHandler.start(connection, registry, prometheus, logger)
-})
-
-new WebsocketClient(INDEXER_WS_URL, {
-  apiKey: INDEXER_API_KEY,
-  blockHandler: [registry.onBlock.bind(registry), gasOracle.onBlock.bind(gasOracle)],
-  transactionHandler: registry.onTransaction.bind(registry),
+  ConnectionHandler.start(connection, registry, blockbook, prometheus, logger)
 })

--- a/node/packages/blockbook/src/index.ts
+++ b/node/packages/blockbook/src/index.ts
@@ -9,13 +9,18 @@ export interface NewBlock {
   hash: string
 }
 
+export interface NewTx {
+  address: string
+  tx: Tx
+}
+
 export interface SubscriptionResponse {
   subscribed: boolean
 }
 
 export interface WebsocketRepsonse {
   id: string
-  data: NewBlock | Tx | SubscriptionResponse
+  data: NewBlock | NewTx | SubscriptionResponse
 }
 
 /**


### PR DESCRIPTION
- leverage blockbook `subscribeAddresses` to filter mempool transactions to only those we care about. this will reduce both nownodes req usage and also lower aws data transfer which will save us $$$
- update all evm `blockHandler` functions to leverage trace by block to unify approach and also reduce request made to nownodes for avalanche which will save us more $$$