### PR TITLE
feat: add jsonrpc endpoint to unchained api

### DIFF
--- a/node/coinstacks/arbitrum-nova/api/src/controller.ts
+++ b/node/coinstacks/arbitrum-nova/api/src/controller.ts
@@ -1,25 +1,10 @@
 import { ethers } from 'ethers'
-import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
+import { Example, Get, Query, Response, Route, Tags } from 'tsoa'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  BadRequestError,
-  BaseAPI,
-  BaseInfo,
-  InternalServerError,
-  SendTxBody,
-  ValidationError,
-} from '../../../common/api/src' // unable to import models from a module with tsoa
-import {
-  API,
-  Account,
-  GasFees,
-  Tx,
-  TxHistory,
-  GasEstimate,
-  TokenMetadata,
-  TokenType,
-} from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { BaseAPI, InternalServerError, ValidationError } from '../../../common/api/src' // unable to import models from a module with tsoa
+import { API, GasEstimate, GasFees } from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { EVM } from '../../../common/api/src/evm/controller'
 import { Service } from '../../../common/api/src/evm/service'
 import { GasOracle } from '../../../common/api/src/evm/gasOracle'
 
@@ -51,154 +36,12 @@ export const service = new Service({
   rpcUrl: RPC_URL,
 })
 
+// assign service to be used for all instances of EVM
+EVM.service = service
+
 @Route('api/v1')
 @Tags('v1')
-export class ArbitrumNova extends Controller implements BaseAPI, API {
-  /**
-   * Get information about the running coinstack
-   *
-   * @returns {Promise<BaseInfo>} coinstack info
-   */
-  @Example<BaseInfo>({
-    network: 'mainnet',
-  })
-  @Get('info/')
-  async getInfo(): Promise<BaseInfo> {
-    return {
-      network: NETWORK as string,
-    }
-  }
-
-  /**
-   * Get account details by address
-   *
-   * @param {string} pubkey account address
-   *
-   * @returns {Promise<Account>} account details
-   *
-   * @example pubkey "0x6e249a692314bceb8ac43b296262df1800915bf4"
-   */
-  @Example<Account>({
-    balance: '3947543807646782',
-    unconfirmedBalance: '0',
-    nonce: 2,
-    pubkey: '0x6E249A692314bcEB8ac43B296262Df1800915Bf4',
-    tokens: [
-      {
-        balance: '14131423',
-        contract: '0x750ba8b76187092B0D1E87E28daaf484d1b5273b',
-        decimals: 6,
-        name: 'USD Coin',
-        symbol: 'USDC',
-        type: 'ERC20',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}')
-  async getAccount(@Path() pubkey: string): Promise<Account> {
-    return service.getAccount(pubkey)
-  }
-
-  /**
-   * Get transaction history by address
-   *
-   * @param {string} pubkey account address
-   * @param {string} [cursor] the cursor returned in previous query (base64 encoded json object with a 'page' property)
-   * @param {number} [pageSize] page size (10 by default)
-   * @param {number} [from] from block number (0 by default)
-   * @param {number} [to] to block number (pending by default)
-   *
-   * @returns {Promise<TxHistory>} transaction history
-   *
-   * @example pubkey "0x6e249a692314bceb8ac43b296262df1800915bf4"
-   */
-  @Example<TxHistory>({
-    pubkey: '0x6e249a692314bceb8ac43b296262df1800915bf4',
-    txs: [
-      {
-        txid: '0x375cb328fe3399f67ac315ee4a00d92b0b60d12c98830d7600aec0f55e4163c6',
-        blockHash: '0x3ee0749ef10654a2bc87e7d949d18d344f26320184e4c0f0f4c3932877d9affa',
-        blockHeight: 26670056,
-        timestamp: 1698434321,
-        status: 1,
-        from: '0xe93685f3bBA03016F02bD1828BaDD6195988D950',
-        to: '0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9',
-        confirmations: 2744,
-        value: '11000000000000000',
-        fee: '1868700000000',
-        gasLimit: '1193952',
-        gasUsed: '155725',
-        gasPrice: '12000000',
-        inputData:
-          '0x0508941e00000000000000000000000000000000000000000000000000000000000000a5000000000000000000000000b6789dacf323d60f650628dc1da344d502bc41e30000000000000000000000000000000000000000000000000000000000030d407ae3e7b0abe71c59d59ffdff318609711ef20011e4eab53d342e4f0093cb0d9b7ae3e7b0abe71c59d59ffdff318609711ef20011e4eab53d342e4f0093cb0d9b00000000000000000000000000000000000000000000000000000000000000e00000000000000000000000006e249a692314bceb8ac43b296262df1800915bf40000000000000000000000000000000000000000000000000000000000000068000000000000000000000000042b8289c97896529ec2fe49ba1a8b9c956a86cc0000000000009f8500a55673b6e6e51de3479b8deb22df46b12308db5e1e00afb6789dacf323d60f650628dc1da344d502bc41e36e249a692314bceb8ac43b296262df1800915bf4000000000000000000000000000000000000000000000000',
-        internalTxs: [
-          {
-            from: '0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9',
-            to: '0x6E249A692314bcEB8ac43B296262Df1800915Bf4',
-            value: '11000000000000000',
-          },
-        ],
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}/txs')
-  async getTxHistory(
-    @Path() pubkey: string,
-    @Query() cursor?: string,
-    @Query() pageSize = 10,
-    @Query() from?: number,
-    @Query() to?: number
-  ): Promise<TxHistory> {
-    return service.getTxHistory(pubkey, cursor, pageSize, from, to)
-  }
-
-  /**
-   * Get transaction details
-   *
-   * @param {string} txid transaction hash
-   *
-   * @example txid "0x375cb328fe3399f67ac315ee4a00d92b0b60d12c98830d7600aec0f55e4163c6"
-   *
-   * @returns {Promise<Tx>} transaction payload
-   */
-  @Example<Tx>({
-    txid: '0x375cb328fe3399f67ac315ee4a00d92b0b60d12c98830d7600aec0f55e4163c6',
-    blockHash: '0x3ee0749ef10654a2bc87e7d949d18d344f26320184e4c0f0f4c3932877d9affa',
-    blockHeight: 26670056,
-    timestamp: 1698434321,
-    status: 1,
-    from: '0xe93685f3bBA03016F02bD1828BaDD6195988D950',
-    to: '0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9',
-    confirmations: 2937,
-    value: '11000000000000000',
-    fee: '1868700000000',
-    gasLimit: '1193952',
-    gasUsed: '155725',
-    gasPrice: '12000000',
-    inputData:
-      '0x0508941e00000000000000000000000000000000000000000000000000000000000000a5000000000000000000000000b6789dacf323d60f650628dc1da344d502bc41e30000000000000000000000000000000000000000000000000000000000030d407ae3e7b0abe71c59d59ffdff318609711ef20011e4eab53d342e4f0093cb0d9b7ae3e7b0abe71c59d59ffdff318609711ef20011e4eab53d342e4f0093cb0d9b00000000000000000000000000000000000000000000000000000000000000e00000000000000000000000006e249a692314bceb8ac43b296262df1800915bf40000000000000000000000000000000000000000000000000000000000000068000000000000000000000000042b8289c97896529ec2fe49ba1a8b9c956a86cc0000000000009f8500a55673b6e6e51de3479b8deb22df46b12308db5e1e00afb6789dacf323d60f650628dc1da344d502bc41e36e249a692314bceb8ac43b296262df1800915bf4000000000000000000000000000000000000000000000000',
-    internalTxs: [
-      {
-        from: '0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9',
-        to: '0x6E249A692314bcEB8ac43B296262Df1800915Bf4',
-        value: '11000000000000000',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('tx/{txid}')
-  async getTransaction(@Path() txid: string): Promise<Tx> {
-    return service.getTransaction(txid)
-  }
-
+export class ArbitrumNova extends EVM implements BaseAPI, API {
   /**
    * Get the estimated gas cost of a transaction
    *
@@ -259,57 +102,5 @@ export class ArbitrumNova extends Controller implements BaseAPI, API {
   @Get('/gas/fees')
   async getGasFees(): Promise<GasFees> {
     return service.getGasFees()
-  }
-
-  /**
-   * Broadcast signed raw transaction
-   *
-   * @param {SendTxBody} body serialized raw transaction hex
-   *
-   * @returns {Promise<string>} transaction id
-   *
-   * @example body {
-   *    "hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-   * }
-   */
-  @Example<string>('0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd')
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Post('send/')
-  async sendTx(@Body() body: SendTxBody): Promise<string> {
-    return service.sendTx(body)
-  }
-
-  /**
-   * Get token metadata
-   *
-   * @param {string} contract contract address
-   * @param {string} id token identifier
-   * @param {TokenType} type token type (erc721 or erc1155)
-   *
-   * @returns {Promise<TokenMetadata>} token metadata
-   *
-   * @example contractAddress "0x6f81e9D51Bf482EC3f3724B28eEFE9f9fBe4Fe04"
-   * @example id "9999"
-   * @example type "erc721"
-   */
-  @Example<TokenMetadata>({
-    name: 'Mira "Striker" Loyola',
-    description: '',
-    media: {
-      url: 'https://dps-gen1-meta.s3.amazonaws.com/9999.png',
-      type: 'image',
-    },
-  })
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('/metadata/token')
-  async getTokenMetadata(
-    @Query() contract: string,
-    @Query() id: string,
-    @Query() type: TokenType
-  ): Promise<TokenMetadata> {
-    return service.getTokenMetadata(contract, id, type)
   }
 }

--- a/node/coinstacks/arbitrum-nova/api/src/swagger.json
+++ b/node/coinstacks/arbitrum-nova/api/src/swagger.json
@@ -311,6 +311,146 @@
 				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
 				"description": "Contains info about EVM transaction history"
 			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method",
+					"params"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
 			"GasEstimate": {
 				"description": "Contains info about estimated gas cost of a transaction",
 				"properties": {
@@ -373,63 +513,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"SendTxBody": {
-				"description": "Contains the serialized raw transaction hex",
-				"properties": {
-					"hex": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"hex"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenMetadata": {
-				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"media": {
-						"properties": {
-							"type": {
-								"type": "string",
-								"enum": [
-									"image",
-									"video"
-								]
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"url"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"description",
-					"media"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenType": {
-				"type": "string",
-				"enum": [
-					"erc721",
-					"erc1155"
-				],
-				"description": "Supported token types for token metadata"
 			}
 		},
 		"securitySchemes": {}
@@ -488,17 +571,17 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"balance": "3947543807646782",
+											"balance": "284809805024198107",
 											"unconfirmedBalance": "0",
-											"nonce": 2,
-											"pubkey": "0x6E249A692314bcEB8ac43B296262Df1800915Bf4",
+											"nonce": 1,
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
 											"tokens": [
 												{
-													"balance": "14131423",
-													"contract": "0x750ba8b76187092B0D1E87E28daaf484d1b5273b",
-													"decimals": 6,
-													"name": "USD Coin",
-													"symbol": "USDC",
+													"balance": "1337",
+													"contract": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
+													"decimals": 18,
+													"name": "FOX",
+													"symbol": "FOX",
 													"type": "ERC20"
 												}
 											]
@@ -552,8 +635,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x6e249a692314bceb8ac43b296262df1800915bf4"
+						}
 					}
 				]
 			}
@@ -572,30 +654,24 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"pubkey": "0x6e249a692314bceb8ac43b296262df1800915bf4",
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==",
 											"txs": [
 												{
-													"txid": "0x375cb328fe3399f67ac315ee4a00d92b0b60d12c98830d7600aec0f55e4163c6",
-													"blockHash": "0x3ee0749ef10654a2bc87e7d949d18d344f26320184e4c0f0f4c3932877d9affa",
-													"blockHeight": 26670056,
-													"timestamp": 1698434321,
+													"txid": "0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002",
+													"blockHash": "0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8",
+													"blockHeight": 12267105,
+													"timestamp": 1618788849,
 													"status": 1,
-													"from": "0xe93685f3bBA03016F02bD1828BaDD6195988D950",
-													"to": "0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9",
-													"confirmations": 2744,
-													"value": "11000000000000000",
-													"fee": "1868700000000",
-													"gasLimit": "1193952",
-													"gasUsed": "155725",
-													"gasPrice": "12000000",
-													"inputData": "0x0508941e00000000000000000000000000000000000000000000000000000000000000a5000000000000000000000000b6789dacf323d60f650628dc1da344d502bc41e30000000000000000000000000000000000000000000000000000000000030d407ae3e7b0abe71c59d59ffdff318609711ef20011e4eab53d342e4f0093cb0d9b7ae3e7b0abe71c59d59ffdff318609711ef20011e4eab53d342e4f0093cb0d9b00000000000000000000000000000000000000000000000000000000000000e00000000000000000000000006e249a692314bceb8ac43b296262df1800915bf40000000000000000000000000000000000000000000000000000000000000068000000000000000000000000042b8289c97896529ec2fe49ba1a8b9c956a86cc0000000000009f8500a55673b6e6e51de3479b8deb22df46b12308db5e1e00afb6789dacf323d60f650628dc1da344d502bc41e36e249a692314bceb8ac43b296262df1800915bf4000000000000000000000000000000000000000000000000",
-													"internalTxs": [
-														{
-															"from": "0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9",
-															"to": "0x6E249A692314bcEB8ac43B296262Df1800915Bf4",
-															"value": "11000000000000000"
-														}
-													]
+													"from": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+													"to": "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7",
+													"confirmations": 2088440,
+													"value": "737092621690531649",
+													"fee": "3180000000009000",
+													"gasLimit": "21000",
+													"gasUsed": "21000",
+													"gasPrice": "151428571429",
+													"inputData": "0x"
 												}
 											]
 										}
@@ -648,8 +724,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x6e249a692314bceb8ac43b296262df1800915bf4"
+						}
 					},
 					{
 						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
@@ -708,27 +783,20 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"txid": "0x375cb328fe3399f67ac315ee4a00d92b0b60d12c98830d7600aec0f55e4163c6",
-											"blockHash": "0x3ee0749ef10654a2bc87e7d949d18d344f26320184e4c0f0f4c3932877d9affa",
-											"blockHeight": 26670056,
-											"timestamp": 1698434321,
+											"txid": "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d",
+											"blockHash": "0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7",
+											"blockHeight": 14813163,
+											"timestamp": 1653078780,
 											"status": 1,
-											"from": "0xe93685f3bBA03016F02bD1828BaDD6195988D950",
-											"to": "0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9",
-											"confirmations": 2937,
-											"value": "11000000000000000",
-											"fee": "1868700000000",
-											"gasLimit": "1193952",
-											"gasUsed": "155725",
-											"gasPrice": "12000000",
-											"inputData": "0x0508941e00000000000000000000000000000000000000000000000000000000000000a5000000000000000000000000b6789dacf323d60f650628dc1da344d502bc41e30000000000000000000000000000000000000000000000000000000000030d407ae3e7b0abe71c59d59ffdff318609711ef20011e4eab53d342e4f0093cb0d9b7ae3e7b0abe71c59d59ffdff318609711ef20011e4eab53d342e4f0093cb0d9b00000000000000000000000000000000000000000000000000000000000000e00000000000000000000000006e249a692314bceb8ac43b296262df1800915bf40000000000000000000000000000000000000000000000000000000000000068000000000000000000000000042b8289c97896529ec2fe49ba1a8b9c956a86cc0000000000009f8500a55673b6e6e51de3479b8deb22df46b12308db5e1e00afb6789dacf323d60f650628dc1da344d502bc41e36e249a692314bceb8ac43b296262df1800915bf4000000000000000000000000000000000000000000000000",
-											"internalTxs": [
-												{
-													"from": "0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9",
-													"to": "0x6E249A692314bcEB8ac43B296262Df1800915Bf4",
-													"value": "11000000000000000"
-												}
-											]
+											"from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
+											"to": "0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD",
+											"confirmations": 21,
+											"value": "49396718157429775",
+											"fee": "603633477678000",
+											"gasLimit": "250000",
+											"gasUsed": "21000",
+											"gasPrice": "28744451318",
+											"inputData": "0x"
 										}
 									}
 								}
@@ -779,8 +847,225 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x375cb328fe3399f67ac315ee4a00d92b0b60d12c98830d7600aec0f55e4163c6"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"name": "Foxy",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
 					}
 				]
 			}
@@ -931,164 +1216,6 @@
 				],
 				"security": [],
 				"parameters": []
-			}
-		},
-		"/api/v1/send": {
-			"post": {
-				"operationId": "SendTx",
-				"responses": {
-					"200": {
-						"description": "transaction id",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "string"
-								},
-								"examples": {
-									"Example 1": {
-										"value": "0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/BadRequestError"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Broadcast signed raw transaction",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "serialized raw transaction hex",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/SendTxBody",
-								"description": "serialized raw transaction hex"
-							},
-							"example": {
-								"hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/metadata/token": {
-			"get": {
-				"operationId": "GetTokenMetadata",
-				"responses": {
-					"200": {
-						"description": "token metadata",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TokenMetadata"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"name": "Mira \"Striker\" Loyola",
-											"description": "",
-											"media": {
-												"url": "https://dps-gen1-meta.s3.amazonaws.com/9999.png",
-												"type": "image"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get token metadata",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "contract address",
-						"in": "query",
-						"name": "contract",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "0x6f81e9D51Bf482EC3f3724B28eEFE9f9fBe4Fe04"
-					},
-					{
-						"description": "token identifier",
-						"in": "query",
-						"name": "id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "9999"
-					},
-					{
-						"description": "token type (erc721 or erc1155)",
-						"in": "query",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/TokenType"
-						}
-					}
-				]
 			}
 		}
 	},

--- a/node/coinstacks/arbitrum/api/src/controller.ts
+++ b/node/coinstacks/arbitrum/api/src/controller.ts
@@ -1,25 +1,10 @@
 import { ethers } from 'ethers'
-import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
+import { Example, Get, Query, Response, Route, Tags } from 'tsoa'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  BadRequestError,
-  BaseAPI,
-  BaseInfo,
-  InternalServerError,
-  SendTxBody,
-  ValidationError,
-} from '../../../common/api/src' // unable to import models from a module with tsoa
-import {
-  API,
-  Account,
-  GasFees,
-  Tx,
-  TxHistory,
-  GasEstimate,
-  TokenMetadata,
-  TokenType,
-} from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { BaseAPI, InternalServerError, ValidationError } from '../../../common/api/src' // unable to import models from a module with tsoa
+import { API, GasEstimate, GasFees } from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { EVM } from '../../../common/api/src/evm/controller'
 import { Service } from '../../../common/api/src/evm/service'
 import { GasOracle } from '../../../common/api/src/evm/gasOracle'
 
@@ -55,146 +40,12 @@ export const service = new Service({
   rpcApiKey: RPC_API_KEY,
 })
 
+// assign service to be used for all instances of EVM
+EVM.service = service
+
 @Route('api/v1')
 @Tags('v1')
-export class Arbitrum extends Controller implements BaseAPI, API {
-  /**
-   * Get information about the running coinstack
-   *
-   * @returns {Promise<BaseInfo>} coinstack info
-   */
-  @Example<BaseInfo>({
-    network: 'mainnet',
-  })
-  @Get('info/')
-  async getInfo(): Promise<BaseInfo> {
-    return {
-      network: NETWORK as string,
-    }
-  }
-
-  /**
-   * Get account details by address
-   *
-   * @param {string} pubkey account address
-   *
-   * @returns {Promise<Account>} account details
-   *
-   * @example pubkey "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
-   */
-  @Example<Account>({
-    balance: '25865025000000',
-    unconfirmedBalance: '0',
-    nonce: 5,
-    pubkey: '0x9D1170D30944F2E30664Be502aC57F6096fB5366',
-    tokens: [
-      {
-        balance: '0',
-        contract: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
-        decimals: 18,
-        name: 'Dai Stablecoin',
-        symbol: 'DAI',
-        type: 'ERC20',
-      },
-      {
-        balance: '0',
-        contract: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
-        decimals: 6,
-        name: 'Tether USD',
-        symbol: 'USDT',
-        type: 'ERC20',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}')
-  async getAccount(@Path() pubkey: string): Promise<Account> {
-    return service.getAccount(pubkey)
-  }
-
-  /**
-   * Get transaction history by address
-   *
-   * @param {string} pubkey account address
-   * @param {string} [cursor] the cursor returned in previous query (base64 encoded json object with a 'page' property)
-   * @param {number} [pageSize] page size (10 by default)
-   * @param {number} [from] from block number (0 by default)
-   * @param {number} [to] to block number (pending by default)
-   *
-   * @returns {Promise<TxHistory>} transaction history
-   *
-   * @example pubkey "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
-   */
-  @Example<TxHistory>({
-    pubkey: '0x9D1170D30944F2E30664Be502aC57F6096fB5366',
-    cursor:
-      'eyJibG9ja2Jvb2tQYWdlIjoyLCJleHBsb3JlclBhZ2UiOjEsImJsb2NrYm9va1R4aWQiOiIweGRhYjE2ODcyNWViMzYyMmQ2MTNkNWRhZWRiZmE5MTdiZWFjNGZhNTJhNWZhYzg2MDk5ZDg1ZmI3MWI1OTYyYTUiLCJibG9ja0hlaWdodCI6NzcyOTExMDV9',
-    txs: [
-      {
-        txid: '0xdab168725eb3622d613d5daedbfa917beac4fa52a5fac86099d85fb71b5962a5',
-        blockHash: '0x332643127493036faba7de88a6fb7d5e8b150d64526c1908fddbeb99fec2c674',
-        blockHeight: 77291105,
-        timestamp: 1680697466,
-        status: 1,
-        from: '0x9D1170D30944F2E30664Be502aC57F6096fB5366',
-        to: '0xc0ef185cC29A3D9f36977BfA92862f833AD59e95',
-        confirmations: 59521378,
-        value: '4159598947212301',
-        fee: '34455000000000',
-        gasLimit: '446815',
-        gasUsed: '344550',
-        gasPrice: '100000000',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}/txs')
-  async getTxHistory(
-    @Path() pubkey: string,
-    @Query() cursor?: string,
-    @Query() pageSize = 10,
-    @Query() from?: number,
-    @Query() to?: number
-  ): Promise<TxHistory> {
-    return service.getTxHistory(pubkey, cursor, pageSize, from, to)
-  }
-
-  /**
-   * Get transaction details
-   *
-   * @param {string} txid transaction hash
-   *
-   * @example txid "0xdab168725eb3622d613d5daedbfa917beac4fa52a5fac86099d85fb71b5962a5"
-   *
-   * @returns {Promise<Tx>} transaction payload
-   */
-  @Example<Tx>({
-    txid: '0xdab168725eb3622d613d5daedbfa917beac4fa52a5fac86099d85fb71b5962a5',
-    blockHash: '0x332643127493036faba7de88a6fb7d5e8b150d64526c1908fddbeb99fec2c674',
-    blockHeight: 77291105,
-    timestamp: 1680697466,
-    status: 1,
-    from: '0x9D1170D30944F2E30664Be502aC57F6096fB5366',
-    to: '0xc0ef185cC29A3D9f36977BfA92862f833AD59e95',
-    confirmations: 59521508,
-    value: '4159598947212301',
-    fee: '34455000000000',
-    gasLimit: '446815',
-    gasUsed: '344550',
-    gasPrice: '100000000',
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('tx/{txid}')
-  async getTransaction(@Path() txid: string): Promise<Tx> {
-    return service.getTransaction(txid)
-  }
-
+export class Arbitrum extends EVM implements BaseAPI, API {
   /**
    * Get the estimated gas cost of a transaction
    *
@@ -207,7 +58,7 @@ export class Arbitrum extends Controller implements BaseAPI, API {
    *
    * @example data "0x"
    * @example from "0x0000000000000000000000000000000000000000"
-   * @example to "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
+   * @example to "0x0000000000000000000000000000000000000000"
    * @example value "1337"
    */
   @Example<GasEstimate>({ gasLimit: '374764' })
@@ -255,57 +106,5 @@ export class Arbitrum extends Controller implements BaseAPI, API {
   @Get('/gas/fees')
   async getGasFees(): Promise<GasFees> {
     return service.getGasFees()
-  }
-
-  /**
-   * Broadcast signed raw transaction
-   *
-   * @param {SendTxBody} body serialized raw transaction hex
-   *
-   * @returns {Promise<string>} transaction id
-   *
-   * @example body {
-   *    "hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-   * }
-   */
-  @Example<string>('0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd')
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Post('send/')
-  async sendTx(@Body() body: SendTxBody): Promise<string> {
-    return service.sendTx(body)
-  }
-
-  /**
-   * Get token metadata
-   *
-   * @param {string} contract contract address
-   * @param {string} id token identifier
-   * @param {TokenType} type token type (erc721 or erc1155)
-   *
-   * @returns {Promise<TokenMetadata>} token metadata
-   *
-   * @example contractAddress "0x1E3E1ed17A8Df57C215b45f00c2eC4717B33a93D"
-   * @example id "1000143"
-   * @example type "erc721"
-   */
-  @Example<TokenMetadata>({
-    name: 'Dragon 30',
-    description: '',
-    media: {
-      url: 'https://img.momoworld.io/dragon/52.png',
-      type: 'image',
-    },
-  })
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('/metadata/token')
-  async getTokenMetadata(
-    @Query() contract: string,
-    @Query() id: string,
-    @Query() type: TokenType
-  ): Promise<TokenMetadata> {
-    return service.getTokenMetadata(contract, id, type)
   }
 }

--- a/node/coinstacks/arbitrum/api/src/swagger.json
+++ b/node/coinstacks/arbitrum/api/src/swagger.json
@@ -311,6 +311,146 @@
 				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
 				"description": "Contains info about EVM transaction history"
 			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method",
+					"params"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
 			"GasEstimate": {
 				"description": "Contains info about estimated gas cost of a transaction",
 				"properties": {
@@ -373,63 +513,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"SendTxBody": {
-				"description": "Contains the serialized raw transaction hex",
-				"properties": {
-					"hex": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"hex"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenMetadata": {
-				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"media": {
-						"properties": {
-							"type": {
-								"type": "string",
-								"enum": [
-									"image",
-									"video"
-								]
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"url"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"description",
-					"media"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenType": {
-				"type": "string",
-				"enum": [
-					"erc721",
-					"erc1155"
-				],
-				"description": "Supported token types for token metadata"
 			}
 		},
 		"securitySchemes": {}
@@ -488,25 +571,17 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"balance": "25865025000000",
+											"balance": "284809805024198107",
 											"unconfirmedBalance": "0",
-											"nonce": 5,
-											"pubkey": "0x9D1170D30944F2E30664Be502aC57F6096fB5366",
+											"nonce": 1,
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
 											"tokens": [
 												{
-													"balance": "0",
-													"contract": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+													"balance": "1337",
+													"contract": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
 													"decimals": 18,
-													"name": "Dai Stablecoin",
-													"symbol": "DAI",
-													"type": "ERC20"
-												},
-												{
-													"balance": "0",
-													"contract": "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
-													"decimals": 6,
-													"name": "Tether USD",
-													"symbol": "USDT",
+													"name": "FOX",
+													"symbol": "FOX",
 													"type": "ERC20"
 												}
 											]
@@ -560,8 +635,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
+						}
 					}
 				]
 			}
@@ -580,23 +654,24 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"pubkey": "0x9D1170D30944F2E30664Be502aC57F6096fB5366",
-											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoyLCJleHBsb3JlclBhZ2UiOjEsImJsb2NrYm9va1R4aWQiOiIweGRhYjE2ODcyNWViMzYyMmQ2MTNkNWRhZWRiZmE5MTdiZWFjNGZhNTJhNWZhYzg2MDk5ZDg1ZmI3MWI1OTYyYTUiLCJibG9ja0hlaWdodCI6NzcyOTExMDV9",
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==",
 											"txs": [
 												{
-													"txid": "0xdab168725eb3622d613d5daedbfa917beac4fa52a5fac86099d85fb71b5962a5",
-													"blockHash": "0x332643127493036faba7de88a6fb7d5e8b150d64526c1908fddbeb99fec2c674",
-													"blockHeight": 77291105,
-													"timestamp": 1680697466,
+													"txid": "0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002",
+													"blockHash": "0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8",
+													"blockHeight": 12267105,
+													"timestamp": 1618788849,
 													"status": 1,
-													"from": "0x9D1170D30944F2E30664Be502aC57F6096fB5366",
-													"to": "0xc0ef185cC29A3D9f36977BfA92862f833AD59e95",
-													"confirmations": 59521378,
-													"value": "4159598947212301",
-													"fee": "34455000000000",
-													"gasLimit": "446815",
-													"gasUsed": "344550",
-													"gasPrice": "100000000"
+													"from": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+													"to": "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7",
+													"confirmations": 2088440,
+													"value": "737092621690531649",
+													"fee": "3180000000009000",
+													"gasLimit": "21000",
+													"gasUsed": "21000",
+													"gasPrice": "151428571429",
+													"inputData": "0x"
 												}
 											]
 										}
@@ -649,8 +724,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
+						}
 					},
 					{
 						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
@@ -709,19 +783,20 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"txid": "0xdab168725eb3622d613d5daedbfa917beac4fa52a5fac86099d85fb71b5962a5",
-											"blockHash": "0x332643127493036faba7de88a6fb7d5e8b150d64526c1908fddbeb99fec2c674",
-											"blockHeight": 77291105,
-											"timestamp": 1680697466,
+											"txid": "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d",
+											"blockHash": "0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7",
+											"blockHeight": 14813163,
+											"timestamp": 1653078780,
 											"status": 1,
-											"from": "0x9D1170D30944F2E30664Be502aC57F6096fB5366",
-											"to": "0xc0ef185cC29A3D9f36977BfA92862f833AD59e95",
-											"confirmations": 59521508,
-											"value": "4159598947212301",
-											"fee": "34455000000000",
-											"gasLimit": "446815",
-											"gasUsed": "344550",
-											"gasPrice": "100000000"
+											"from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
+											"to": "0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD",
+											"confirmations": 21,
+											"value": "49396718157429775",
+											"fee": "603633477678000",
+											"gasLimit": "250000",
+											"gasUsed": "21000",
+											"gasPrice": "28744451318",
+											"inputData": "0x"
 										}
 									}
 								}
@@ -772,8 +847,225 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xdab168725eb3622d613d5daedbfa917beac4fa52a5fac86099d85fb71b5962a5"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"name": "Foxy",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
 					}
 				]
 			}
@@ -854,7 +1146,7 @@
 						"schema": {
 							"type": "string"
 						},
-						"example": "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
+						"example": "0x0000000000000000000000000000000000000000"
 					},
 					{
 						"description": "transaction value in wei",
@@ -924,164 +1216,6 @@
 				],
 				"security": [],
 				"parameters": []
-			}
-		},
-		"/api/v1/send": {
-			"post": {
-				"operationId": "SendTx",
-				"responses": {
-					"200": {
-						"description": "transaction id",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "string"
-								},
-								"examples": {
-									"Example 1": {
-										"value": "0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/BadRequestError"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Broadcast signed raw transaction",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "serialized raw transaction hex",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/SendTxBody",
-								"description": "serialized raw transaction hex"
-							},
-							"example": {
-								"hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/metadata/token": {
-			"get": {
-				"operationId": "GetTokenMetadata",
-				"responses": {
-					"200": {
-						"description": "token metadata",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TokenMetadata"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"name": "Dragon 30",
-											"description": "",
-											"media": {
-												"url": "https://img.momoworld.io/dragon/52.png",
-												"type": "image"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get token metadata",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "contract address",
-						"in": "query",
-						"name": "contract",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "0x1E3E1ed17A8Df57C215b45f00c2eC4717B33a93D"
-					},
-					{
-						"description": "token identifier",
-						"in": "query",
-						"name": "id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "1000143"
-					},
-					{
-						"description": "token type (erc721 or erc1155)",
-						"in": "query",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/TokenType"
-						}
-					}
-				]
 			}
 		}
 	},

--- a/node/coinstacks/avalanche/api/src/controller.ts
+++ b/node/coinstacks/avalanche/api/src/controller.ts
@@ -1,25 +1,10 @@
 import { ethers } from 'ethers'
-import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
+import { Example, Get, Query, Response, Route, Tags } from 'tsoa'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  BadRequestError,
-  BaseAPI,
-  BaseInfo,
-  InternalServerError,
-  SendTxBody,
-  ValidationError,
-} from '../../../common/api/src' // unable to import models from a module with tsoa
-import {
-  API,
-  Account,
-  GasFees,
-  Tx,
-  TxHistory,
-  GasEstimate,
-  TokenMetadata,
-  TokenType,
-} from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { BaseAPI, InternalServerError, ValidationError } from '../../../common/api/src' // unable to import models from a module with tsoa
+import { API, GasEstimate, GasFees } from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { EVM } from '../../../common/api/src/evm/controller'
 import { Service } from '../../../common/api/src/evm/service'
 import { GasOracle } from '../../../common/api/src/evm/gasOracle'
 
@@ -55,138 +40,12 @@ export const service = new Service({
   rpcApiKey: RPC_API_KEY,
 })
 
+// assign service to be used for all instances of EVM
+EVM.service = service
+
 @Route('api/v1')
 @Tags('v1')
-export class Avalanche extends Controller implements BaseAPI, API {
-  /**
-   * Get information about the running coinstack
-   *
-   * @returns {Promise<BaseInfo>} coinstack info
-   */
-  @Example<BaseInfo>({
-    network: 'mainnet',
-  })
-  @Get('info/')
-  async getInfo(): Promise<BaseInfo> {
-    return {
-      network: NETWORK as string,
-    }
-  }
-
-  /**
-   * Get account details by address
-   *
-   * @param {string} pubkey account address
-   *
-   * @returns {Promise<Account>} account details
-   *
-   * @example pubkey "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
-   */
-  @Example<Account>({
-    balance: '183750000000000',
-    unconfirmedBalance: '0',
-    nonce: 322,
-    pubkey: '0x9D1170D30944F2E30664Be502aC57F6096fB5366',
-    tokens: [
-      {
-        balance: '1337',
-        contract: '0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB',
-        decimals: 18,
-        name: 'Wrapped Ether',
-        symbol: 'WETH.e',
-        type: 'ERC20',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}')
-  async getAccount(@Path() pubkey: string): Promise<Account> {
-    return service.getAccount(pubkey)
-  }
-
-  /**
-   * Get transaction history by address
-   *
-   * @param {string} pubkey account address
-   * @param {string} [cursor] the cursor returned in previous query (base64 encoded json object with a 'page' property)
-   * @param {number} [pageSize] page size (10 by default)
-   * @param {number} [from] from block number (0 by default)
-   * @param {number} [to] to block number (pending by default)
-   *
-   * @returns {Promise<TxHistory>} transaction history
-   *
-   * @example pubkey "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
-   */
-  @Example<TxHistory>({
-    pubkey: '0x9D1170D30944F2E30664Be502aC57F6096fB5366',
-    cursor:
-      'eyJibG9ja2Jvb2tQYWdlIjoyLCJleHBsb3JlclBhZ2UiOjEsImJsb2NrYm9va1R4aWQiOiIweDE0YTZlYTA4MWRhYWI1OWI1ZGQ3YTE3NjQ4YTAwNGU5Y2EzNzdhNWVkMmE5N2E4NGUyYWQ4MDVkZjJlMjUzM2QiLCJibG9ja0hlaWdodCI6MTc1MTIxNjR9',
-    txs: [
-      {
-        txid: '0x14a6ea081daab59b5dd7a17648a004e9ca377a5ed2a97a84e2ad805df2e2533d',
-        blockHash: '0x748fff248d4a033c28cb6cc45b78ad7f471ac4d958971570e3e3afe4e0f84c1f',
-        blockHeight: 17512164,
-        timestamp: 1658197214,
-        status: 1,
-        from: '0xa3682Fe8fD73B90A7564585A436EC2D2AEb612eE',
-        to: '0x9D1170D30944F2E30664Be502aC57F6096fB5366',
-        confirmations: 119004,
-        value: '410000000000000000',
-        fee: '525000000000000',
-        gasLimit: '21000',
-        gasUsed: '21000',
-        gasPrice: '25000000000',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}/txs')
-  async getTxHistory(
-    @Path() pubkey: string,
-    @Query() cursor?: string,
-    @Query() pageSize = 10,
-    @Query() from?: number,
-    @Query() to?: number
-  ): Promise<TxHistory> {
-    return service.getTxHistory(pubkey, cursor, pageSize, from, to)
-  }
-
-  /**
-   * Get transaction details
-   *
-   * @param {string} txid transaction hash
-   *
-   * @example txid "0x14a6ea081daab59b5dd7a17648a004e9ca377a5ed2a97a84e2ad805df2e2533d"
-   *
-   * @returns {Promise<Tx>} transaction payload
-   */
-  @Example<Tx>({
-    txid: '0x14a6ea081daab59b5dd7a17648a004e9ca377a5ed2a97a84e2ad805df2e2533d',
-    blockHash: '0x748fff248d4a033c28cb6cc45b78ad7f471ac4d958971570e3e3afe4e0f84c1f',
-    blockHeight: 17512164,
-    timestamp: 1658197214,
-    status: 1,
-    from: '0xa3682Fe8fD73B90A7564585A436EC2D2AEb612eE',
-    to: '0x9D1170D30944F2E30664Be502aC57F6096fB5366',
-    confirmations: 119004,
-    value: '410000000000000000',
-    fee: '525000000000000',
-    gasLimit: '21000',
-    gasUsed: '21000',
-    gasPrice: '25000000000',
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('tx/{txid}')
-  async getTransaction(@Path() txid: string): Promise<Tx> {
-    return service.getTransaction(txid)
-  }
-
+export class Avalanche extends EVM implements BaseAPI, API {
   /**
    * Get the estimated gas cost of a transaction
    *
@@ -247,58 +106,5 @@ export class Avalanche extends Controller implements BaseAPI, API {
   @Get('/gas/fees')
   async getGasFees(): Promise<GasFees> {
     return service.getGasFees()
-  }
-
-  /**
-   * Broadcast signed raw transaction
-   *
-   * @param {SendTxBody} body serialized raw transaction hex
-   *
-   * @returns {Promise<string>} transaction id
-   *
-   * @example body {
-   *    "hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-   * }
-   */
-  @Example<string>('0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd')
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Post('send/')
-  async sendTx(@Body() body: SendTxBody): Promise<string> {
-    return service.sendTx(body)
-  }
-
-  /**
-   * Get token metadata
-   *
-   * @param {string} contract contract address
-   * @param {string} id token identifier
-   * @param {TokenType} type token type (erc721 or erc1155)
-   *
-   * @returns {Promise<TokenMetadata>} token metadata
-   *
-   * @example contractAddress "0x3025C5c2aA6eb7364555aAC0074292195701bBD6"
-   * @example id "4525"
-   * @example type "erc721"
-   */
-  @Example<TokenMetadata>({
-    name: 'MadSkullz #5136',
-    description:
-      'MadSkullz #5136 is one of the 6666 NFTs from MadSkullz Collection that are joining SkullzCity to fight for Freedomz.',
-    media: {
-      url: 'https://cdn.madskullz.io/madskullz/images/5136.png',
-      type: 'image',
-    },
-  })
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('/metadata/token')
-  async getTokenMetadata(
-    @Query() contract: string,
-    @Query() id: string,
-    @Query() type: TokenType
-  ): Promise<TokenMetadata> {
-    return service.getTokenMetadata(contract, id, type)
   }
 }

--- a/node/coinstacks/avalanche/api/src/swagger.json
+++ b/node/coinstacks/avalanche/api/src/swagger.json
@@ -311,6 +311,146 @@
 				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
 				"description": "Contains info about EVM transaction history"
 			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method",
+					"params"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
 			"GasEstimate": {
 				"description": "Contains info about estimated gas cost of a transaction",
 				"properties": {
@@ -373,63 +513,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"SendTxBody": {
-				"description": "Contains the serialized raw transaction hex",
-				"properties": {
-					"hex": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"hex"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenMetadata": {
-				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"media": {
-						"properties": {
-							"type": {
-								"type": "string",
-								"enum": [
-									"image",
-									"video"
-								]
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"url"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"description",
-					"media"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenType": {
-				"type": "string",
-				"enum": [
-					"erc721",
-					"erc1155"
-				],
-				"description": "Supported token types for token metadata"
 			}
 		},
 		"securitySchemes": {}
@@ -488,17 +571,17 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"balance": "183750000000000",
+											"balance": "284809805024198107",
 											"unconfirmedBalance": "0",
-											"nonce": 322,
-											"pubkey": "0x9D1170D30944F2E30664Be502aC57F6096fB5366",
+											"nonce": 1,
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
 											"tokens": [
 												{
 													"balance": "1337",
-													"contract": "0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB",
+													"contract": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
 													"decimals": 18,
-													"name": "Wrapped Ether",
-													"symbol": "WETH.e",
+													"name": "FOX",
+													"symbol": "FOX",
 													"type": "ERC20"
 												}
 											]
@@ -552,8 +635,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
+						}
 					}
 				]
 			}
@@ -572,23 +654,24 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"pubkey": "0x9D1170D30944F2E30664Be502aC57F6096fB5366",
-											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoyLCJleHBsb3JlclBhZ2UiOjEsImJsb2NrYm9va1R4aWQiOiIweDE0YTZlYTA4MWRhYWI1OWI1ZGQ3YTE3NjQ4YTAwNGU5Y2EzNzdhNWVkMmE5N2E4NGUyYWQ4MDVkZjJlMjUzM2QiLCJibG9ja0hlaWdodCI6MTc1MTIxNjR9",
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==",
 											"txs": [
 												{
-													"txid": "0x14a6ea081daab59b5dd7a17648a004e9ca377a5ed2a97a84e2ad805df2e2533d",
-													"blockHash": "0x748fff248d4a033c28cb6cc45b78ad7f471ac4d958971570e3e3afe4e0f84c1f",
-													"blockHeight": 17512164,
-													"timestamp": 1658197214,
+													"txid": "0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002",
+													"blockHash": "0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8",
+													"blockHeight": 12267105,
+													"timestamp": 1618788849,
 													"status": 1,
-													"from": "0xa3682Fe8fD73B90A7564585A436EC2D2AEb612eE",
-													"to": "0x9D1170D30944F2E30664Be502aC57F6096fB5366",
-													"confirmations": 119004,
-													"value": "410000000000000000",
-													"fee": "525000000000000",
+													"from": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+													"to": "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7",
+													"confirmations": 2088440,
+													"value": "737092621690531649",
+													"fee": "3180000000009000",
 													"gasLimit": "21000",
 													"gasUsed": "21000",
-													"gasPrice": "25000000000"
+													"gasPrice": "151428571429",
+													"inputData": "0x"
 												}
 											]
 										}
@@ -641,8 +724,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x9D1170D30944F2E30664Be502aC57F6096fB5366"
+						}
 					},
 					{
 						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
@@ -701,19 +783,20 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"txid": "0x14a6ea081daab59b5dd7a17648a004e9ca377a5ed2a97a84e2ad805df2e2533d",
-											"blockHash": "0x748fff248d4a033c28cb6cc45b78ad7f471ac4d958971570e3e3afe4e0f84c1f",
-											"blockHeight": 17512164,
-											"timestamp": 1658197214,
+											"txid": "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d",
+											"blockHash": "0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7",
+											"blockHeight": 14813163,
+											"timestamp": 1653078780,
 											"status": 1,
-											"from": "0xa3682Fe8fD73B90A7564585A436EC2D2AEb612eE",
-											"to": "0x9D1170D30944F2E30664Be502aC57F6096fB5366",
-											"confirmations": 119004,
-											"value": "410000000000000000",
-											"fee": "525000000000000",
-											"gasLimit": "21000",
+											"from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
+											"to": "0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD",
+											"confirmations": 21,
+											"value": "49396718157429775",
+											"fee": "603633477678000",
+											"gasLimit": "250000",
 											"gasUsed": "21000",
-											"gasPrice": "25000000000"
+											"gasPrice": "28744451318",
+											"inputData": "0x"
 										}
 									}
 								}
@@ -764,8 +847,225 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x14a6ea081daab59b5dd7a17648a004e9ca377a5ed2a97a84e2ad805df2e2533d"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"name": "Foxy",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
 					}
 				]
 			}
@@ -916,164 +1216,6 @@
 				],
 				"security": [],
 				"parameters": []
-			}
-		},
-		"/api/v1/send": {
-			"post": {
-				"operationId": "SendTx",
-				"responses": {
-					"200": {
-						"description": "transaction id",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "string"
-								},
-								"examples": {
-									"Example 1": {
-										"value": "0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/BadRequestError"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Broadcast signed raw transaction",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "serialized raw transaction hex",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/SendTxBody",
-								"description": "serialized raw transaction hex"
-							},
-							"example": {
-								"hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/metadata/token": {
-			"get": {
-				"operationId": "GetTokenMetadata",
-				"responses": {
-					"200": {
-						"description": "token metadata",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TokenMetadata"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"name": "MadSkullz #5136",
-											"description": "MadSkullz #5136 is one of the 6666 NFTs from MadSkullz Collection that are joining SkullzCity to fight for Freedomz.",
-											"media": {
-												"url": "https://cdn.madskullz.io/madskullz/images/5136.png",
-												"type": "image"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get token metadata",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "contract address",
-						"in": "query",
-						"name": "contract",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "0x3025C5c2aA6eb7364555aAC0074292195701bBD6"
-					},
-					{
-						"description": "token identifier",
-						"in": "query",
-						"name": "id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "4525"
-					},
-					{
-						"description": "token type (erc721 or erc1155)",
-						"in": "query",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/TokenType"
-						}
-					}
-				]
 			}
 		}
 	},

--- a/node/coinstacks/bnbsmartchain/api/src/controller.ts
+++ b/node/coinstacks/bnbsmartchain/api/src/controller.ts
@@ -1,25 +1,10 @@
 import { ethers } from 'ethers'
-import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
+import { Example, Get, Query, Response, Route, Tags } from 'tsoa'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  BadRequestError,
-  BaseAPI,
-  BaseInfo,
-  InternalServerError,
-  SendTxBody,
-  ValidationError,
-} from '../../../common/api/src' // unable to import models from a module with tsoa
-import {
-  API,
-  Account,
-  GasFees,
-  Tx,
-  TxHistory,
-  GasEstimate,
-  TokenType,
-  TokenMetadata,
-} from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { BaseAPI, InternalServerError, ValidationError } from '../../../common/api/src' // unable to import models from a module with tsoa
+import { API, GasEstimate, GasFees } from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { EVM } from '../../../common/api/src/evm/controller'
 import { Service } from '../../../common/api/src/evm/service'
 import { GasOracle } from '../../../common/api/src/evm/gasOracle'
 
@@ -55,138 +40,12 @@ export const service = new Service({
   rpcApiKey: RPC_API_KEY,
 })
 
+// assign service to be used for all instances of EVM
+EVM.service = service
+
 @Route('api/v1')
 @Tags('v1')
-export class BNBSmartChain extends Controller implements BaseAPI, API {
-  /**
-   * Get information about the running coinstack
-   *
-   * @returns {Promise<BaseInfo>} coinstack info
-   */
-  @Example<BaseInfo>({
-    network: 'mainnet',
-  })
-  @Get('info/')
-  async getInfo(): Promise<BaseInfo> {
-    return {
-      network: NETWORK as string,
-    }
-  }
-
-  /**
-   * Get account details by address
-   *
-   * @param {string} pubkey account address
-   *
-   * @returns {Promise<Account>} account details
-   *
-   * @example pubkey "0xC480394241c76F3993ec5D121ce4F198f7844443"
-   */
-  @Example<Account>({
-    balance: '294505451261967226',
-    unconfirmedBalance: '0',
-    nonce: 74,
-    pubkey: '0xC480394241c76F3993ec5D121ce4F198f7844443',
-    tokens: [
-      {
-        balance: '0',
-        contract: '0x04756126F044634C9a0f0E985e60c88a51ACC206',
-        decimals: 18,
-        name: 'Carbon',
-        symbol: 'CSIX',
-        type: 'BEP20',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}')
-  async getAccount(@Path() pubkey: string): Promise<Account> {
-    return service.getAccount(pubkey)
-  }
-
-  /**
-   * Get transaction history by address
-   *
-   * @param {string} pubkey account address
-   * @param {string} [cursor] the cursor returned in previous query (base64 encoded json object with a 'page' property)
-   * @param {number} [pageSize] page size (10 by default)
-   * @param {number} [from] from block number (0 by default)
-   * @param {number} [to] to block number (pending by default)
-   *
-   * @returns {Promise<TxHistory>} transaction history
-   *
-   * @example pubkey "0xC480394241c76F3993ec5D121ce4F198f7844443"
-   */
-  @Example<TxHistory>({
-    pubkey: '0xC480394241c76F3993ec5D121ce4F198f7844443',
-    cursor:
-      'eyJibG9ja2Jvb2tQYWdlIjoxLCJleHBsb3JlclBhZ2UiOjEsImV4cGxvcmVyVHhpZCI6IjB4MTVkODlmMTdmOWQ2NmZiM2VkMTIwZTc3Mjc0NWQ1MTIzODQ3ZGY3MjM2N2EyNWMwNGUzYWRjY2JlYjgwM2FiMyIsImJsb2NrYm9va1R4aWQiOiIweDJkZjdkZTM1ZTk1NmE3ZTY1M2M1YTE3Mjc2NzM5ZGViNmY0NGUzOGZlMDRiMmUxYjcwYTc2ZmE4YjA2NWNkYjIiLCJibG9ja0hlaWdodCI6MjU4Mzk1Njl9',
-    txs: [
-      {
-        txid: '0x025b88d4b35e1fd28ee372deb1cb28c2c862703dce444629c47e27b8b8759cc4',
-        blockHash: '0x695b9e8a01b9564387bde6d52fd2775867c7b56ee0c1a9d61bbcc2b38a9c835f',
-        blockHeight: 25839827,
-        timestamp: 1676923869,
-        status: 1,
-        from: '0xC480394241c76F3993ec5D121ce4F198f7844443',
-        to: '0x215B8E1810Bb8FCcf2D90eE87631F16B5F4a895f',
-        confirmations: 50,
-        value: '1200000000000000000',
-        fee: '105000000000000',
-        gasLimit: '21000',
-        gasUsed: '21000',
-        gasPrice: '5000000000',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}/txs')
-  async getTxHistory(
-    @Path() pubkey: string,
-    @Query() cursor?: string,
-    @Query() pageSize = 10,
-    @Query() from?: number,
-    @Query() to?: number
-  ): Promise<TxHistory> {
-    return service.getTxHistory(pubkey, cursor, pageSize, from, to)
-  }
-
-  /**
-   * Get transaction details
-   *
-   * @param {string} txid transaction hash
-   *
-   * @example txid "0x025b88d4b35e1fd28ee372deb1cb28c2c862703dce444629c47e27b8b8759cc4"
-   *
-   * @returns {Promise<Tx>} transaction payload
-   */
-  @Example<Tx>({
-    txid: '0x025b88d4b35e1fd28ee372deb1cb28c2c862703dce444629c47e27b8b8759cc4',
-    blockHash: '0x695b9e8a01b9564387bde6d52fd2775867c7b56ee0c1a9d61bbcc2b38a9c835f',
-    blockHeight: 25839827,
-    timestamp: 1676923869,
-    status: 1,
-    from: '0xC480394241c76F3993ec5D121ce4F198f7844443',
-    to: '0x215B8E1810Bb8FCcf2D90eE87631F16B5F4a895f',
-    confirmations: 50,
-    value: '1200000000000000000',
-    fee: '105000000000000',
-    gasLimit: '21000',
-    gasUsed: '21000',
-    gasPrice: '5000000000',
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('tx/{txid}')
-  async getTransaction(@Path() txid: string): Promise<Tx> {
-    return service.getTransaction(txid)
-  }
-
+export class BNBSmartChain extends EVM implements BaseAPI, API {
   /**
    * Get the estimated gas cost of a transaction
    *
@@ -244,58 +103,5 @@ export class BNBSmartChain extends Controller implements BaseAPI, API {
   @Get('/gas/fees')
   async getGasFees(): Promise<GasFees> {
     return service.getGasFees()
-  }
-
-  /**
-   * Broadcast signed raw transaction
-   *
-   * @param {SendTxBody} body serialized raw transaction hex
-   *
-   * @returns {Promise<string>} transaction id
-   *
-   * @example body {
-   *    "hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-   * }
-   */
-  @Example<string>('0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd')
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Post('send/')
-  async sendTx(@Body() body: SendTxBody): Promise<string> {
-    return service.sendTx(body)
-  }
-
-  /**
-  /**
-   * Get token metadata
-   *
-   * @param {string} contract contract address
-   * @param {string} id token identifier
-   * @param {TokenType} type token type (erc721 or erc1155)
-   *
-   * @returns {Promise<TokenMetadata>} token metadata
-   *
-   * @example contractAddress "0x5000Aecf70A935E49C5A1c8AC3469430A8d39072"
-   * @example id "47240"
-   * @example type "erc721"
-   */
-  @Example<TokenMetadata>({
-    name: 'Giant Squid zkGalxe Special NFT | Manta Network',
-    description: '',
-    media: {
-      url: 'https://cdn.galxe.com/galaxy/mantanetwork/54518748-d6e7-4ab4-9386-e941bfc42945.png',
-      type: 'image',
-    },
-  })
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('/metadata/token')
-  async getTokenMetadata(
-    @Query() contract: string,
-    @Query() id: string,
-    @Query() type: TokenType
-  ): Promise<TokenMetadata> {
-    return service.getTokenMetadata(contract, id, type)
   }
 }

--- a/node/coinstacks/bnbsmartchain/api/src/swagger.json
+++ b/node/coinstacks/bnbsmartchain/api/src/swagger.json
@@ -311,6 +311,146 @@
 				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
 				"description": "Contains info about EVM transaction history"
 			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method",
+					"params"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
 			"GasEstimate": {
 				"description": "Contains info about estimated gas cost of a transaction",
 				"properties": {
@@ -373,63 +513,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"SendTxBody": {
-				"description": "Contains the serialized raw transaction hex",
-				"properties": {
-					"hex": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"hex"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenMetadata": {
-				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"media": {
-						"properties": {
-							"type": {
-								"type": "string",
-								"enum": [
-									"image",
-									"video"
-								]
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"url"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"description",
-					"media"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenType": {
-				"type": "string",
-				"enum": [
-					"erc721",
-					"erc1155"
-				],
-				"description": "Supported token types for token metadata"
 			}
 		},
 		"securitySchemes": {}
@@ -488,18 +571,18 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"balance": "294505451261967226",
+											"balance": "284809805024198107",
 											"unconfirmedBalance": "0",
-											"nonce": 74,
-											"pubkey": "0xC480394241c76F3993ec5D121ce4F198f7844443",
+											"nonce": 1,
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
 											"tokens": [
 												{
-													"balance": "0",
-													"contract": "0x04756126F044634C9a0f0E985e60c88a51ACC206",
+													"balance": "1337",
+													"contract": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
 													"decimals": 18,
-													"name": "Carbon",
-													"symbol": "CSIX",
-													"type": "BEP20"
+													"name": "FOX",
+													"symbol": "FOX",
+													"type": "ERC20"
 												}
 											]
 										}
@@ -552,8 +635,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xC480394241c76F3993ec5D121ce4F198f7844443"
+						}
 					}
 				]
 			}
@@ -572,23 +654,24 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"pubkey": "0xC480394241c76F3993ec5D121ce4F198f7844443",
-											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoxLCJleHBsb3JlclBhZ2UiOjEsImV4cGxvcmVyVHhpZCI6IjB4MTVkODlmMTdmOWQ2NmZiM2VkMTIwZTc3Mjc0NWQ1MTIzODQ3ZGY3MjM2N2EyNWMwNGUzYWRjY2JlYjgwM2FiMyIsImJsb2NrYm9va1R4aWQiOiIweDJkZjdkZTM1ZTk1NmE3ZTY1M2M1YTE3Mjc2NzM5ZGViNmY0NGUzOGZlMDRiMmUxYjcwYTc2ZmE4YjA2NWNkYjIiLCJibG9ja0hlaWdodCI6MjU4Mzk1Njl9",
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==",
 											"txs": [
 												{
-													"txid": "0x025b88d4b35e1fd28ee372deb1cb28c2c862703dce444629c47e27b8b8759cc4",
-													"blockHash": "0x695b9e8a01b9564387bde6d52fd2775867c7b56ee0c1a9d61bbcc2b38a9c835f",
-													"blockHeight": 25839827,
-													"timestamp": 1676923869,
+													"txid": "0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002",
+													"blockHash": "0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8",
+													"blockHeight": 12267105,
+													"timestamp": 1618788849,
 													"status": 1,
-													"from": "0xC480394241c76F3993ec5D121ce4F198f7844443",
-													"to": "0x215B8E1810Bb8FCcf2D90eE87631F16B5F4a895f",
-													"confirmations": 50,
-													"value": "1200000000000000000",
-													"fee": "105000000000000",
+													"from": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+													"to": "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7",
+													"confirmations": 2088440,
+													"value": "737092621690531649",
+													"fee": "3180000000009000",
 													"gasLimit": "21000",
 													"gasUsed": "21000",
-													"gasPrice": "5000000000"
+													"gasPrice": "151428571429",
+													"inputData": "0x"
 												}
 											]
 										}
@@ -641,8 +724,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xC480394241c76F3993ec5D121ce4F198f7844443"
+						}
 					},
 					{
 						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
@@ -701,19 +783,20 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"txid": "0x025b88d4b35e1fd28ee372deb1cb28c2c862703dce444629c47e27b8b8759cc4",
-											"blockHash": "0x695b9e8a01b9564387bde6d52fd2775867c7b56ee0c1a9d61bbcc2b38a9c835f",
-											"blockHeight": 25839827,
-											"timestamp": 1676923869,
+											"txid": "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d",
+											"blockHash": "0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7",
+											"blockHeight": 14813163,
+											"timestamp": 1653078780,
 											"status": 1,
-											"from": "0xC480394241c76F3993ec5D121ce4F198f7844443",
-											"to": "0x215B8E1810Bb8FCcf2D90eE87631F16B5F4a895f",
-											"confirmations": 50,
-											"value": "1200000000000000000",
-											"fee": "105000000000000",
-											"gasLimit": "21000",
+											"from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
+											"to": "0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD",
+											"confirmations": 21,
+											"value": "49396718157429775",
+											"fee": "603633477678000",
+											"gasLimit": "250000",
 											"gasUsed": "21000",
-											"gasPrice": "5000000000"
+											"gasPrice": "28744451318",
+											"inputData": "0x"
 										}
 									}
 								}
@@ -764,8 +847,225 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x025b88d4b35e1fd28ee372deb1cb28c2c862703dce444629c47e27b8b8759cc4"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"name": "Foxy",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
 					}
 				]
 			}
@@ -916,164 +1216,6 @@
 				],
 				"security": [],
 				"parameters": []
-			}
-		},
-		"/api/v1/send": {
-			"post": {
-				"operationId": "SendTx",
-				"responses": {
-					"200": {
-						"description": "transaction id",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "string"
-								},
-								"examples": {
-									"Example 1": {
-										"value": "0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/BadRequestError"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Broadcast signed raw transaction",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "serialized raw transaction hex",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/SendTxBody",
-								"description": "serialized raw transaction hex"
-							},
-							"example": {
-								"hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/metadata/token": {
-			"get": {
-				"operationId": "GetTokenMetadata",
-				"responses": {
-					"200": {
-						"description": "token metadata",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TokenMetadata"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"name": "Giant Squid zkGalxe Special NFT | Manta Network",
-											"description": "",
-											"media": {
-												"url": "https://cdn.galxe.com/galaxy/mantanetwork/54518748-d6e7-4ab4-9386-e941bfc42945.png",
-												"type": "image"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "/**\n  Get token metadata",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "contract address",
-						"in": "query",
-						"name": "contract",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "0x5000Aecf70A935E49C5A1c8AC3469430A8d39072"
-					},
-					{
-						"description": "token identifier",
-						"in": "query",
-						"name": "id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "47240"
-					},
-					{
-						"description": "token type (erc721 or erc1155)",
-						"in": "query",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/TokenType"
-						}
-					}
-				]
 			}
 		}
 	},

--- a/node/coinstacks/common/api/src/evm/controller.ts
+++ b/node/coinstacks/common/api/src/evm/controller.ts
@@ -1,0 +1,215 @@
+import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
+import {
+  BadRequestError,
+  BaseAPI,
+  BaseInfo,
+  InternalServerError,
+  RPCRequest,
+  RPCResponse,
+  SendTxBody,
+  ValidationError,
+} from '../'
+import { API, Account, Tx, TxHistory, TokenMetadata, TokenType } from './models'
+import { Service } from './service'
+
+const NETWORK = process.env.NETWORK
+
+if (!NETWORK) throw new Error('NETWORK env var not set')
+
+@Route('api/v1')
+@Tags('v1')
+export class EVM extends Controller implements BaseAPI, Omit<API, 'getGasFees' | 'estimateGas'> {
+  static service: Service
+
+  /**
+   * Get information about the running coinstack
+   *
+   * @returns {Promise<BaseInfo>} coinstack info
+   */
+  @Example<BaseInfo>({
+    network: 'mainnet',
+  })
+  @Get('info/')
+  async getInfo(): Promise<BaseInfo> {
+    return {
+      network: NETWORK as string,
+    }
+  }
+
+  /**
+   * Get account details by address
+   *
+   * @param {string} pubkey account address
+   *
+   * @returns {Promise<Account>} account details
+   */
+  @Example<Account>({
+    balance: '284809805024198107',
+    unconfirmedBalance: '0',
+    nonce: 1,
+    pubkey: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
+    tokens: [
+      {
+        balance: '1337',
+        contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
+        decimals: 18,
+        name: 'FOX',
+        symbol: 'FOX',
+        type: 'ERC20',
+      },
+    ],
+  })
+  @Response<BadRequestError>(400, 'Bad Request')
+  @Response<ValidationError>(422, 'Validation Error')
+  @Response<InternalServerError>(500, 'Internal Server Error')
+  @Get('account/{pubkey}')
+  async getAccount(@Path() pubkey: string): Promise<Account> {
+    return EVM.service.getAccount(pubkey)
+  }
+
+  /**
+   * Get transaction history by address
+   *
+   * @param {string} pubkey account address
+   * @param {string} [cursor] the cursor returned in previous query (base64 encoded json object with a 'page' property)
+   * @param {number} [pageSize] page size (10 by default)
+   * @param {number} [from] from block number (0 by default)
+   * @param {number} [to] to block number (pending by default)
+   *
+   * @returns {Promise<TxHistory>} transaction history
+   */
+  @Example<TxHistory>({
+    pubkey: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
+    cursor:
+      'eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==',
+    txs: [
+      {
+        txid: '0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002',
+        blockHash: '0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8',
+        blockHeight: 12267105,
+        timestamp: 1618788849,
+        status: 1,
+        from: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
+        to: '0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7',
+        confirmations: 2088440,
+        value: '737092621690531649',
+        fee: '3180000000009000',
+        gasLimit: '21000',
+        gasUsed: '21000',
+        gasPrice: '151428571429',
+        inputData: '0x',
+      },
+    ],
+  })
+  @Response<BadRequestError>(400, 'Bad Request')
+  @Response<ValidationError>(422, 'Validation Error')
+  @Response<InternalServerError>(500, 'Internal Server Error')
+  @Get('account/{pubkey}/txs')
+  async getTxHistory(
+    @Path() pubkey: string,
+    @Query() cursor?: string,
+    @Query() pageSize = 10,
+    @Query() from?: number,
+    @Query() to?: number
+  ): Promise<TxHistory> {
+    return EVM.service.getTxHistory(pubkey, cursor, pageSize, from, to)
+  }
+
+  /**
+   * Get transaction details
+   *
+   * @param {string} txid transaction hash
+   *
+   * @returns {Promise<Tx>} transaction payload
+   */
+  @Example<Tx>({
+    txid: '0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d',
+    blockHash: '0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7',
+    blockHeight: 14813163,
+    timestamp: 1653078780,
+    status: 1,
+    from: '0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8',
+    to: '0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD',
+    confirmations: 21,
+    value: '49396718157429775',
+    fee: '603633477678000',
+    gasLimit: '250000',
+    gasUsed: '21000',
+    gasPrice: '28744451318',
+    inputData: '0x',
+  })
+  @Response<BadRequestError>(400, 'Bad Request')
+  @Response<ValidationError>(422, 'Validation Error')
+  @Response<InternalServerError>(500, 'Internal Server Error')
+  @Get('tx/{txid}')
+  async getTransaction(@Path() txid: string): Promise<Tx> {
+    return EVM.service.getTransaction(txid)
+  }
+
+  /**
+   * Sends raw transaction to be broadcast to the node.
+   *
+   * @param {SendTxBody} body serialized raw transaction hex
+   *
+   * @returns {Promise<string>} transaction id
+   */
+  @Response<BadRequestError>(400, 'Bad Request')
+  @Response<ValidationError>(422, 'Validation Error')
+  @Response<InternalServerError>(500, 'Internal Server Error')
+  @Post('send/')
+  async sendTx(@Body() body: SendTxBody): Promise<string> {
+    return EVM.service.sendTx(body)
+  }
+
+  /**
+   * Makes a jsonrpc request to the node.
+   *
+   * @param {RPCRequest | Array<RPCRequest>} body jsonrpc request or batch requests
+   *
+   * @returns {Promise<RPCResponse | Array<RPCResponse>>} jsonrpc response or batch responses
+   *
+   * @example body {
+   *    "jsonrpc": "2.0",
+   *    "id": "test",
+   *    "method": "eth_blockNumber",
+   *    "params": []
+   * }
+   */
+  @Example<RPCResponse>({
+    jsonrpc: '2.0',
+    id: 'test',
+    result: '0x1a4',
+  })
+  @Post('jsonrpc/')
+  async doRpcRequest(@Body() body: RPCRequest | Array<RPCRequest>): Promise<RPCResponse | Array<RPCResponse>> {
+    return EVM.service.doRpcRequest(body)
+  }
+
+  /**
+   * Get token metadata
+   *
+   * @param {string} contract contract address
+   * @param {string} id token identifier
+   * @param {TokenType} type token type (erc721 or erc1155)
+   *
+   * @returns {Promise<TokenMetadata>} token metadata
+   */
+  @Example<TokenMetadata>({
+    name: 'Foxy',
+    description: 'FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle',
+    media: {
+      url: 'https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru',
+      type: 'image',
+    },
+  })
+  @Response<ValidationError>(422, 'Validation Error')
+  @Response<InternalServerError>(500, 'Internal Server Error')
+  @Get('/metadata/token')
+  async getTokenMetadata(
+    @Query() contract: string,
+    @Query() id: string,
+    @Query() type: TokenType
+  ): Promise<TokenMetadata> {
+    return EVM.service.getTokenMetadata(contract, id, type)
+  }
+}

--- a/node/coinstacks/common/api/src/evm/controller.ts
+++ b/node/coinstacks/common/api/src/evm/controller.ts
@@ -44,10 +44,10 @@ export class EVM extends Controller implements BaseAPI, Omit<API, 'getGasFees' |
    * @returns {Promise<Account>} account details
    */
   @Example<Account>({
-    balance: '284809805024198107',
+    balance: '0',
     unconfirmedBalance: '0',
-    nonce: 1,
-    pubkey: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
+    nonce: 0,
+    pubkey: '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
     tokens: [
       {
         balance: '1337',
@@ -79,25 +79,22 @@ export class EVM extends Controller implements BaseAPI, Omit<API, 'getGasFees' |
    * @returns {Promise<TxHistory>} transaction history
    */
   @Example<TxHistory>({
-    pubkey: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
-    cursor:
-      'eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==',
+    pubkey: '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
     txs: [
       {
-        txid: '0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002',
-        blockHash: '0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8',
-        blockHeight: 12267105,
-        timestamp: 1618788849,
+        txid: '0x6850c6f3af68eb60a211af8f07f5b305375d0c94786b79a48371f5143953cb26',
+        blockHash: '0x969bda3f454330557492deacffb0ee8a7fd1d094cf884926d24c71ad11ed13bb',
+        blockHeight: 15624164,
+        timestamp: 1664275343,
         status: 1,
-        from: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
-        to: '0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7',
-        confirmations: 2088440,
-        value: '737092621690531649',
-        fee: '3180000000009000',
+        from: '0xc730B028dA66EBB14f20e67c68DD809FBC49890D',
+        to: '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
+        confirmations: 3911254,
+        value: '5384660932716527',
+        fee: '278408778879000',
         gasLimit: '21000',
         gasUsed: '21000',
-        gasPrice: '151428571429',
-        inputData: '0x',
+        gasPrice: '13257560899',
       },
     ],
   })
@@ -123,20 +120,19 @@ export class EVM extends Controller implements BaseAPI, Omit<API, 'getGasFees' |
    * @returns {Promise<Tx>} transaction payload
    */
   @Example<Tx>({
-    txid: '0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d',
-    blockHash: '0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7',
-    blockHeight: 14813163,
-    timestamp: 1653078780,
+    txid: '0x6850c6f3af68eb60a211af8f07f5b305375d0c94786b79a48371f5143953cb26',
+    blockHash: '0x969bda3f454330557492deacffb0ee8a7fd1d094cf884926d24c71ad11ed13bb',
+    blockHeight: 15624164,
+    timestamp: 1664275343,
     status: 1,
-    from: '0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8',
-    to: '0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD',
-    confirmations: 21,
-    value: '49396718157429775',
-    fee: '603633477678000',
-    gasLimit: '250000',
+    from: '0xc730B028dA66EBB14f20e67c68DD809FBC49890D',
+    to: '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF',
+    confirmations: 3911254,
+    value: '5384660932716527',
+    fee: '278408778879000',
+    gasLimit: '21000',
     gasUsed: '21000',
-    gasPrice: '28744451318',
-    inputData: '0x',
+    gasPrice: '13257560899',
   })
   @Response<BadRequestError>(400, 'Bad Request')
   @Response<ValidationError>(422, 'Validation Error')
@@ -195,7 +191,7 @@ export class EVM extends Controller implements BaseAPI, Omit<API, 'getGasFees' |
    * @returns {Promise<TokenMetadata>} token metadata
    */
   @Example<TokenMetadata>({
-    name: 'Foxy',
+    name: 'FoxyFox',
     description: 'FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle',
     media: {
       url: 'https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru',

--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -876,4 +876,14 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       }
     }
   }
+
+  async doRpcRequest(req: RPCRequest | Array<RPCRequest>): Promise<RPCResponse | Array<RPCResponse>> {
+    try {
+      const config = this.rpcApiKey ? { headers: { 'api-key': this.rpcApiKey } } : undefined
+      const { data } = await axiosWithRetry.post<RPCResponse>(this.rpcUrl, req, config)
+      return data
+    } catch (err) {
+      throw handleError(err)
+    }
+  }
 }

--- a/node/coinstacks/common/api/src/models.ts
+++ b/node/coinstacks/common/api/src/models.ts
@@ -74,3 +74,21 @@ export interface BaseTxHistory<T = BaseTx> extends Pagination {
   pubkey: string
   txs: Array<T>
 }
+
+export interface RPCRequest {
+  jsonrpc: '2.0'
+  id: string | number
+  method: string
+  params: Array<unknown>
+}
+
+export interface RPCResponse {
+  jsonrpc: '2.0'
+  id: string | number
+  result?: unknown
+  error?: {
+    code: number
+    message: string
+    data?: unknown
+  }
+}

--- a/node/coinstacks/common/api/src/types.ts
+++ b/node/coinstacks/common/api/src/types.ts
@@ -4,17 +4,3 @@
 export interface Cursor {
   page: number
 }
-
-export interface RPCRequest {
-  jsonrpc: '2.0'
-  id: string
-  method: string
-  params: Array<unknown>
-}
-
-export interface RPCResponse {
-  jsonrpc: '2.0'
-  id: string
-  result?: unknown
-  error?: Record<string, unknown>
-}

--- a/node/coinstacks/ethereum/api/src/controller.ts
+++ b/node/coinstacks/ethereum/api/src/controller.ts
@@ -1,25 +1,10 @@
 import { ethers } from 'ethers'
-import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
+import { Example, Get, Query, Response, Route, Tags } from 'tsoa'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  BadRequestError,
-  BaseAPI,
-  BaseInfo,
-  InternalServerError,
-  SendTxBody,
-  ValidationError,
-} from '../../../common/api/src' // unable to import models from a module with tsoa
-import {
-  API,
-  Account,
-  GasFees,
-  Tx,
-  TxHistory,
-  GasEstimate,
-  TokenMetadata,
-  TokenType,
-} from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { BaseAPI, InternalServerError, ValidationError } from '../../../common/api/src' // unable to import models from a module with tsoa
+import { API, GasEstimate, GasFees } from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { EVM } from '../../../common/api/src/evm/controller'
 import { Service } from '../../../common/api/src/evm/service'
 import { GasOracle } from '../../../common/api/src/evm/gasOracle'
 
@@ -58,140 +43,12 @@ export const service = new Service({
   rpcApiKey: RPC_API_KEY,
 })
 
+// assign service to be used for all instances of EVM
+EVM.service = service
+
 @Route('api/v1')
 @Tags('v1')
-export class Ethereum extends Controller implements BaseAPI, API {
-  /**
-   * Get information about the running coinstack
-   *
-   * @returns {Promise<BaseInfo>} coinstack info
-   */
-  @Example<BaseInfo>({
-    network: 'mainnet',
-  })
-  @Get('info/')
-  async getInfo(): Promise<BaseInfo> {
-    return {
-      network: NETWORK as string,
-    }
-  }
-
-  /**
-   * Get account details by address
-   *
-   * @param {string} pubkey account address
-   *
-   * @returns {Promise<Account>} account details
-   *
-   * @example pubkey "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa"
-   */
-  @Example<Account>({
-    balance: '284809805024198107',
-    unconfirmedBalance: '0',
-    nonce: 1,
-    pubkey: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
-    tokens: [
-      {
-        balance: '1337',
-        contract: '0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d',
-        decimals: 18,
-        name: 'FOX',
-        symbol: 'FOX',
-        type: 'ERC20',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}')
-  async getAccount(@Path() pubkey: string): Promise<Account> {
-    return service.getAccount(pubkey)
-  }
-
-  /**
-   * Get transaction history by address
-   *
-   * @param {string} pubkey account address
-   * @param {string} [cursor] the cursor returned in previous query (base64 encoded json object with a 'page' property)
-   * @param {number} [pageSize] page size (10 by default)
-   * @param {number} [from] from block number (0 by default)
-   * @param {number} [to] to block number (pending by default)
-   *
-   * @returns {Promise<TxHistory>} transaction history
-   *
-   * @example pubkey "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa"
-   */
-  @Example<TxHistory>({
-    pubkey: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
-    cursor:
-      'eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==',
-    txs: [
-      {
-        txid: '0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002',
-        blockHash: '0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8',
-        blockHeight: 12267105,
-        timestamp: 1618788849,
-        status: 1,
-        from: '0xB3DD70991aF983Cf82d95c46C24979ee98348ffa',
-        to: '0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7',
-        confirmations: 2088440,
-        value: '737092621690531649',
-        fee: '3180000000009000',
-        gasLimit: '21000',
-        gasUsed: '21000',
-        gasPrice: '151428571429',
-        inputData: '0x',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}/txs')
-  async getTxHistory(
-    @Path() pubkey: string,
-    @Query() cursor?: string,
-    @Query() pageSize = 10,
-    @Query() from?: number,
-    @Query() to?: number
-  ): Promise<TxHistory> {
-    return service.getTxHistory(pubkey, cursor, pageSize, from, to)
-  }
-
-  /**
-   * Get transaction details
-   *
-   * @param {string} txid transaction hash
-   *
-   * @example txid "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d"
-   *
-   * @returns {Promise<Tx>} transaction payload
-   */
-  @Example<Tx>({
-    txid: '0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d',
-    blockHash: '0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7',
-    blockHeight: 14813163,
-    timestamp: 1653078780,
-    status: 1,
-    from: '0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8',
-    to: '0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD',
-    confirmations: 21,
-    value: '49396718157429775',
-    fee: '603633477678000',
-    gasLimit: '250000',
-    gasUsed: '21000',
-    gasPrice: '28744451318',
-    inputData: '0x',
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('tx/{txid}')
-  async getTransaction(@Path() txid: string): Promise<Tx> {
-    return service.getTransaction(txid)
-  }
-
+export class Ethereum extends EVM implements BaseAPI, API {
   /**
    * Get the estimated gas cost of a transaction
    *
@@ -204,7 +61,7 @@ export class Ethereum extends Controller implements BaseAPI, API {
    *
    * @example data "0x"
    * @example from "0x0000000000000000000000000000000000000000"
-   * @example to "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7"
+   * @example to "0x0000000000000000000000000000000000000000"
    * @example value "1337"
    */
   @Example<GasEstimate>({ gasLimit: '26540' })
@@ -252,57 +109,5 @@ export class Ethereum extends Controller implements BaseAPI, API {
   @Get('/gas/fees')
   async getGasFees(): Promise<GasFees> {
     return service.getGasFees()
-  }
-
-  /**
-   * Sends raw transaction to be broadcast to the node.
-   *
-   * @param {SendTxBody} body serialized raw transaction hex
-   *
-   * @returns {Promise<string>} transaction id
-   *
-   * @example body {
-   *    "hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-   * }
-   */
-  @Example<string>('0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd')
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Post('send/')
-  async sendTx(@Body() body: SendTxBody): Promise<string> {
-    return service.sendTx(body)
-  }
-
-  /**
-   * Get token metadata
-   *
-   * @param {string} contract contract address
-   * @param {string} id token identifier
-   * @param {TokenType} type token type (erc721 or erc1155)
-   *
-   * @returns {Promise<TokenMetadata>} token metadata
-   *
-   * @example contractAddress "0x4Db1f25D3d98600140dfc18dEb7515Be5Bd293Af"
-   * @example id "3150"
-   * @example type "erc721"
-   */
-  @Example<TokenMetadata>({
-    name: 'HAPE #3150',
-    description: '8192 next-generation, high-fashion HAPES.',
-    media: {
-      url: 'https://meta.hapeprime.com/3150.png',
-      type: 'image',
-    },
-  })
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('/metadata/token')
-  async getTokenMetadata(
-    @Query() contract: string,
-    @Query() id: string,
-    @Query() type: TokenType
-  ): Promise<TokenMetadata> {
-    return service.getTokenMetadata(contract, id, type)
   }
 }

--- a/node/coinstacks/ethereum/api/src/swagger.json
+++ b/node/coinstacks/ethereum/api/src/swagger.json
@@ -311,6 +311,146 @@
 				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
 				"description": "Contains info about EVM transaction history"
 			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method",
+					"params"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
 			"GasEstimate": {
 				"description": "Contains info about estimated gas cost of a transaction",
 				"properties": {
@@ -373,63 +513,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"SendTxBody": {
-				"description": "Contains the serialized raw transaction hex",
-				"properties": {
-					"hex": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"hex"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenMetadata": {
-				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"media": {
-						"properties": {
-							"type": {
-								"type": "string",
-								"enum": [
-									"image",
-									"video"
-								]
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"url"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"description",
-					"media"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenType": {
-				"type": "string",
-				"enum": [
-					"erc721",
-					"erc1155"
-				],
-				"description": "Supported token types for token metadata"
 			}
 		},
 		"securitySchemes": {}
@@ -552,8 +635,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa"
+						}
 					}
 				]
 			}
@@ -642,8 +724,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa"
+						}
 					},
 					{
 						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
@@ -766,8 +847,225 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"name": "Foxy",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
 					}
 				]
 			}
@@ -848,7 +1146,7 @@
 						"schema": {
 							"type": "string"
 						},
-						"example": "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7"
+						"example": "0x0000000000000000000000000000000000000000"
 					},
 					{
 						"description": "transaction value in wei",
@@ -918,164 +1216,6 @@
 				],
 				"security": [],
 				"parameters": []
-			}
-		},
-		"/api/v1/send": {
-			"post": {
-				"operationId": "SendTx",
-				"responses": {
-					"200": {
-						"description": "transaction id",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "string"
-								},
-								"examples": {
-									"Example 1": {
-										"value": "0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/BadRequestError"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Sends raw transaction to be broadcast to the node.",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "serialized raw transaction hex",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/SendTxBody",
-								"description": "serialized raw transaction hex"
-							},
-							"example": {
-								"hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/metadata/token": {
-			"get": {
-				"operationId": "GetTokenMetadata",
-				"responses": {
-					"200": {
-						"description": "token metadata",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TokenMetadata"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"name": "HAPE #3150",
-											"description": "8192 next-generation, high-fashion HAPES.",
-											"media": {
-												"url": "https://meta.hapeprime.com/3150.png",
-												"type": "image"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get token metadata",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "contract address",
-						"in": "query",
-						"name": "contract",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "0x4Db1f25D3d98600140dfc18dEb7515Be5Bd293Af"
-					},
-					{
-						"description": "token identifier",
-						"in": "query",
-						"name": "id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "3150"
-					},
-					{
-						"description": "token type (erc721 or erc1155)",
-						"in": "query",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/TokenType"
-						}
-					}
-				]
 			}
 		}
 	},

--- a/node/coinstacks/gnosis/api/src/controller.ts
+++ b/node/coinstacks/gnosis/api/src/controller.ts
@@ -1,25 +1,10 @@
 import { ethers } from 'ethers'
-import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
+import { Example, Get, Query, Response, Route, Tags } from 'tsoa'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  BadRequestError,
-  BaseAPI,
-  BaseInfo,
-  InternalServerError,
-  SendTxBody,
-  ValidationError,
-} from '../../../common/api/src' // unable to import models from a module with tsoa
-import {
-  API,
-  Account,
-  GasFees,
-  Tx,
-  TxHistory,
-  GasEstimate,
-  TokenMetadata,
-  TokenType,
-} from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { BaseAPI, InternalServerError, ValidationError } from '../../../common/api/src' // unable to import models from a module with tsoa
+import { API, GasEstimate, GasFees } from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { EVM } from '../../../common/api/src/evm/controller'
 import { Service } from '../../../common/api/src/evm/service'
 import { GasOracle } from '../../../common/api/src/evm/gasOracle'
 
@@ -54,138 +39,12 @@ export const service = new Service({
   rpcUrl: RPC_URL,
 })
 
+// assign service to be used for all instances of EVM
+EVM.service = service
+
 @Route('api/v1')
 @Tags('v1')
-export class Gnosis extends Controller implements BaseAPI, API {
-  /**
-   * Get information about the running coinstack
-   *
-   * @returns {Promise<BaseInfo>} coinstack info
-   */
-  @Example<BaseInfo>({
-    network: 'mainnet',
-  })
-  @Get('info/')
-  async getInfo(): Promise<BaseInfo> {
-    return {
-      network: NETWORK as string,
-    }
-  }
-
-  /**
-   * Get account details by address
-   *
-   * @param {string} pubkey account address
-   *
-   * @returns {Promise<Account>} account details
-   *
-   * @example pubkey "0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0"
-   */
-  @Example<Account>({
-    balance: '400000000000000000',
-    unconfirmedBalance: '0',
-    nonce: 0,
-    pubkey: '0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0',
-    tokens: [
-      {
-        balance: '1510000000000000000000',
-        contract: '0x21a42669643f45Bc0e086b8Fc2ed70c23D67509d',
-        decimals: 18,
-        name: 'FOX on xDai',
-        symbol: 'FOX',
-        type: 'ERC20',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}')
-  async getAccount(@Path() pubkey: string): Promise<Account> {
-    return service.getAccount(pubkey)
-  }
-
-  /**
-   * Get transaction history by address
-   *
-   * @param {string} pubkey account address
-   * @param {string} [cursor] the cursor returned in previous query (base64 encoded json object with a 'page' property)
-   * @param {number} [pageSize] page size (10 by default)
-   * @param {number} [from] from block number (0 by default)
-   * @param {number} [to] to block number (pending by default)
-   *
-   * @returns {Promise<TxHistory>} transaction history
-   *
-   * @example pubkey "0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0"
-   */
-  @Example<TxHistory>({
-    pubkey: '0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0',
-    cursor:
-      'eyJibG9ja2Jvb2tQYWdlIjozLCJleHBsb3JlclBhZ2UiOjEsImJsb2NrYm9va1R4aWQiOiIweGNlZTEwY2ViNzAwZDJmOGI1ODQ2YzVhY2E5NTg5NjY2NGZjYzk2ZDQzYTdiODg2NzRiYjA3MzJjMDI4MGVhNGYiLCJibG9ja0hlaWdodCI6MjYyNDQ2MTJ9',
-    txs: [
-      {
-        txid: '0xee248fabdd59f26d78ae37d311a34ce8a87ebcfc2251a11245647266f3518c2f',
-        blockHash: '0x7104073111b319c81ef45d2c76e82ca1a582eb1094fa5a3302b83ca40bf5ae6d',
-        blockHeight: 27990203,
-        timestamp: 1684334420,
-        status: 1,
-        from: '0x9045A4d097F03f34f515A3b3e7B2fD889Dd2Abb7',
-        to: '0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0',
-        confirmations: 17368,
-        value: '400000000000000000',
-        fee: '31500000147000',
-        gasLimit: '21000',
-        gasUsed: '21000',
-        gasPrice: '1500000007',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}/txs')
-  async getTxHistory(
-    @Path() pubkey: string,
-    @Query() cursor?: string,
-    @Query() pageSize = 10,
-    @Query() from?: number,
-    @Query() to?: number
-  ): Promise<TxHistory> {
-    return service.getTxHistory(pubkey, cursor, pageSize, from, to)
-  }
-
-  /**
-   * Get transaction details
-   *
-   * @param {string} txid transaction hash
-   *
-   * @example txid "0xee248fabdd59f26d78ae37d311a34ce8a87ebcfc2251a11245647266f3518c2f"
-   *
-   * @returns {Promise<Tx>} transaction payload
-   */
-  @Example<Tx>({
-    txid: '0xee248fabdd59f26d78ae37d311a34ce8a87ebcfc2251a11245647266f3518c2f',
-    blockHash: '0x7104073111b319c81ef45d2c76e82ca1a582eb1094fa5a3302b83ca40bf5ae6d',
-    blockHeight: 27990203,
-    timestamp: 1684334420,
-    status: 1,
-    from: '0x9045A4d097F03f34f515A3b3e7B2fD889Dd2Abb7',
-    to: '0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0',
-    confirmations: 17385,
-    value: '400000000000000000',
-    fee: '31500000147000',
-    gasLimit: '21000',
-    gasUsed: '21000',
-    gasPrice: '1500000007',
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('tx/{txid}')
-  async getTransaction(@Path() txid: string): Promise<Tx> {
-    return service.getTransaction(txid)
-  }
-
+export class Gnosis extends EVM implements BaseAPI, API {
   /**
    * Get the estimated gas cost of a transaction
    *
@@ -246,57 +105,5 @@ export class Gnosis extends Controller implements BaseAPI, API {
   @Get('/gas/fees')
   async getGasFees(): Promise<GasFees> {
     return service.getGasFees()
-  }
-
-  /**
-   * Sends raw transaction to be broadcast to the node.
-   *
-   * @param {SendTxBody} body serialized raw transaction hex
-   *
-   * @returns {Promise<string>} transaction id
-   *
-   * @example body {
-   *    "hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-   * }
-   */
-  @Example<string>('0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd')
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Post('send/')
-  async sendTx(@Body() body: SendTxBody): Promise<string> {
-    return service.sendTx(body)
-  }
-
-  /**
-   * Get token metadata
-   *
-   * @param {string} contract contract address
-   * @param {string} id token identifier
-   * @param {TokenType} type token type (erc721 or erc1155)
-   *
-   * @returns {Promise<TokenMetadata>} token metadata
-   *
-   * @example contractAddress "0xB7F00edD54533b61a39e6E3B7bE710725DffB9d8"
-   * @example id "285605"
-   * @example type "erc721"
-   */
-  @Example<TokenMetadata>({
-    name: 'Loyalty Program',
-    description: 'Welcome to the zkBridge Loyalty Point Program.',
-    media: {
-      url: 'https://gateway.pinata.cloud/ipfs/QmVSiYEQaksNSR2vpKazf6vfe69xA2odJWurVEu4r53Cof',
-      type: 'image',
-    },
-  })
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('/metadata/token')
-  async getTokenMetadata(
-    @Query() contract: string,
-    @Query() id: string,
-    @Query() type: TokenType
-  ): Promise<TokenMetadata> {
-    return service.getTokenMetadata(contract, id, type)
   }
 }

--- a/node/coinstacks/gnosis/api/src/swagger.json
+++ b/node/coinstacks/gnosis/api/src/swagger.json
@@ -311,6 +311,146 @@
 				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
 				"description": "Contains info about EVM transaction history"
 			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method",
+					"params"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
 			"GasEstimate": {
 				"description": "Contains info about estimated gas cost of a transaction",
 				"properties": {
@@ -373,63 +513,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"SendTxBody": {
-				"description": "Contains the serialized raw transaction hex",
-				"properties": {
-					"hex": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"hex"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenMetadata": {
-				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"media": {
-						"properties": {
-							"type": {
-								"type": "string",
-								"enum": [
-									"image",
-									"video"
-								]
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"url"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"description",
-					"media"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenType": {
-				"type": "string",
-				"enum": [
-					"erc721",
-					"erc1155"
-				],
-				"description": "Supported token types for token metadata"
 			}
 		},
 		"securitySchemes": {}
@@ -488,16 +571,16 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"balance": "400000000000000000",
+											"balance": "284809805024198107",
 											"unconfirmedBalance": "0",
-											"nonce": 0,
-											"pubkey": "0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0",
+											"nonce": 1,
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
 											"tokens": [
 												{
-													"balance": "1510000000000000000000",
-													"contract": "0x21a42669643f45Bc0e086b8Fc2ed70c23D67509d",
+													"balance": "1337",
+													"contract": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
 													"decimals": 18,
-													"name": "FOX on xDai",
+													"name": "FOX",
 													"symbol": "FOX",
 													"type": "ERC20"
 												}
@@ -552,8 +635,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0"
+						}
 					}
 				]
 			}
@@ -572,23 +654,24 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"pubkey": "0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0",
-											"cursor": "eyJibG9ja2Jvb2tQYWdlIjozLCJleHBsb3JlclBhZ2UiOjEsImJsb2NrYm9va1R4aWQiOiIweGNlZTEwY2ViNzAwZDJmOGI1ODQ2YzVhY2E5NTg5NjY2NGZjYzk2ZDQzYTdiODg2NzRiYjA3MzJjMDI4MGVhNGYiLCJibG9ja0hlaWdodCI6MjYyNDQ2MTJ9",
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==",
 											"txs": [
 												{
-													"txid": "0xee248fabdd59f26d78ae37d311a34ce8a87ebcfc2251a11245647266f3518c2f",
-													"blockHash": "0x7104073111b319c81ef45d2c76e82ca1a582eb1094fa5a3302b83ca40bf5ae6d",
-													"blockHeight": 27990203,
-													"timestamp": 1684334420,
+													"txid": "0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002",
+													"blockHash": "0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8",
+													"blockHeight": 12267105,
+													"timestamp": 1618788849,
 													"status": 1,
-													"from": "0x9045A4d097F03f34f515A3b3e7B2fD889Dd2Abb7",
-													"to": "0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0",
-													"confirmations": 17368,
-													"value": "400000000000000000",
-													"fee": "31500000147000",
+													"from": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+													"to": "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7",
+													"confirmations": 2088440,
+													"value": "737092621690531649",
+													"fee": "3180000000009000",
 													"gasLimit": "21000",
 													"gasUsed": "21000",
-													"gasPrice": "1500000007"
+													"gasPrice": "151428571429",
+													"inputData": "0x"
 												}
 											]
 										}
@@ -641,8 +724,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0"
+						}
 					},
 					{
 						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
@@ -701,19 +783,20 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"txid": "0xee248fabdd59f26d78ae37d311a34ce8a87ebcfc2251a11245647266f3518c2f",
-											"blockHash": "0x7104073111b319c81ef45d2c76e82ca1a582eb1094fa5a3302b83ca40bf5ae6d",
-											"blockHeight": 27990203,
-											"timestamp": 1684334420,
+											"txid": "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d",
+											"blockHash": "0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7",
+											"blockHeight": 14813163,
+											"timestamp": 1653078780,
 											"status": 1,
-											"from": "0x9045A4d097F03f34f515A3b3e7B2fD889Dd2Abb7",
-											"to": "0xBA7A4c521DfCD18fEB7cdA4B7CA182d739B7A6a0",
-											"confirmations": 17385,
-											"value": "400000000000000000",
-											"fee": "31500000147000",
-											"gasLimit": "21000",
+											"from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
+											"to": "0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD",
+											"confirmations": 21,
+											"value": "49396718157429775",
+											"fee": "603633477678000",
+											"gasLimit": "250000",
 											"gasUsed": "21000",
-											"gasPrice": "1500000007"
+											"gasPrice": "28744451318",
+											"inputData": "0x"
 										}
 									}
 								}
@@ -764,8 +847,225 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xee248fabdd59f26d78ae37d311a34ce8a87ebcfc2251a11245647266f3518c2f"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"name": "Foxy",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
 					}
 				]
 			}
@@ -916,164 +1216,6 @@
 				],
 				"security": [],
 				"parameters": []
-			}
-		},
-		"/api/v1/send": {
-			"post": {
-				"operationId": "SendTx",
-				"responses": {
-					"200": {
-						"description": "transaction id",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "string"
-								},
-								"examples": {
-									"Example 1": {
-										"value": "0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/BadRequestError"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Sends raw transaction to be broadcast to the node.",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "serialized raw transaction hex",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/SendTxBody",
-								"description": "serialized raw transaction hex"
-							},
-							"example": {
-								"hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/metadata/token": {
-			"get": {
-				"operationId": "GetTokenMetadata",
-				"responses": {
-					"200": {
-						"description": "token metadata",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TokenMetadata"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"name": "Loyalty Program",
-											"description": "Welcome to the zkBridge Loyalty Point Program.",
-											"media": {
-												"url": "https://gateway.pinata.cloud/ipfs/QmVSiYEQaksNSR2vpKazf6vfe69xA2odJWurVEu4r53Cof",
-												"type": "image"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get token metadata",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "contract address",
-						"in": "query",
-						"name": "contract",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "0xB7F00edD54533b61a39e6E3B7bE710725DffB9d8"
-					},
-					{
-						"description": "token identifier",
-						"in": "query",
-						"name": "id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "285605"
-					},
-					{
-						"description": "token type (erc721 or erc1155)",
-						"in": "query",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/TokenType"
-						}
-					}
-				]
 			}
 		}
 	},

--- a/node/coinstacks/optimism/api/src/swagger.json
+++ b/node/coinstacks/optimism/api/src/swagger.json
@@ -311,6 +311,146 @@
 				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
 				"description": "Contains info about EVM transaction history"
 			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method",
+					"params"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
 			"OptimismGasEstimate": {
 				"description": "Contains info about estimated gas cost of a transaction on both L1 and L2",
 				"properties": {
@@ -381,63 +521,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"SendTxBody": {
-				"description": "Contains the serialized raw transaction hex",
-				"properties": {
-					"hex": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"hex"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenMetadata": {
-				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"media": {
-						"properties": {
-							"type": {
-								"type": "string",
-								"enum": [
-									"image",
-									"video"
-								]
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"url"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"description",
-					"media"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenType": {
-				"type": "string",
-				"enum": [
-					"erc721",
-					"erc1155"
-				],
-				"description": "Supported token types for token metadata"
 			}
 		},
 		"securitySchemes": {}
@@ -496,17 +579,17 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"balance": "1502668290366088",
+											"balance": "284809805024198107",
 											"unconfirmedBalance": "0",
 											"nonce": 1,
-											"pubkey": "0x15E03a18349cA885482F59935Af48C5fFbAb8DE1",
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
 											"tokens": [
 												{
-													"balance": "0",
-													"contract": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-													"decimals": 6,
-													"name": "USD Coin",
-													"symbol": "USDC",
+													"balance": "1337",
+													"contract": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
+													"decimals": 18,
+													"name": "FOX",
+													"symbol": "FOX",
 													"type": "ERC20"
 												}
 											]
@@ -560,8 +643,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x15E03a18349cA885482F59935Af48C5fFbAb8DE1"
+						}
 					}
 				]
 			}
@@ -580,35 +662,24 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"pubkey": "0x15E03a18349cA885482F59935Af48C5fFbAb8DE1",
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==",
 											"txs": [
 												{
-													"txid": "0xf4101d7a7fc71410b9ca82dce0b1cce153dea3d4d09bd83bbe510e28033e85db",
-													"blockHash": "0x980152b8671b1e3e3b0bd5d26f09a584210da32dbad3a586a2fa2bb7c6be926f",
-													"blockHeight": 60720938,
-													"timestamp": 1672939590,
+													"txid": "0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002",
+													"blockHash": "0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8",
+													"blockHeight": 12267105,
+													"timestamp": 1618788849,
 													"status": 1,
-													"from": "0x15E03a18349cA885482F59935Af48C5fFbAb8DE1",
-													"to": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-													"confirmations": 1002,
-													"value": "0",
-													"fee": "58723200000",
-													"gasLimit": "150000",
-													"gasUsed": "36702",
-													"gasPrice": "1600000",
-													"inputData": "0xa9059cbb000000000000000000000000ebe80f029b1c02862b9e8a70a7e5317c06f62cae000000000000000000000000000000000000000000000000000000000788d3b0",
-													"tokenTransfers": [
-														{
-															"contract": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-															"decimals": 6,
-															"name": "USD Coin",
-															"symbol": "USDC",
-															"type": "ERC20",
-															"from": "0x15E03a18349cA885482F59935Af48C5fFbAb8DE1",
-															"to": "0xEbe80f029b1c02862B9E8a70a7e5317C06F62Cae",
-															"value": "126407600"
-														}
-													]
+													"from": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+													"to": "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7",
+													"confirmations": 2088440,
+													"value": "737092621690531649",
+													"fee": "3180000000009000",
+													"gasLimit": "21000",
+													"gasUsed": "21000",
+													"gasPrice": "151428571429",
+													"inputData": "0x"
 												}
 											]
 										}
@@ -661,8 +732,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x15E03a18349cA885482F59935Af48C5fFbAb8DE1"
+						}
 					},
 					{
 						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
@@ -721,32 +791,20 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"txid": "0xf4101d7a7fc71410b9ca82dce0b1cce153dea3d4d09bd83bbe510e28033e85db",
-											"blockHash": "0x980152b8671b1e3e3b0bd5d26f09a584210da32dbad3a586a2fa2bb7c6be926f",
-											"blockHeight": 60720938,
-											"timestamp": 1672939590,
+											"txid": "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d",
+											"blockHash": "0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7",
+											"blockHeight": 14813163,
+											"timestamp": 1653078780,
 											"status": 1,
-											"from": "0x15E03a18349cA885482F59935Af48C5fFbAb8DE1",
-											"to": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-											"confirmations": 1303,
-											"value": "0",
-											"fee": "58723200000",
-											"gasLimit": "150000",
-											"gasUsed": "36702",
-											"gasPrice": "1600000",
-											"inputData": "0xa9059cbb000000000000000000000000ebe80f029b1c02862b9e8a70a7e5317c06f62cae000000000000000000000000000000000000000000000000000000000788d3b0",
-											"tokenTransfers": [
-												{
-													"contract": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-													"decimals": 6,
-													"name": "USD Coin",
-													"symbol": "USDC",
-													"type": "ERC20",
-													"from": "0x15E03a18349cA885482F59935Af48C5fFbAb8DE1",
-													"to": "0xEbe80f029b1c02862B9E8a70a7e5317C06F62Cae",
-													"value": "126407600"
-												}
-											]
+											"from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
+											"to": "0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD",
+											"confirmations": 21,
+											"value": "49396718157429775",
+											"fee": "603633477678000",
+											"gasLimit": "250000",
+											"gasUsed": "21000",
+											"gasPrice": "28744451318",
+											"inputData": "0x"
 										}
 									}
 								}
@@ -797,8 +855,225 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0xf4101d7a7fc71410b9ca82dce0b1cce153dea3d4d09bd83bbe510e28033e85db"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"name": "Foxy",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
 					}
 				]
 			}
@@ -943,164 +1218,6 @@
 				],
 				"security": [],
 				"parameters": []
-			}
-		},
-		"/api/v1/send": {
-			"post": {
-				"operationId": "SendTx",
-				"responses": {
-					"200": {
-						"description": "transaction id",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "string"
-								},
-								"examples": {
-									"Example 1": {
-										"value": "0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/BadRequestError"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Broadcast signed raw transaction",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "serialized raw transaction hex",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/SendTxBody",
-								"description": "serialized raw transaction hex"
-							},
-							"example": {
-								"hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/metadata/token": {
-			"get": {
-				"operationId": "GetTokenMetadata",
-				"responses": {
-					"200": {
-						"description": "token metadata",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TokenMetadata"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"name": "Fire 15976",
-											"description": "",
-											"media": {
-												"url": "https://dftqodalckck7.cloudfront.net/optimism/15976.svg",
-												"type": "image"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get token metadata",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "contract address",
-						"in": "query",
-						"name": "contract",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "0x081911b600Be8cf0E3545a0Ff9415C099C1b85fe"
-					},
-					{
-						"description": "token identifier",
-						"in": "query",
-						"name": "id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "15976"
-					},
-					{
-						"description": "token type (erc721 or erc1155)",
-						"in": "query",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/TokenType"
-						}
-					}
-				]
 			}
 		}
 	},

--- a/node/coinstacks/polygon/api/src/controller.ts
+++ b/node/coinstacks/polygon/api/src/controller.ts
@@ -1,25 +1,10 @@
 import { ethers } from 'ethers'
-import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
+import { Example, Get, Query, Response, Route, Tags } from 'tsoa'
 import { Blockbook } from '@shapeshiftoss/blockbook'
 import { Logger } from '@shapeshiftoss/logger'
-import {
-  BadRequestError,
-  BaseAPI,
-  BaseInfo,
-  InternalServerError,
-  SendTxBody,
-  ValidationError,
-} from '../../../common/api/src' // unable to import models from a module with tsoa
-import {
-  API,
-  Account,
-  GasFees,
-  Tx,
-  TxHistory,
-  GasEstimate,
-  TokenMetadata,
-  TokenType,
-} from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { BaseAPI, InternalServerError, ValidationError } from '../../../common/api/src' // unable to import models from a module with tsoa
+import { API, GasEstimate, GasFees } from '../../../common/api/src/evm' // unable to import models from a module with tsoa
+import { EVM } from '../../../common/api/src/evm/controller'
 import { Service } from '../../../common/api/src/evm/service'
 import { GasOracle } from '../../../common/api/src/evm/gasOracle'
 
@@ -56,167 +41,12 @@ export const service = new Service({
   rpcApiKey: RPC_API_KEY,
 })
 
+// assign service to be used for all instances of EVM
+EVM.service = service
+
 @Route('api/v1')
 @Tags('v1')
-export class Polygon extends Controller implements BaseAPI, API {
-  /**
-   * Get information about the running coinstack
-   *
-   * @returns {Promise<BaseInfo>} coinstack info
-   */
-  @Example<BaseInfo>({
-    network: 'mainnet',
-  })
-  @Get('info/')
-  async getInfo(): Promise<BaseInfo> {
-    return {
-      network: NETWORK as string,
-    }
-  }
-
-  /**
-   * Get account details by address
-   *
-   * @param {string} pubkey account address
-   *
-   * @returns {Promise<Account>} account details
-   *
-   * @example pubkey "0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA"
-   */
-  @Example<Account>({
-    balance: '5509799116755998875',
-    unconfirmedBalance: '0',
-    nonce: 6,
-    pubkey: '0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA',
-    tokens: [
-      {
-        balance: '504032777',
-        contract: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-        decimals: 6,
-        name: 'USD Coin (PoS)',
-        symbol: 'USDC',
-        type: 'ERC20',
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}')
-  async getAccount(@Path() pubkey: string): Promise<Account> {
-    return service.getAccount(pubkey)
-  }
-
-  /**
-   * Get transaction history by address
-   *
-   * @param {string} pubkey account address
-   * @param {string} [cursor] the cursor returned in previous query (base64 encoded json object with a 'page' property)
-   * @param {number} [pageSize] page size (10 by default)
-   * @param {number} [from] from block number (0 by default)
-   * @param {number} [to] to block number (pending by default)
-   *
-   * @returns {Promise<TxHistory>} transaction history
-   *
-   * @example pubkey "0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA"
-   */
-  @Example<TxHistory>({
-    pubkey: '0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA',
-    cursor:
-      'eyJibG9ja2Jvb2tQYWdlIjozLCJleHBsb3JlclBhZ2UiOjEsImJsb2NrYm9va1R4aWQiOiIweGQwYzIwZmRlM2JmNWQ5NmNkNTdkN2E3MDJkYzAwYjI0ODNlOTRhZTQ0YTM0NjU3YTQzZGZkZTIyNDBmNDljNjYiLCJleHBsb3JlclR4aWQiOiIweGQwYzIwZmRlM2JmNWQ5NmNkNTdkN2E3MDJkYzAwYjI0ODNlOTRhZTQ0YTM0NjU3YTQzZGZkZTIyNDBmNDljNjYiLCJibG9ja0hlaWdodCI6NDE2Mjg3MjB9',
-    txs: [
-      {
-        txid: '0x8207404cac0b02ed15dd2690fcfb618a7d7b0482e12345e4483fed398f073890',
-        blockHash: '0x00561abfd4c6a15fbeae39a1223b0a0ffbd9a4eb22e902c7b0e551049a33b2c0',
-        blockHeight: 41639607,
-        timestamp: 1681745623,
-        status: 1,
-        from: '0xe93685f3bBA03016F02bD1828BaDD6195988D950',
-        to: '0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f',
-        confirmations: 155,
-        value: '0',
-        fee: '94583813568181480',
-        gasLimit: '1200108',
-        gasUsed: '223268',
-        gasPrice: '423633541610',
-        inputData:
-          '0x252f7b0100000000000000000000000000000000000000000000000000000000000000700000000000000000000000009d1b1669c73b033dfe47ae5a0164ab96df25b944000000000000000000000000000000000000000000000000000000000003b920cb300a75b8df105ca88a050fa3480cd5e139b4dde3387beddfcdf2f9b31e8638cb300a75b8df105ca88a050fa3480cd5e139b4dde3387beddfcdf2f9b31e863800000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000002740000000000000000000000004d73adb72bc3dd368966edd0f0b2148401a178e200000000000190b3007045a01e4e04f14f7a4a6702c74187c5f6222033cd006d9d1b1669c73b033dfe47ae5a0164ab96df25b944000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000249f00000000000000000000000000000000000000000000000000000017d7309b7ab000000000000000000000000000000000000000000000000000000001e0aee090000000000000000000000000000000000000000000000000000000000003b1a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000462ee000000000000000000000000000000000000000000000000000000001e0f8c1100000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000143f758726e31b299afb85b3d5c8b1fec9b20b17ca0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-        tokenTransfers: [
-          {
-            contract: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-            decimals: 6,
-            name: 'USD Coin (PoS)',
-            symbol: 'USDC',
-            type: 'ERC20',
-            from: '0x1205f31718499dBf1fCa446663B532Ef87481fe1',
-            to: '0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA',
-            value: '504032777',
-          },
-        ],
-      },
-    ],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('account/{pubkey}/txs')
-  async getTxHistory(
-    @Path() pubkey: string,
-    @Query() cursor?: string,
-    @Query() pageSize = 10,
-    @Query() from?: number,
-    @Query() to?: number
-  ): Promise<TxHistory> {
-    return service.getTxHistory(pubkey, cursor, pageSize, from, to)
-  }
-
-  /**
-   * Get transaction details
-   *
-   * @param {string} txid transaction hash
-   *
-   * @example txid "0x8207404cac0b02ed15dd2690fcfb618a7d7b0482e12345e4483fed398f073890"
-   *
-   * @returns {Promise<Tx>} transaction payload
-   */
-  @Example<Tx>({
-    txid: '0x8207404cac0b02ed15dd2690fcfb618a7d7b0482e12345e4483fed398f073890',
-    blockHash: '0x00561abfd4c6a15fbeae39a1223b0a0ffbd9a4eb22e902c7b0e551049a33b2c0',
-    blockHeight: 41639607,
-    timestamp: 1681745623,
-    status: 1,
-    from: '0xe93685f3bBA03016F02bD1828BaDD6195988D950',
-    to: '0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f',
-    confirmations: 193,
-    value: '0',
-    fee: '94583813568181480',
-    gasLimit: '1200108',
-    gasUsed: '223268',
-    gasPrice: '423633541610',
-    inputData:
-      '0x252f7b0100000000000000000000000000000000000000000000000000000000000000700000000000000000000000009d1b1669c73b033dfe47ae5a0164ab96df25b944000000000000000000000000000000000000000000000000000000000003b920cb300a75b8df105ca88a050fa3480cd5e139b4dde3387beddfcdf2f9b31e8638cb300a75b8df105ca88a050fa3480cd5e139b4dde3387beddfcdf2f9b31e863800000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000002740000000000000000000000004d73adb72bc3dd368966edd0f0b2148401a178e200000000000190b3007045a01e4e04f14f7a4a6702c74187c5f6222033cd006d9d1b1669c73b033dfe47ae5a0164ab96df25b944000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000249f00000000000000000000000000000000000000000000000000000017d7309b7ab000000000000000000000000000000000000000000000000000000001e0aee090000000000000000000000000000000000000000000000000000000000003b1a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000462ee000000000000000000000000000000000000000000000000000000001e0f8c1100000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000143f758726e31b299afb85b3d5c8b1fec9b20b17ca0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-    tokenTransfers: [
-      {
-        contract: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-        decimals: 6,
-        name: 'USD Coin (PoS)',
-        symbol: 'USDC',
-        type: 'ERC20',
-        from: '0x1205f31718499dBf1fCa446663B532Ef87481fe1',
-        to: '0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA',
-        value: '504032777',
-      },
-    ],
-    internalTxs: [],
-  })
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('tx/{txid}')
-  async getTransaction(@Path() txid: string): Promise<Tx> {
-    return service.getTransaction(txid)
-  }
-
+export class Polygon extends EVM implements BaseAPI, API {
   /**
    * Get the estimated gas cost of a transaction
    *
@@ -277,57 +107,5 @@ export class Polygon extends Controller implements BaseAPI, API {
   @Get('/gas/fees')
   async getGasFees(): Promise<GasFees> {
     return service.getGasFees()
-  }
-
-  /**
-   * Broadcast signed raw transaction
-   *
-   * @param {SendTxBody} body serialized raw transaction hex
-   *
-   * @returns {Promise<string>} transaction id
-   *
-   * @example body {
-   *    "hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-   * }
-   */
-  @Example<string>('0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd')
-  @Response<BadRequestError>(400, 'Bad Request')
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Post('send/')
-  async sendTx(@Body() body: SendTxBody): Promise<string> {
-    return service.sendTx(body)
-  }
-
-  /**
-   * Get token metadata
-   *
-   * @param {string} contract contract address
-   * @param {string} id token identifier
-   * @param {TokenType} type token type (erc721 or erc1155)
-   *
-   * @returns {Promise<TokenMetadata>} token metadata
-   *
-   * @example contractAddress "0x495D897BE6a6e57432C954f3C381eaBfa4699795"
-   * @example id "5705"
-   * @example type "erc721"
-   */
-  @Example<TokenMetadata>({
-    name: 'On-chain Quest',
-    description: '',
-    media: {
-      url: 'https://cdn.galxe.com/galaxy/symbiosis/a9e5b6a0-6e72-4f09-8a96-bd9ca313411f.png',
-      type: 'image',
-    },
-  })
-  @Response<ValidationError>(422, 'Validation Error')
-  @Response<InternalServerError>(500, 'Internal Server Error')
-  @Get('/metadata/token')
-  async getTokenMetadata(
-    @Query() contract: string,
-    @Query() id: string,
-    @Query() type: TokenType
-  ): Promise<TokenMetadata> {
-    return service.getTokenMetadata(contract, id, type)
   }
 }

--- a/node/coinstacks/polygon/api/src/swagger.json
+++ b/node/coinstacks/polygon/api/src/swagger.json
@@ -311,6 +311,146 @@
 				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
 				"description": "Contains info about EVM transaction history"
 			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method",
+					"params"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
 			"GasEstimate": {
 				"description": "Contains info about estimated gas cost of a transaction",
 				"properties": {
@@ -373,63 +513,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"SendTxBody": {
-				"description": "Contains the serialized raw transaction hex",
-				"properties": {
-					"hex": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"hex"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenMetadata": {
-				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"media": {
-						"properties": {
-							"type": {
-								"type": "string",
-								"enum": [
-									"image",
-									"video"
-								]
-							},
-							"url": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"url"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"name",
-					"description",
-					"media"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"TokenType": {
-				"type": "string",
-				"enum": [
-					"erc721",
-					"erc1155"
-				],
-				"description": "Supported token types for token metadata"
 			}
 		},
 		"securitySchemes": {}
@@ -488,17 +571,17 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"balance": "5509799116755998875",
+											"balance": "284809805024198107",
 											"unconfirmedBalance": "0",
-											"nonce": 6,
-											"pubkey": "0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA",
+											"nonce": 1,
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
 											"tokens": [
 												{
-													"balance": "504032777",
-													"contract": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
-													"decimals": 6,
-													"name": "USD Coin (PoS)",
-													"symbol": "USDC",
+													"balance": "1337",
+													"contract": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
+													"decimals": 18,
+													"name": "FOX",
+													"symbol": "FOX",
 													"type": "ERC20"
 												}
 											]
@@ -552,8 +635,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA"
+						}
 					}
 				]
 			}
@@ -572,36 +654,24 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"pubkey": "0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA",
-											"cursor": "eyJibG9ja2Jvb2tQYWdlIjozLCJleHBsb3JlclBhZ2UiOjEsImJsb2NrYm9va1R4aWQiOiIweGQwYzIwZmRlM2JmNWQ5NmNkNTdkN2E3MDJkYzAwYjI0ODNlOTRhZTQ0YTM0NjU3YTQzZGZkZTIyNDBmNDljNjYiLCJleHBsb3JlclR4aWQiOiIweGQwYzIwZmRlM2JmNWQ5NmNkNTdkN2E3MDJkYzAwYjI0ODNlOTRhZTQ0YTM0NjU3YTQzZGZkZTIyNDBmNDljNjYiLCJibG9ja0hlaWdodCI6NDE2Mjg3MjB9",
+											"pubkey": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+											"cursor": "eyJibG9ja2Jvb2tQYWdlIjoxLCJldGhlcnNjYW5QYWdlIjoxLCJibG9ja2Jvb2tUeGlkIjoiMHhhZWU0MzJmODUzZmRjMTNhZDlmZjZjYWJlMmEzOTQwM2Q4N2RkZWUxODQyNDk2ODE4ZmNkODg3NDdmNjU2NmY5IiwiYmxvY2tIZWlnaHQiOjEzODUwMjEzfQ==",
 											"txs": [
 												{
-													"txid": "0x8207404cac0b02ed15dd2690fcfb618a7d7b0482e12345e4483fed398f073890",
-													"blockHash": "0x00561abfd4c6a15fbeae39a1223b0a0ffbd9a4eb22e902c7b0e551049a33b2c0",
-													"blockHeight": 41639607,
-													"timestamp": 1681745623,
+													"txid": "0x8e3528c933483770a3c8377c2ee7e34f846908653168188fd0d90a20b295d002",
+													"blockHash": "0x94228c1b7052720846e2d7b9f36de30acf45d9a06ec483bd4433c5c38c8673a8",
+													"blockHeight": 12267105,
+													"timestamp": 1618788849,
 													"status": 1,
-													"from": "0xe93685f3bBA03016F02bD1828BaDD6195988D950",
-													"to": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f",
-													"confirmations": 155,
-													"value": "0",
-													"fee": "94583813568181480",
-													"gasLimit": "1200108",
-													"gasUsed": "223268",
-													"gasPrice": "423633541610",
-													"inputData": "0x252f7b0100000000000000000000000000000000000000000000000000000000000000700000000000000000000000009d1b1669c73b033dfe47ae5a0164ab96df25b944000000000000000000000000000000000000000000000000000000000003b920cb300a75b8df105ca88a050fa3480cd5e139b4dde3387beddfcdf2f9b31e8638cb300a75b8df105ca88a050fa3480cd5e139b4dde3387beddfcdf2f9b31e863800000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000002740000000000000000000000004d73adb72bc3dd368966edd0f0b2148401a178e200000000000190b3007045a01e4e04f14f7a4a6702c74187c5f6222033cd006d9d1b1669c73b033dfe47ae5a0164ab96df25b944000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000249f00000000000000000000000000000000000000000000000000000017d7309b7ab000000000000000000000000000000000000000000000000000000001e0aee090000000000000000000000000000000000000000000000000000000000003b1a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000462ee000000000000000000000000000000000000000000000000000000001e0f8c1100000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000143f758726e31b299afb85b3d5c8b1fec9b20b17ca0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-													"tokenTransfers": [
-														{
-															"contract": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
-															"decimals": 6,
-															"name": "USD Coin (PoS)",
-															"symbol": "USDC",
-															"type": "ERC20",
-															"from": "0x1205f31718499dBf1fCa446663B532Ef87481fe1",
-															"to": "0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA",
-															"value": "504032777"
-														}
-													]
+													"from": "0xB3DD70991aF983Cf82d95c46C24979ee98348ffa",
+													"to": "0x642F4Bda144C63f6DC47EE0fDfbac0a193e2eDb7",
+													"confirmations": 2088440,
+													"value": "737092621690531649",
+													"fee": "3180000000009000",
+													"gasLimit": "21000",
+													"gasUsed": "21000",
+													"gasPrice": "151428571429",
+													"inputData": "0x"
 												}
 											]
 										}
@@ -654,8 +724,7 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA"
+						}
 					},
 					{
 						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
@@ -714,33 +783,20 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"txid": "0x8207404cac0b02ed15dd2690fcfb618a7d7b0482e12345e4483fed398f073890",
-											"blockHash": "0x00561abfd4c6a15fbeae39a1223b0a0ffbd9a4eb22e902c7b0e551049a33b2c0",
-											"blockHeight": 41639607,
-											"timestamp": 1681745623,
+											"txid": "0x8825fe8d60e1aa8d990f150bffe1196adcab36d0c4e98bac76c691719103b79d",
+											"blockHash": "0x122f1e1b594b797d96c1777ce9cdb68ddb69d262ac7f2ddc345909aba4ebabd7",
+											"blockHeight": 14813163,
+											"timestamp": 1653078780,
 											"status": 1,
-											"from": "0xe93685f3bBA03016F02bD1828BaDD6195988D950",
-											"to": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f",
-											"confirmations": 193,
-											"value": "0",
-											"fee": "94583813568181480",
-											"gasLimit": "1200108",
-											"gasUsed": "223268",
-											"gasPrice": "423633541610",
-											"inputData": "0x252f7b0100000000000000000000000000000000000000000000000000000000000000700000000000000000000000009d1b1669c73b033dfe47ae5a0164ab96df25b944000000000000000000000000000000000000000000000000000000000003b920cb300a75b8df105ca88a050fa3480cd5e139b4dde3387beddfcdf2f9b31e8638cb300a75b8df105ca88a050fa3480cd5e139b4dde3387beddfcdf2f9b31e863800000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000002740000000000000000000000004d73adb72bc3dd368966edd0f0b2148401a178e200000000000190b3007045a01e4e04f14f7a4a6702c74187c5f6222033cd006d9d1b1669c73b033dfe47ae5a0164ab96df25b944000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000249f00000000000000000000000000000000000000000000000000000017d7309b7ab000000000000000000000000000000000000000000000000000000001e0aee090000000000000000000000000000000000000000000000000000000000003b1a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000462ee000000000000000000000000000000000000000000000000000000001e0f8c1100000000000000000000000000000000000000000000000000000000000001c0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000143f758726e31b299afb85b3d5c8b1fec9b20b17ca0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-											"tokenTransfers": [
-												{
-													"contract": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
-													"decimals": 6,
-													"name": "USD Coin (PoS)",
-													"symbol": "USDC",
-													"type": "ERC20",
-													"from": "0x1205f31718499dBf1fCa446663B532Ef87481fe1",
-													"to": "0x3f758726E31b299Afb85b3D5C8B1fEc9b20b17cA",
-													"value": "504032777"
-												}
-											],
-											"internalTxs": []
+											"from": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
+											"to": "0x275C7d416c1DBfafa53A861EEc6F0AD6138ca4dD",
+											"confirmations": 21,
+											"value": "49396718157429775",
+											"fee": "603633477678000",
+											"gasLimit": "250000",
+											"gasUsed": "21000",
+											"gasPrice": "28744451318",
+											"inputData": "0x"
 										}
 									}
 								}
@@ -791,8 +847,225 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						},
-						"example": "0x8207404cac0b02ed15dd2690fcfb618a7d7b0482e12345e4483fed398f073890"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"name": "Foxy",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
 					}
 				]
 			}
@@ -943,164 +1216,6 @@
 				],
 				"security": [],
 				"parameters": []
-			}
-		},
-		"/api/v1/send": {
-			"post": {
-				"operationId": "SendTx",
-				"responses": {
-					"200": {
-						"description": "transaction id",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "string"
-								},
-								"examples": {
-									"Example 1": {
-										"value": "0xb9d4ad5408f53eac8627f9ccd840ba8fb3469d55cd9cc2a11c6e049f1eef4edd"
-									}
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/BadRequestError"
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Broadcast signed raw transaction",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"description": "serialized raw transaction hex",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/SendTxBody",
-								"description": "serialized raw transaction hex"
-							},
-							"example": {
-								"hex": "0xf86c0a85046c7cfe0083016dea94d1310c1e038bc12865d3d3997275b3e4737c6302880b503be34d9fe80080269fc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfaa0387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/api/v1/metadata/token": {
-			"get": {
-				"operationId": "GetTokenMetadata",
-				"responses": {
-					"200": {
-						"description": "token metadata",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/TokenMetadata"
-								},
-								"examples": {
-									"Example 1": {
-										"value": {
-											"name": "On-chain Quest",
-											"description": "",
-											"media": {
-												"url": "https://cdn.galxe.com/galaxy/symbiosis/a9e5b6a0-6e72-4f09-8a96-bd9ca313411f.png",
-												"type": "image"
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"422": {
-						"description": "Validation Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/ValidationError"
-								}
-							}
-						}
-					},
-					"500": {
-						"description": "Internal Server Error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/InternalServerError"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get token metadata",
-				"tags": [
-					"v1"
-				],
-				"security": [],
-				"parameters": [
-					{
-						"description": "contract address",
-						"in": "query",
-						"name": "contract",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "0x495D897BE6a6e57432C954f3C381eaBfa4699795"
-					},
-					{
-						"description": "token identifier",
-						"in": "query",
-						"name": "id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						},
-						"example": "5705"
-					},
-					{
-						"description": "token type (erc721 or erc1155)",
-						"in": "query",
-						"name": "type",
-						"required": true,
-						"schema": {
-							"$ref": "#/components/schemas/TokenType"
-						}
-					}
-				]
 			}
 		}
 	},


### PR DESCRIPTION
- add `/jsonrpc` endpoint to unchained api to proxy raw node requests
    - this will allow us to remove api gateway proxy doing the same thing and lower overhead and hopefully spend $
- dry up evm api with a common controller for shared/identical endpoints 