### PR TITLE
feat: affiliate fees indexer and endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ aliases:
     service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-1.133.0
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
-    service-memory-limit-1: 12Gi
+    service-memory-limit-1: 16Gi
     service-storage-size-1: 3500Gi
     service-name-2: timescaledb
     service-image-2: timescale/timescaledb:2.13.0-pg15

--- a/go/cmd/thorchain/main.go
+++ b/go/cmd/thorchain/main.go
@@ -76,7 +76,12 @@ func main() {
 		logger.Panicf("failed to create new websocket client: %+v", err)
 	}
 
-	api := api.New(httpClient, wsClient, blockService, *swaggerPath, prometheus)
+	indexer := api.NewAffiliateFeeIndexer(cfg, httpClient)
+	if err := indexer.Sync(); err != nil {
+		logger.Panicf("failed to index affiliate fees: %+v", err)
+	}
+
+	api := api.New(httpClient, wsClient, blockService, indexer, *swaggerPath, prometheus)
 	defer api.Shutdown()
 
 	go api.Serve(errChan)

--- a/go/coinstacks/thorchain/api/affiliateFees.go
+++ b/go/coinstacks/thorchain/api/affiliateFees.go
@@ -1,0 +1,263 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/shapeshift/unchained/coinstacks/thorchain"
+	"github.com/shapeshift/unchained/pkg/cosmos"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tendermintjson "github.com/tendermint/tendermint/libs/json"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+	tendermint "github.com/tendermint/tendermint/rpc/jsonrpc/client"
+	"github.com/tendermint/tendermint/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	blockWorkers     = 10
+	resultWorkers    = 100
+	pageSize         = 25
+	affiliateAddress = "thor1xmaggkcln5m5fnha2780xrdrulmplvfrz6wj3l"
+)
+
+type AffiliateFeeIndexer struct {
+	AffiliateFees []*AffiliateFee
+	conf          cosmos.Config
+	httpClient    *cosmos.HTTPClient
+	mu            sync.Mutex
+	pageCh        chan int
+	resultCh      chan *coretypes.ResultBlockSearch
+}
+
+type AffiliateFee struct {
+	Amount      string
+	Asset       string
+	BlockHeight int64
+	BlockHash   string
+	Timestamp   int64
+	Address     string
+	TxID        string
+}
+
+func NewAffiliateFeeIndexer(conf cosmos.Config, httpClient *cosmos.HTTPClient) *AffiliateFeeIndexer {
+	return &AffiliateFeeIndexer{
+		AffiliateFees: []*AffiliateFee{},
+		conf:          conf,
+		httpClient:    httpClient,
+		pageCh:        make(chan int),
+		resultCh:      make(chan *coretypes.ResultBlockSearch),
+	}
+}
+
+func (i *AffiliateFeeIndexer) Sync() error {
+	logger.Info("Started indexing affiliate fees")
+	start := time.Now()
+
+	defer close(i.resultCh)
+
+	if err := i.listen(); err != nil {
+		return err
+	}
+
+	go func() {
+		for j := 0; j < resultWorkers; j++ {
+			go func() {
+				for result := range i.resultCh {
+					for _, b := range result.Blocks {
+						block := b.Block
+						if err := i.handleBlock(block); err != nil {
+							logger.Error(err)
+						}
+					}
+				}
+			}()
+		}
+	}()
+
+	result, err := i.httpClient.BlockSearch(fmt.Sprintf(`"outbound.to='%s'"`, "thor1xmaggkcln5m5fnha2780xrdrulmplvfrz6wj3l"), 1, pageSize)
+	if err != nil {
+		return err
+	}
+
+	maxPages := int(math.Ceil(float64(result.TotalCount) / float64(pageSize)))
+	i.resultCh <- result
+
+	g := new(errgroup.Group)
+	for w := 0; w <= blockWorkers; w++ {
+		g.Go(func() error {
+			return i.fetchBlocks()
+		})
+	}
+
+	go func() {
+		page := 2
+		for {
+			if page > maxPages {
+				close(i.pageCh)
+				break
+			}
+			i.pageCh <- page
+			page++
+		}
+	}()
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	logger.Infof("Finished indexing affiliate fees (%s)", time.Since(start))
+
+	return nil
+}
+
+func (i *AffiliateFeeIndexer) listen() error {
+	wsURL, err := url.Parse(i.conf.WSURL)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse WSURL: %s", i.conf.WSURL)
+	}
+
+	client, err := tendermint.NewWS(wsURL.String(), "/websocket")
+	if err != nil {
+		return errors.Wrapf(err, "failed to create websocket client")
+	}
+
+	// use default dialer
+	client.Dialer = net.Dial
+
+	tendermint.MaxReconnectAttempts(10)(client)
+	tendermint.OnReconnect(func() {
+		logger.Info("OnReconnect triggered: resubscribing")
+		_ = client.Subscribe(context.Background(), types.EventQueryNewBlockHeader.String())
+	})(client)
+
+	if err := client.Start(); err != nil {
+		return errors.Wrap(err, "failed to start websocket client")
+	}
+
+	if err = client.Subscribe(context.Background(), types.EventQueryNewBlockHeader.String()); err != nil {
+		return errors.Wrap(err, "failed to subscribe to newBlocks")
+	}
+
+	go func(client *tendermint.WSClient) {
+		for r := range client.ResponsesCh {
+			if r.Error != nil {
+				if r.Error.Code == -32000 {
+					err := client.UnsubscribeAll(context.Background())
+					if err != nil {
+						logger.Error(errors.Wrap(err, "failed to unsubscribe from all subscriptions"))
+					}
+
+					err = client.Subscribe(context.Background(), types.EventQueryNewBlockHeader.String())
+					if err != nil {
+						logger.Error(errors.Wrap(err, "failed to subscribe to newBlocks"))
+					}
+
+					continue
+				}
+
+				logger.Error(r.Error.Error())
+				continue
+			}
+
+			result := &coretypes.ResultEvent{}
+			if err := tendermintjson.Unmarshal(r.Result, result); err != nil {
+				logger.Errorf("failed to unmarshal tx message: %v", err)
+				continue
+			}
+
+			if result.Data != nil {
+				switch result.Data.(type) {
+				case types.EventDataNewBlockHeader:
+					go i.handleNewBlockHeader(result.Data.(types.EventDataNewBlockHeader))
+				default:
+					fmt.Printf("unsupported result type: %T", result.Data)
+				}
+			}
+		}
+	}(client)
+
+	return nil
+}
+
+func (i *AffiliateFeeIndexer) fetchBlocks() error {
+	for page := range i.pageCh {
+		result, err := i.httpClient.BlockSearch(fmt.Sprintf(`"outbound.to='%s'"`, "thor1xmaggkcln5m5fnha2780xrdrulmplvfrz6wj3l"), page, pageSize)
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch blocks for page: %d", page)
+		}
+
+		i.resultCh <- result
+	}
+
+	return nil
+}
+
+func (i *AffiliateFeeIndexer) handleBlock(block *tmtypes.Block) error {
+	blockResult, err := i.httpClient.BlockResults(int(block.Height))
+	if err != nil {
+		return errors.Wrapf(err, "failed to handle block: %v", block.Height)
+	}
+
+	b := &ResultBlock{
+		Block: block,
+	}
+
+	if err := i.processAffiliateFees(b, blockResult.EndBlockEvents); err != nil {
+		return errors.Wrap(err, "failed to process affiliate fees")
+	}
+
+	return nil
+}
+
+func (i *AffiliateFeeIndexer) handleNewBlockHeader(newBlockHeader types.EventDataNewBlockHeader) {
+	b := &NewBlockHeader{
+		EventDataNewBlockHeader: newBlockHeader,
+	}
+
+	if err := i.processAffiliateFees(b, newBlockHeader.ResultEndBlock.Events); err != nil {
+		logger.Panicf("failed to process affiliate fees: %+v", err)
+	}
+}
+
+func (i *AffiliateFeeIndexer) processAffiliateFees(block Block, endBlockEvents []abci.Event) error {
+	_, typedEvents, err := thorchain.ParseBlockEvents(endBlockEvents)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse block events")
+	}
+
+	for _, event := range typedEvents {
+		affiliateFee := &AffiliateFee{
+			BlockHash:   block.Hash(),
+			BlockHeight: block.Height(),
+			Timestamp:   block.Timestamp(),
+		}
+
+		switch v := event.(type) {
+		case *thorchain.EventOutbound:
+			coinParts := strings.Fields(v.Coin)
+			affiliateFee.TxID = v.InTxID
+			affiliateFee.Address = v.To
+			affiliateFee.Amount = coinParts[0]
+			affiliateFee.Asset = coinParts[1]
+		default:
+			continue
+		}
+
+		if affiliateFee.Address == affiliateAddress {
+			i.mu.Lock()
+			i.AffiliateFees = append(i.AffiliateFees, affiliateFee)
+			i.mu.Unlock()
+		}
+	}
+
+	return nil
+}

--- a/go/coinstacks/thorchain/api/handler.go
+++ b/go/coinstacks/thorchain/api/handler.go
@@ -17,6 +17,7 @@ import (
 
 type Handler struct {
 	*cosmos.Handler
+	indexer *AffiliateFeeIndexer
 }
 
 func (h *Handler) StartWebsocket() error {
@@ -144,6 +145,35 @@ func (h *Handler) GetTxHistory(pubkey string, cursor string, pageSize int) (api.
 	}
 
 	return txHistory, nil
+}
+
+// Contains info about the affiliate revenue earned
+// swagger:model AffiliateRevenue
+type AffiliateRevenue struct {
+	// Affiliate address
+	// required: true
+	Address string `json:"address"`
+	// Amount earned (RUNE)
+	// required: true
+	Amount string `json:"amount"`
+}
+
+func (h *Handler) GetAffiliateRevenue(start int, end int) (*AffiliateRevenue, error) {
+	total := big.NewInt(0)
+	for _, fee := range h.indexer.AffiliateFees {
+		if fee.Timestamp >= int64(start) && fee.Timestamp <= int64(end) {
+			amount := new(big.Int)
+			amount.SetString(fee.Amount, 10)
+			total.Add(total, amount)
+		}
+	}
+
+	a := &AffiliateRevenue{
+		Address: affiliateAddress,
+		Amount:  total.String(),
+	}
+
+	return a, nil
 }
 
 func (h *Handler) ParseMessages(msgs []sdk.Msg, events cosmos.EventsByMsgIndex) []cosmos.Message {

--- a/go/coinstacks/thorchain/api/swagger.json
+++ b/go/coinstacks/thorchain/api/swagger.json
@@ -122,6 +122,51 @@
         }
       }
     },
+    "/api/v1/affiliate/revenue": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Get total ss affiliate revenue earned.",
+        "operationId": "GetAffiliateRevenue",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Start",
+            "description": "Start timestamp",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "End",
+            "description": "End timestamp",
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AffiliateRevenue",
+            "schema": {
+              "$ref": "#/definitions/AffiliateRevenue"
+            }
+          },
+          "400": {
+            "description": "BadRequestError",
+            "schema": {
+              "$ref": "#/definitions/BadRequestError"
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "schema": {
+              "$ref": "#/definitions/InternalServerError"
+            }
+          }
+        }
+      }
+    },
     "/api/v1/gas/estimate": {
       "post": {
         "tags": [
@@ -283,6 +328,27 @@
           "$ref": "#/definitions/CosmosSDKAccount"
         }
       ],
+      "x-go-package": "github.com/shapeshift/unchained/coinstacks/thorchain/api"
+    },
+    "AffiliateRevenue": {
+      "description": "Contains info about the affiliate revenue earned",
+      "type": "object",
+      "required": [
+        "address",
+        "amount"
+      ],
+      "properties": {
+        "address": {
+          "description": "Affiliate address",
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "amount": {
+          "description": "Amount earned (RUNE)",
+          "type": "string",
+          "x-go-name": "Amount"
+        }
+      },
       "x-go-package": "github.com/shapeshift/unchained/coinstacks/thorchain/api"
     },
     "ApiError": {

--- a/go/coinstacks/thorchain/api/types.go
+++ b/go/coinstacks/thorchain/api/types.go
@@ -3,7 +3,47 @@ package api
 import (
 	"github.com/shapeshift/unchained/coinstacks/thorchain"
 	"github.com/shapeshift/unchained/pkg/cosmos"
+	"github.com/tendermint/tendermint/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
+
+type Block interface {
+	Hash() string
+	Height() int64
+	Timestamp() int64
+}
+
+type ResultBlock struct {
+	*tmtypes.Block
+}
+
+func (b *ResultBlock) Hash() string {
+	return b.Block.Hash().String()
+}
+
+func (b *ResultBlock) Height() int64 {
+	return b.Block.Height
+}
+
+func (b *ResultBlock) Timestamp() int64 {
+	return b.Block.Time.UnixMilli()
+}
+
+type NewBlockHeader struct {
+	types.EventDataNewBlockHeader
+}
+
+func (b *NewBlockHeader) Hash() string {
+	return b.Header.Hash().String()
+}
+
+func (b *NewBlockHeader) Height() int64 {
+	return b.Header.Height
+}
+
+func (b *NewBlockHeader) Timestamp() int64 {
+	return b.Header.Time.UnixMilli()
+}
 
 // ResultTx represents a tx_search ResultTx created from block_result block events
 type ResultTx struct {

--- a/go/pkg/cosmos/block.go
+++ b/go/pkg/cosmos/block.go
@@ -137,6 +137,10 @@ func (c *HTTPClient) BlockResults(height int) (*coretypes.ResultBlockResults, er
 		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
+	if res.Error != nil {
+		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get block results for block: %v", height)
+	}
+
 	result := &coretypes.ResultBlockResults{}
 	if err := tmjson.Unmarshal(res.Result, result); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal block result: %v", res.Result)


### PR DESCRIPTION
- Added in memory affiliate fee indexer for shapeshift affiliate address
- Added websocket to listen for new affiliate fees
- Added endpoint to allow querying affiliate fees by unix timestamp range
- Increased thornode memory limit to handle indexing burden