### PR TITLE
fix: switch utxo fee estimation from websocket to http

### DIFF
--- a/node/coinstacks/common/api/src/utxo/service.ts
+++ b/node/coinstacks/common/api/src/utxo/service.ts
@@ -154,7 +154,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       return Object.entries(blockTimes).reduce<NetworkFees>((prev, [key, val], index) => {
         const networkFee: NetworkFee = {
           blocksUntilConfirmation: val,
-          satsPerKiloByte: Number(result[index].feePerUnit),
+          satsPerKiloByte: Number(result[index]) * 100000000,
         }
         return { ...prev, [key]: networkFee }
       }, {})

--- a/node/packages/blockbook/src/models.ts
+++ b/node/packages/blockbook/src/models.ts
@@ -285,23 +285,6 @@ export interface Vout {
 export type Xpub = Address
 
 /**
- * Contains info about current network fees
- */
-export interface NetworkFee {
-  feePerTx?: string
-  feePerUnit?: string
-  feeLimit?: string
-}
-
-/**
- * Response data for fees endpoint on websocket API
- */
-export interface FeeResponse {
-  id: number
-  data: NetworkFee[]
-}
-
-/**
  * Arguments to Blockbook constructor
  */
 export interface BlockbookArgs {

--- a/node/packages/blockbook/src/swagger.json
+++ b/node/packages/blockbook/src/swagger.json
@@ -806,22 +806,6 @@
 				],
 				"type": "object",
 				"additionalProperties": false
-			},
-			"NetworkFee": {
-				"description": "Contains info about current network fees",
-				"properties": {
-					"feePerTx": {
-						"type": "string"
-					},
-					"feePerUnit": {
-						"type": "string"
-					},
-					"feeLimit": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
 			}
 		},
 		"securitySchemes": {}
@@ -1953,41 +1937,20 @@
 							"application/json": {
 								"schema": {
 									"items": {
-										"$ref": "#/components/schemas/NetworkFee"
+										"type": "string"
 									},
 									"type": "array"
 								},
 								"examples": {
 									"Example 1": {
-										"value": [
-											{
-												"feePerTx": "23424",
-												"feePerUnit": "14186",
-												"feeLimit": "99999"
-											},
-											{
-												"feePerTx": "11245",
-												"feePerUnit": "13727",
-												"feeLimit": "99999"
-											},
-											{
-												"feePerTx": "8263",
-												"feePerUnit": "10719",
-												"feeLimit": "99999"
-											},
-											{
-												"feePerTx": "1243",
-												"feePerUnit": "2015",
-												"feeLimit": "99999"
-											}
-										]
+										"value": []
 									}
 								}
 							}
 						}
 					}
 				},
-				"description": "Returns estimated network fees for the specified confirmation times (in blocks)",
+				"description": "Returns estimated network fees in BTC/kB for the specified block confirmation times",
 				"tags": [
 					"v2"
 				],


### PR DESCRIPTION
Due to websocket connection issues against nownodes blockbook instances (presumably connection limits or rate limits), we are unable to reliably use blockbook websockets to estimate fees for utxo chains. This update leverages the blockbook rest endpoint for estimating fees instead.

Note: this increases our request count consumption from 1 request to 3 requests for every estimate call, so if/when nownodes fixes their websocket connections, we may want to switch back, but considering the `/fees` endpoint isn't heavily used, there probably won't be too drastic of a difference.