### PR TITLE
chore: disable volume alert for thorchain-v1

### DIFF
--- a/monitoring/src/alertmanager/config.yaml
+++ b/monitoring/src/alertmanager/config.yaml
@@ -45,6 +45,7 @@ route:
         - alertname = "KubePersistentVolumeFillingUp"
         - namespace = "unchained"
         - severity = "critical"
+        - asset != "thorchain-v1"
     - receiver: "discord_critical"
       group_by: ["alertname", "namespace", "statefulset"]
       group_wait: 5m
@@ -110,6 +111,7 @@ route:
         - alertname = "KubePersistentVolumeFillingUp"
         - namespace = "unchained-dev"
         - severity = "critical"
+        - asset != "thorchain-v1"
     - receiver: "discord_dev"
       group_by: ["alertname", "namespace", "statefulset"]
       group_wait: 15m


### PR DESCRIPTION
No need to alert on volume size for `thorchain-v1` as it is a static archive volume now.