### PR TITLE
feat: update send endpoints to use raw jsonrpc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,8 @@ aliases:
     indexer-url: https://btcbook.nownodes.io
     indexer-ws-url: wss://btcbook.nownodes.io/wss
     indexer-api-key: $NOW_NODES_API_KEY
+    rpc-url: https://btc.nownodes.io
+    rpc-api-key: $NOW_NODES_API_KEY
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 4
@@ -192,9 +194,8 @@ aliases:
     <<: *bitcoin
     environment: dev
     pulumi-stack: public-dev-us-east-2
-    indexer-url: https://btcbook.nownodes.io
-    indexer-ws-url: wss://btcbook.nownodes.io/wss
     indexer-api-key: $NOW_NODES_API_KEY_DEV
+    rpc-api-key: $NOW_NODES_API_KEY_DEV
     api-replicas: 1
     api-max-replicas: 2
     stateful-service-replicas: 0
@@ -295,6 +296,8 @@ aliases:
     indexer-url: https://dogebook.nownodes.io
     indexer-ws-url: wss://dogebook.nownodes.io/wss
     indexer-api-key: $NOW_NODES_API_KEY
+    rpc-url: https://doge.nownodes.io
+    rpc-api-key: $NOW_NODES_API_KEY
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 4
@@ -308,9 +311,8 @@ aliases:
     <<: *dogecoin
     environment: dev
     pulumi-stack: public-dev-us-east-2
-    indexer-url: https://dogebook.nownodes.io
-    indexer-ws-url: wss://dogebook.nownodes.io/wss
     indexer-api-key: $NOW_NODES_API_KEY_DEV
+    rpc-api-key: $NOW_NODES_API_KEY_DEV
     api-replicas: 1
     api-max-replicas: 2
 
@@ -321,6 +323,8 @@ aliases:
     indexer-url: https://ltcbook.nownodes.io
     indexer-ws-url: wss://ltcbook.nownodes.io/wss
     indexer-api-key: $NOW_NODES_API_KEY
+    rpc-url: https://ltc.nownodes.io
+    rpc-api-key: $NOW_NODES_API_KEY
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 4
@@ -334,9 +338,8 @@ aliases:
     <<: *litecoin
     environment: dev
     pulumi-stack: public-dev-us-east-2
-    indexer-url: https://ltcbook.nownodes.io
-    indexer-ws-url: wss://ltcbook.nownodes.io/wss
     indexer-api-key: $NOW_NODES_API_KEY_DEV
+    rpc-api-key: $NOW_NODES_API_KEY_DEV
     api-replicas: 1
     api-max-replicas: 2
 
@@ -347,6 +350,8 @@ aliases:
     indexer-url: https://bchbook.nownodes.io
     indexer-ws-url: wss://bchbook.nownodes.io/wss
     indexer-api-key: $NOW_NODES_API_KEY
+    rpc-url: https://bch.nownodes.io
+    rpc-api-key: $NOW_NODES_API_KEY
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 4
@@ -360,9 +365,8 @@ aliases:
     <<: *bitcoincash
     environment: dev
     pulumi-stack: public-dev-us-east-2
-    indexer-url: https://bchbook.nownodes.io
-    indexer-ws-url: wss://bchbook.nownodes.io/wss
     indexer-api-key: $NOW_NODES_API_KEY_DEV
+    rpc-api-key: $NOW_NODES_API_KEY_DEV
     api-replicas: 1
     api-max-replicas: 2
 

--- a/node/coinstacks/bitcoin/api/src/controller.ts
+++ b/node/coinstacks/bitcoin/api/src/controller.ts
@@ -7,9 +7,12 @@ import { Logger } from '@shapeshiftoss/logger'
 const INDEXER_URL = process.env.INDEXER_URL
 const INDEXER_WS_URL = process.env.INDEXER_WS_URL
 const INDEXER_API_KEY = process.env.INDEXER_API_KEY
+const RPC_URL = process.env.RPC_URL
+const RPC_API_KEY = process.env.RPC_API_KEY
 
 if (!INDEXER_URL) throw new Error('INDEXER_URL env var not set')
 if (!INDEXER_WS_URL) throw new Error('INDEXER_WS_URL env var not set')
+if (!RPC_URL) throw new Error('RPC_URL env var not set')
 
 export const logger = new Logger({
   namespace: ['unchained', 'coinstacks', 'bitcoin', 'api'],
@@ -28,7 +31,13 @@ export const formatAddress = (address: string): string => {
   return address
 }
 
-export const service = new Service({ blockbook, isXpub, addressFormatter: formatAddress })
+export const service = new Service({
+  blockbook,
+  rpcUrl: RPC_URL,
+  rpcApiKey: RPC_API_KEY,
+  isXpub,
+  addressFormatter: formatAddress,
+})
 
 // assign service to be used for all instances of UTXO
 UTXO.service = service

--- a/node/coinstacks/bitcoin/sample.env
+++ b/node/coinstacks/bitcoin/sample.env
@@ -1,8 +1,10 @@
 # SECRET ENVIRONMENT VARIABLES
 INDEXER_API_KEY=
+RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
 INDEXER_URL=https://btcbook.nownodes.io
 INDEXER_WS_URL=wss:/btcbook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
+RPC_URL=https://btc.nownodes.io

--- a/node/coinstacks/bitcoincash/api/src/controller.ts
+++ b/node/coinstacks/bitcoincash/api/src/controller.ts
@@ -7,9 +7,12 @@ import { Logger } from '@shapeshiftoss/logger'
 const INDEXER_URL = process.env.INDEXER_URL
 const INDEXER_WS_URL = process.env.INDEXER_WS_URL
 const INDEXER_API_KEY = process.env.INDEXER_API_KEY
+const RPC_URL = process.env.RPC_URL
+const RPC_API_KEY = process.env.RPC_API_KEY
 
 if (!INDEXER_URL) throw new Error('INDEXER_URL env var not set')
 if (!INDEXER_WS_URL) throw new Error('INDEXER_WS_URL env var not set')
+if (!RPC_URL) throw new Error('RPC_URL env var not set')
 
 export const logger = new Logger({
   namespace: ['unchained', 'coinstacks', 'bitcoincash', 'api'],
@@ -38,7 +41,13 @@ export const formatAddress = (address: string): string => {
   return address
 }
 
-export const service = new Service({ addressFormatter: formatAddress, blockbook, isXpub })
+export const service = new Service({
+  blockbook,
+  rpcApiKey: RPC_API_KEY,
+  rpcUrl: RPC_URL,
+  isXpub,
+  addressFormatter: formatAddress,
+})
 
 // assign service to be used for all instances of UTXO
 UTXO.service = service

--- a/node/coinstacks/bitcoincash/sample.env
+++ b/node/coinstacks/bitcoincash/sample.env
@@ -1,8 +1,10 @@
 # SECRET ENVIRONMENT VARIABLES
 INDEXER_API_KEY=
+RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
 INDEXER_URL=https://bchbook.nownodes.io
 INDEXER_WS_URL=wss:/bchbook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
+RPC_URL=https://bch.nownodes.io

--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -333,8 +333,19 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
 
   async sendTx(body: SendTxBody): Promise<string> {
     try {
-      const { result } = await this.blockbook.sendTransaction(body.hex)
-      return result
+      const request: RPCRequest = {
+        jsonrpc: '2.0',
+        id: 'eth_sendRawTransaction',
+        method: 'eth_sendRawTransaction',
+        params: [body.hex],
+      }
+
+      const config = this.rpcApiKey ? { headers: { 'api-key': this.rpcApiKey } } : undefined
+      const { data } = await axiosNoRetry.post<RPCResponse>(this.rpcUrl, request, config)
+
+      if (!data.result) throw new Error(JSON.stringify(data.error))
+
+      return data.result as string
     } catch (err) {
       throw handleError(err)
     }

--- a/node/coinstacks/common/api/src/utils.ts
+++ b/node/coinstacks/common/api/src/utils.ts
@@ -16,7 +16,7 @@ export const handleError = (err: unknown): ApiError => {
     return new ApiError(
       err.response?.statusText || 'Internal Server Error',
       err.response?.status ?? 500,
-      err.response?.data.message || err.message
+      JSON.stringify(err.response?.data.error) || err.response?.data.message || err.message
     )
   }
 
@@ -25,7 +25,7 @@ export const handleError = (err: unknown): ApiError => {
   }
 
   if (err instanceof Error) {
-    return new ApiError('Internal Server Error', 500, err.message)
+    return new ApiError('Internal Server Error', 500, err.message || 'unknown error')
   }
 
   return new ApiError('Internal Server Error', 500, 'unknown error')

--- a/node/coinstacks/dogecoin/api/src/controller.ts
+++ b/node/coinstacks/dogecoin/api/src/controller.ts
@@ -6,9 +6,12 @@ import { Logger } from '@shapeshiftoss/logger'
 const INDEXER_URL = process.env.INDEXER_URL
 const INDEXER_WS_URL = process.env.INDEXER_WS_URL
 const INDEXER_API_KEY = process.env.INDEXER_API_KEY
+const RPC_URL = process.env.RPC_URL
+const RPC_API_KEY = process.env.RPC_API_KEY
 
 if (!INDEXER_URL) throw new Error('INDEXER_URL env var not set')
 if (!INDEXER_WS_URL) throw new Error('INDEXER_WS_URL env var not set')
+if (!RPC_URL) throw new Error('RPC_URL env var not set')
 
 export const logger = new Logger({
   namespace: ['unchained', 'coinstacks', 'dogecoin', 'api'],
@@ -23,7 +26,13 @@ const isXpub = (pubkey: string): boolean => {
 
 export const formatAddress = (address: string): string => address
 
-export const service = new Service({ blockbook, isXpub, addressFormatter: formatAddress })
+export const service = new Service({
+  blockbook,
+  rpcUrl: RPC_URL,
+  rpcApiKey: RPC_API_KEY,
+  isXpub,
+  addressFormatter: formatAddress,
+})
 
 // assign service to be used for all instances of UTXO
 UTXO.service = service

--- a/node/coinstacks/dogecoin/sample.env
+++ b/node/coinstacks/dogecoin/sample.env
@@ -1,8 +1,10 @@
 # SECRET ENVIRONMENT VARIABLES
 INDEXER_API_KEY=
+RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
 INDEXER_URL=https://dogebook.nownodes.io
 INDEXER_WS_URL=wss:/dogebook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
+RPC_URL=https://doge.nownodes.io

--- a/node/coinstacks/litecoin/api/src/controller.ts
+++ b/node/coinstacks/litecoin/api/src/controller.ts
@@ -7,9 +7,12 @@ import { Logger } from '@shapeshiftoss/logger'
 const INDEXER_URL = process.env.INDEXER_URL
 const INDEXER_WS_URL = process.env.INDEXER_WS_URL
 const INDEXER_API_KEY = process.env.INDEXER_API_KEY
+const RPC_URL = process.env.RPC_URL
+const RPC_API_KEY = process.env.RPC_API_KEY
 
 if (!INDEXER_URL) throw new Error('INDEXER_URL env var not set')
 if (!INDEXER_WS_URL) throw new Error('INDEXER_WS_URL env var not set')
+if (!RPC_URL) throw new Error('RPC_URL env var not set')
 
 export const logger = new Logger({
   namespace: ['unchained', 'coinstacks', 'litecoin', 'api'],
@@ -28,7 +31,13 @@ export const formatAddress = (address: string): string => {
   return address
 }
 
-export const service = new Service({ blockbook, isXpub, addressFormatter: formatAddress })
+export const service = new Service({
+  blockbook,
+  rpcUrl: RPC_URL,
+  rpcApiKey: RPC_API_KEY,
+  isXpub,
+  addressFormatter: formatAddress,
+})
 
 // assign service to be used for all instances of UTXO
 UTXO.service = service

--- a/node/coinstacks/litecoin/sample.env
+++ b/node/coinstacks/litecoin/sample.env
@@ -1,8 +1,10 @@
 # SECRET ENVIRONMENT VARIABLES
 INDEXER_API_KEY=
+RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
 INDEXER_URL=https://ltcbook.nownodes.io
 INDEXER_WS_URL=wss:/ltcbook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
+RPC_URL=https://ltc.nownodes.io


### PR DESCRIPTION
Sends were being sent through blockbook which also had a retry which resulted in 520 responses on failed sends due to timeouts and thereby not returning any useful error response message as to why the send failed. Update `/send` to use raw jsonrpc calls with no retry to ensure the send fails within expected timeout and return useful error message for debugging purposes.