### PR TITLE
feat: update response of utxo chain queries by address

### DIFF
--- a/node/coinstacks/common/api/src/utxo/service.ts
+++ b/node/coinstacks/common/api/src/utxo/service.ts
@@ -48,7 +48,12 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       const addresses = data.tokens?.map<Address>((token) => ({
         balance: token.balance ?? '0',
         pubkey: token.name,
-      }))
+      })) ?? [
+        {
+          balance: data.balance,
+          pubkey: data.address,
+        },
+      ]
 
       // For any change indexes detected by blockbook, we want to find the next unused address.
       // To do this we will add 1 to any address indexes found and keep track of the highest index.
@@ -141,7 +146,10 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   async getUtxos(pubkey: string): Promise<Array<Utxo>> {
     try {
       const data = await this.blockbook.getUtxo(pubkey)
-      return data
+      return data.map((utxo) => {
+        if (utxo.address) return utxo
+        return { ...utxo, address: pubkey }
+      })
     } catch (err) {
       throw handleError(err)
     }


### PR DESCRIPTION
With the upcoming addition of phantom wallet which only supports a single address for bitcoin (no account xpub exposed), it was noticed that the responses were not conforming to the queries by xpub. Update to conform as closely as possible (note we cannot determine the derivation path for `/utxo` endpoint)