### PR TITLE
chore: upgrade thorchain v1.130.1 -> v1.131.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,7 @@ aliases:
     api-memory-request: 250Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-1.130.1
+    service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-1.131.0
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 12Gi

--- a/go/coinstacks/thorchain/daemon/init.sh
+++ b/go/coinstacks/thorchain/daemon/init.sh
@@ -4,6 +4,9 @@ set -e
 
 apk add bash
 
+export THOR_TENDERMINT_RPC_EXPERIMENTAL_SUBSCRIPTION_BUFFER_SIZE=5000
+export THOR_TENDERMINT_RPC_EXPERIMENTAL_WEBSOCKET_WRITE_BUFFER_SIZE=5000
+
 start_coin() {
   /scripts/fullnode.sh thornode start \
     --p2p.laddr=tcp://0.0.0.0:27146 \


### PR DESCRIPTION
https://gitlab.com/thorchain/thornode/-/tree/v1.131.0?ref_type=tags

This release introduced the experimental buffer configs which have been set and updated to 5k to ensure websockets will stay open and healthy even through periods of high tx congestion (successfully process <5k txs in a block). During the last period I was seeing spikes upwards of 3k, so this adds a pretty healthy buffer that obviously can be tweaked in the future if needed.