### PR TITLE
chore: respond with api error message

### DIFF
--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -298,7 +298,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       const gasLimit = await this.provider.estimateGas(tx)
       return { gasLimit: gasLimit.toString() }
     } catch (err) {
-      throw new ApiError('Internal Server Error', 500, JSON.stringify(err))
+      throw handleError(err)
     }
   }
 
@@ -327,7 +327,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
         fast: estimatedFees['90'],
       }
     } catch (err) {
-      throw new ApiError('Internal Server Error', 500, JSON.stringify(err))
+      throw handleError(err)
     }
   }
 

--- a/node/coinstacks/common/api/src/index.ts
+++ b/node/coinstacks/common/api/src/index.ts
@@ -15,10 +15,13 @@ export * as utxo from './utxo'
  * Generic api error for handling failed requests
  */
 export class ApiError extends Error {
+  statusText: string
   statusCode: number
-  constructor(name: string, statusCode: number, message?: string) {
+
+  constructor(statusText: string, statusCode: number, message?: string) {
     super(message)
-    this.name = name
+    this.name = this.constructor.name
+    this.statusText = statusText
     this.statusCode = statusCode
   }
 }

--- a/node/coinstacks/common/api/src/middleware.ts
+++ b/node/coinstacks/common/api/src/middleware.ts
@@ -18,7 +18,7 @@ export function errorHandler(err: Error, req: Request, res: Response, next: Next
     })
   }
 
-  if (err instanceof ApiError) {
+  if (err.constructor.name === ApiError.prototype.constructor.name) {
     const e = err as ApiError
     console.error(e)
     return res.status(e.statusCode ?? 500).json({ message: e.message })


### PR DESCRIPTION
- use common `handleError` func for all evm service functions
- extend api error class slightly
- narrow on constructor name and response with api error message