### PR TITLE
fix: thorchain-v1 confirmations

### DIFF
--- a/go/cmd/thorchain-v1/sample.env
+++ b/go/cmd/thorchain-v1/sample.env
@@ -1,2 +1,3 @@
 LCD_URL=https://dev-daemon.thorchain-v1.shapeshift.com/lcd
 RPC_URL=https://dev-daemon.thorchain-v1.shapeshift.com/rpc
+WS_URL=wss://dev-daemon.thorchain.shapeshift.com/rpc

--- a/go/coinstacks/thorchain-v1/api/api.go
+++ b/go/coinstacks/thorchain-v1/api/api.go
@@ -47,13 +47,13 @@ type API struct {
 	handler *Handler
 }
 
-func New(httpClient *cosmos.HTTPClient, blockService *cosmos.BlockService, swaggerPath string, prometheus *metrics.Prometheus) *API {
+func New(httpClient *cosmos.HTTPClient, wsClient *cosmos.WSClient, blockService *cosmos.BlockService, swaggerPath string, prometheus *metrics.Prometheus) *API {
 	r := mux.NewRouter()
 
 	handler := &Handler{
 		Handler: &cosmos.Handler{
 			HTTPClient:   httpClient,
-			WSClient:     nil,
+			WSClient:     wsClient,
 			BlockService: blockService,
 			Denom:        "rune",
 		},

--- a/go/coinstacks/thorchain-v1/api/handler.go
+++ b/go/coinstacks/thorchain-v1/api/handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/pkg/errors"
 	"github.com/shapeshift/unchained/pkg/api"
 	"github.com/shapeshift/unchained/pkg/cosmos"
 	"github.com/shapeshift/unchained/pkg/thorchain"
@@ -13,6 +14,11 @@ type Handler struct {
 }
 
 func (h *Handler) StartWebsocket() error {
+	err := h.WSClient.Start()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	return nil
 }
 

--- a/go/coinstacks/thorchain-v1/api/websocket.go
+++ b/go/coinstacks/thorchain-v1/api/websocket.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/shapeshift/unchained/pkg/cosmos"
+	tendermintjson "github.com/tendermint/tendermint/libs/json"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+	tendermint "github.com/tendermint/tendermint/rpc/jsonrpc/client"
+	"github.com/tendermint/tendermint/types"
+)
+
+type WSClient struct {
+	blockService *cosmos.BlockService
+	client       *tendermint.WSClient
+	errChan      chan<- error
+}
+
+func NewWebsocketClient(conf cosmos.Config, blockService *cosmos.BlockService, errChan chan<- error) (*WSClient, error) {
+	wsURL, err := url.Parse(conf.WSURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse WSURL: %s", conf.WSURL)
+	}
+
+	client, err := tendermint.NewWS(wsURL.String(), "/websocket")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create websocket client")
+	}
+
+	// use default dialer
+	client.Dialer = net.Dial
+
+	ws := &WSClient{
+		blockService: blockService,
+		client:       client,
+		errChan:      errChan,
+	}
+
+	tendermint.MaxReconnectAttempts(10)(client)
+	tendermint.OnReconnect(func() {
+		logger.Info("OnReconnect triggered: resubscribing")
+		_ = client.Subscribe(context.Background(), types.EventQueryNewBlockHeader.String())
+	})(client)
+
+	return ws, nil
+}
+
+func (ws *WSClient) Start() error {
+	err := ws.client.Start()
+	if err != nil {
+		return errors.Wrap(err, "failed to start websocket client")
+	}
+
+	err = ws.client.Subscribe(context.Background(), types.EventQueryNewBlockHeader.String())
+	if err != nil {
+		return errors.Wrap(err, "failed to subscribe to newBlocks")
+	}
+
+	go ws.listen()
+
+	return nil
+}
+
+func (ws *WSClient) Stop() {
+	if err := ws.client.Stop(); err != nil {
+		logger.Errorf("failed to stop the websocket client: %v", err)
+	}
+}
+
+func (ws *WSClient) listen() {
+	for r := range ws.client.ResponsesCh {
+		if r.Error != nil {
+			// resubscribe if subscription is cancelled by the server for reason: client is not pulling messages fast enough
+			// experimental rpc config available to help mitigate this issue: https://github.com/tendermint/tendermint/blob/main/config/config.go#L373
+			if r.Error.Code == -32000 {
+				err := ws.client.UnsubscribeAll(context.Background())
+				if err != nil {
+					logger.Error(errors.Wrap(err, "failed to unsubscribe from all subscriptions"))
+				}
+
+				err = ws.client.Subscribe(context.Background(), types.EventQueryNewBlockHeader.String())
+				if err != nil {
+					logger.Error(errors.Wrap(err, "failed to subscribe to newBlocks"))
+				}
+
+				continue
+			}
+
+			logger.Error(r.Error.Error())
+			continue
+		}
+
+		result := &coretypes.ResultEvent{}
+		if err := tendermintjson.Unmarshal(r.Result, result); err != nil {
+			logger.Errorf("failed to unmarshal tx message: %v", err)
+			continue
+		}
+
+		if result.Data != nil {
+			switch result.Data.(type) {
+			case types.EventDataNewBlockHeader:
+				go ws.handleNewBlockHeader(result.Data.(types.EventDataNewBlockHeader))
+			default:
+				fmt.Printf("unsupported result type: %T", result.Data)
+			}
+		}
+	}
+
+	// if reconnect fails, ResponsesCh is closed
+	ws.errChan <- errors.New("websocket client connection closed by server")
+}
+
+func (ws *WSClient) handleNewBlockHeader(block types.EventDataNewBlockHeader) {
+	b := &cosmos.BlockResponse{
+		Height:    int(block.Header.Height),
+		Hash:      block.Header.Hash().String(),
+		Timestamp: int(block.Header.Time.Unix()),
+	}
+
+	ws.blockService.WriteBlock(b, true)
+}

--- a/go/pkg/cosmos/handler.go
+++ b/go/pkg/cosmos/handler.go
@@ -119,9 +119,7 @@ func (h *Handler) StartWebsocket() error {
 }
 
 func (h *Handler) StopWebsocket() {
-	if h.WSClient != nil {
-		h.WSClient.Stop()
-	}
+	h.WSClient.Stop()
 }
 
 func (h *Handler) GetInfo() (api.Info, error) {


### PR DESCRIPTION
Leverage `thorchain-1` websockets to update `BlockService.Latest.Height` on `newBlockHeader`. This ensures we can accurately calculate the number of confirmations on `thorchain-v1` transactions.