### PR TITLE
chore: follow up updates for thorchain hard fork

### DIFF
--- a/go/coinstacks/thorchain-v1/daemon/init.sh
+++ b/go/coinstacks/thorchain-v1/daemon/init.sh
@@ -5,7 +5,8 @@ set -e
 apk add bash
 
 start_coin() {
-  /scripts/fullnode.sh thornode start \
+  thornode start \
+    --p2p.pex=false \
     --p2p.laddr=tcp://0.0.0.0:27146 \
     --proxy_app=tcp://127.0.0.1:27148 \
     --rpc.laddr=tcp://0.0.0.0:27147 &

--- a/go/coinstacks/thorchain/daemon/readiness.sh
+++ b/go/coinstacks/thorchain/daemon/readiness.sh
@@ -20,9 +20,9 @@ CATCHING_UP=$(echo $STATUS | jq -r '.result.sync_info.catching_up')
 NUM_PEERS=$(echo $NET_INFO | jq -r '.result.n_peers')
 
 status_curls=(
-  "curl -sf -m 3 https://rpc-v2.ninerealms.com/status"
+  "curl -sf -m 3 https://rpc.ninerealms.com/status"
   # referer header now required to avoid being blocked
-  #"curl -sf -m 3 -H \"Referer: https://app.thorswap.finance\" https://rpc-v2.thorswap.net/status"
+  #"curl -sf -m 3 -H \"Referer: https://app.thorswap.finance\" https://rpc.thorswap.net/status"
 )
 
 if [[ $IS_SYNCING == false && $CATCHING_UP == false ]]; then


### PR DESCRIPTION
- start thornode directly for legacy (render-config is broken post fork)
- disable p2p for legacy
- update readiness endpoint