### PR TITLE
chore: optimism updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,7 +456,7 @@ aliases:
     service-memory-limit-1: 24Gi
     service-storage-size-1: 1250Gi
     service-name-2: op-node
-    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.3
+    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.4
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 2Gi

--- a/node/coinstacks/optimism/daemon/init.sh
+++ b/node/coinstacks/optimism/daemon/init.sh
@@ -13,7 +13,6 @@ fi
 
 start() {
   geth \
-    --networkid 10 \
     --syncmode full \
     --datadir $DATA_DIR \
     --authrpc.jwtsecret /jwt.hex \
@@ -31,6 +30,7 @@ start() {
     --ws.origins "*" \
     --rollup.disabletxpoolgossip=true \
     --rollup.sequencerhttp https://mainnet-sequencer.optimism.io \
+    --op-network op-mainnet \
     --txlookuplimit 0 \
     --cache 4096 \
     --maxpeers 0 \

--- a/node/coinstacks/optimism/op-node/init.sh
+++ b/node/coinstacks/optimism/op-node/init.sh
@@ -6,7 +6,7 @@ apk add bash curl jq
 
 start() {
   op-node \
-    --network $NETWORK \
+    --network op-mainnet \
     --rpc.addr 0.0.0.0 \
     --rpc.port 9545 \
     --l1 $L1_RPC_ENDPOINT \

--- a/node/coinstacks/optimism/pulumi/index.ts
+++ b/node/coinstacks/optimism/pulumi/index.ts
@@ -38,11 +38,10 @@ export = async (): Promise<Outputs> => {
         return {
           ...service,
           env: {
-            NETWORK: config.network,
             L1_RPC_ENDPOINT: `http://ethereum-svc.unchained.svc.cluster.local:8545`,
             L1_BEACON_ENDPOINT: `http://ethereum-svc.unchained.svc.cluster.local:3500`,
           },
-          ports: { 'op-node-rpc': { port: 9545 } },
+          ports: { 'op-node-rpc': { port: 9545, ingressRoute: false } },
           configMapData: { 'evm.sh': readFileSync('../../../scripts/evm.sh').toString() },
           volumeMounts: [
             { name: 'config-map', mountPath: '/jwt.hex', subPath: 'jwt.hex' },


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/releases/tag/v1.7.4

- use `op-mainnet` network constants
- don't expose op-node rpc