### PR TITLE
fix: upgrade globalfee module -> feemarket module

### DIFF
--- a/go/cmd/cosmos/main.go
+++ b/go/cmd/cosmos/main.go
@@ -54,6 +54,7 @@ func main() {
 		Bech32PkPrefix:    "cosmospub",
 		Bech32ValPrefix:   "cosmosvaloper",
 		Bech32PkValPrefix: "cosmosvalpub",
+		Denom:             "uatom",
 		Encoding:          encoding,
 		APIKEY:            conf.APIKEY,
 		GRPCURL:           conf.GRPCURL,

--- a/go/pkg/cosmos/cosmos.go
+++ b/go/pkg/cosmos/cosmos.go
@@ -42,6 +42,7 @@ type Config struct {
 	Bech32ValPrefix   string
 	Bech32PkPrefix    string
 	Bech32PkValPrefix string
+	Denom             string
 	Encoding          *params.EncodingConfig
 	APIKEY            string
 	GRPCURL           string
@@ -53,6 +54,7 @@ type Config struct {
 // HTTPClient allows communicating over http
 type HTTPClient struct {
 	ctx      context.Context
+	denom    string
 	encoding *params.EncodingConfig
 	LCD      *resty.Client
 	RPC      *resty.Client
@@ -84,6 +86,7 @@ func NewHTTPClient(conf Config) (*HTTPClient, error) {
 
 	c := &HTTPClient{
 		ctx:      context.Background(),
+		denom:    conf.Denom,
 		encoding: conf.Encoding,
 		LCD:      lcd,
 		RPC:      rpc,

--- a/go/pkg/cosmos/fees.go
+++ b/go/pkg/cosmos/fees.go
@@ -1,7 +1,6 @@
 package cosmos
 
 import (
-	"encoding/json"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,21 +11,16 @@ func (c *HTTPClient) GetGlobalMinimumGasPrices() (map[string]sdk.Dec, error) {
 	gasPrices := make(map[string]sdk.Dec)
 
 	var res struct {
-		Param struct {
-			Amount string `json:"subspace"`
-			Key    string `json:"key"`
-			Value  string `json:"value"`
-		} `json:"param"`
+		Price struct {
+			Amount string `json:"amount"`
+			Denom  string `json:"denom"`
+		} `json:"price"`
 	}
 
 	e := &ErrorResponse{}
 
-	queryParams := map[string]string{
-		"subspace": "globalfee",
-		"key":      "MinimumGasPricesParam",
-	}
-
-	r, err := c.LCD.R().SetResult(&res).SetError(e).SetQueryParams(queryParams).Get("/cosmos/params/v1beta1/params")
+	url := fmt.Sprintf("/feemarket/v1/gas_price/%s", c.denom)
+	r, err := c.LCD.R().SetResult(&res).SetError(e).Get(url)
 	if err != nil {
 		return gasPrices, errors.Wrap(err, "failed to get globalfee params")
 	}
@@ -35,27 +29,12 @@ func (c *HTTPClient) GetGlobalMinimumGasPrices() (map[string]sdk.Dec, error) {
 		return gasPrices, errors.Errorf("failed to get globalfee params: %s", e.Msg)
 	}
 
-	values := []struct {
-		Denom  string `json:"denom"`
-		Amount string `json:"amount"`
-	}{}
-
-	err = json.Unmarshal([]byte(res.Param.Value), &values)
+	amount, err := sdk.NewDecFromStr(res.Price.Amount)
 	if err != nil {
-		return gasPrices, errors.Wrapf(err, "failed to unmarshal value: %s", res.Param.Value)
+		return gasPrices, errors.Errorf("failed to handle amount: %s", err)
 	}
 
-	for _, value := range values {
-		coinStr := fmt.Sprintf("%s%s", value.Amount, value.Denom)
-
-		coin, err := sdk.ParseDecCoin(coinStr)
-		if err != nil {
-			logger.Errorf("failed to parse dec coin: %s: %v", coinStr, err)
-			continue
-		}
-
-		gasPrices[coin.GetDenom()] = coin.Amount
-	}
+	gasPrices[res.Price.Denom] = amount
 
 	return gasPrices, nil
 }


### PR DESCRIPTION
Latest fork of cosmos removed the `globalfee` module and replaced it with `feemarket` module. Update the Unchained API to fetch minimum gas prices from the new `feemarket` module

https://github.com/cosmos/gaia/pull/3028