### PR TITLE
chore: upgrade base node stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,13 +637,13 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101315.3
+    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101408.0
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 18Gi
     service-storage-size-1: 750Gi
     service-name-2: op-node
-    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.9.0
+    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.9.1
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 2Gi

--- a/node/coinstacks/base/daemon/init.sh
+++ b/node/coinstacks/base/daemon/init.sh
@@ -36,6 +36,7 @@ start() {
     --rollup.sequencerhttp https://mainnet-sequencer.base.org \
     --rollup.halt major \
     --op-network base-mainnet \
+    --state.scheme hash \
     --history.transactions 0 \
     --cache 4096 \
     --maxpeers 0 \


### PR DESCRIPTION
- https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101408.0
- https://github.com/ethereum-optimism/optimism/releases/tag/v1.9.1