### PR TITLE
feat: add solana get token endpoint

### DIFF
--- a/node/coinstacks/solana/api/package.json
+++ b/node/coinstacks/solana/api/package.json
@@ -15,6 +15,6 @@
     "@shapeshiftoss/common-api": "^10.0.0",
     "@shapeshiftoss/websocket": "^10.0.0",
     "@solana/web3.js": "^1.95.3",
-    "helius-sdk": "^1.3.6"
+    "helius-sdk": "^1.4.0"
   }
 }

--- a/node/coinstacks/solana/api/src/controller.ts
+++ b/node/coinstacks/solana/api/src/controller.ts
@@ -357,7 +357,7 @@ export class Solana implements BaseAPI, API {
   @Post('/fees/estimate')
   async estimateFees(@Body() body: EstimateFeesBody): Promise<string> {
     try {
-      if (!('serializedTx' in body)) throw new Error('Use serializedTx (message deprecated)')
+      if (!('serializedTx' in body) || !body.serializedTx) throw new Error('serializedTx required')
 
       const deserializedTransaction = VersionedTransaction.deserialize(Buffer.from(body.serializedTx, 'base64'))
 

--- a/node/coinstacks/solana/api/src/controller.ts
+++ b/node/coinstacks/solana/api/src/controller.ts
@@ -13,7 +13,7 @@ import {
   ValidationError,
   handleError,
 } from '../../../common/api/src' // unable to import models from a module with tsoa
-import { Account, API, EstimateFeesBody, PriorityFees, TokenBalance, Tx, TxHistory } from './models'
+import { Account, API, EstimateFeesBody, PriorityFees, Token, TokenBalance, Tx, TxHistory } from './models'
 import { axiosNoRetry, axiosWithRetry, getTransaction } from './utils'
 import { NativeBalance } from './types'
 
@@ -27,6 +27,7 @@ if (!NETWORK) throw new Error('NETWORK env var not set')
 if (!RPC_URL) throw new Error('RPC_URL env var not set')
 if (!RPC_API_KEY) throw new Error('RPC_API_KEY env var not set')
 
+const rpcUrl = RPC_API_KEY ? `${RPC_URL}?api-key=${RPC_API_KEY}` : `${RPC_URL}`
 const heliusSdk = new Helius(RPC_API_KEY)
 
 @Route('api/v1')
@@ -395,9 +396,46 @@ export class Solana implements BaseAPI, API {
   @Post('jsonrpc/')
   async doRpcRequest(@Body() body: RPCRequest | Array<RPCRequest>): Promise<RPCResponse | Array<RPCResponse>> {
     try {
-      const url = RPC_API_KEY ? `${RPC_URL}?api-key=${RPC_API_KEY}` : `${RPC_URL}`
-      const { data } = await axiosWithRetry.post<RPCResponse>(url, body)
+      const { data } = await axiosWithRetry.post<RPCResponse>(rpcUrl, body)
       return data
+    } catch (err) {
+      throw handleError(err)
+    }
+  }
+
+  /**
+   * Get token details
+   *
+   * @param {string} id token id
+   *
+   * @returns {Promise<Token>} token details
+   *
+   * @example pubkey "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+   */
+  @Example<Token>({
+    id: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    name: 'USD Coin',
+    symbol: 'USDC',
+    decimals: 6,
+    type: 'FungibleToken',
+  })
+  @Response<ValidationError>(422, 'Validation Error')
+  @Response<InternalServerError>(500, 'Internal Server Error')
+  @Get('/token/{id}')
+  async getToken(@Path() id: string): Promise<Token> {
+    try {
+      const asset = await heliusSdk.rpc.getAsset({ id })
+
+      if (asset.content?.metadata === undefined) throw new Error('token metadata undefined')
+      if (asset.token_info?.decimals === undefined) throw new Error('token decimals undefined')
+
+      return {
+        id: asset.id,
+        name: asset.content.metadata.name,
+        symbol: asset.content.metadata.symbol,
+        decimals: asset.token_info.decimals,
+        type: asset.interface,
+      }
     } catch (err) {
       throw handleError(err)
     }

--- a/node/coinstacks/solana/api/src/controller.ts
+++ b/node/coinstacks/solana/api/src/controller.ts
@@ -30,12 +30,12 @@ if (!RPC_API_KEY) throw new Error('RPC_API_KEY env var not set')
 const rpcUrl = RPC_API_KEY ? `${RPC_URL}?api-key=${RPC_API_KEY}` : `${RPC_URL}`
 const heliusSdk = new Helius(RPC_API_KEY)
 
+const tokens: Record<string, Token> = {}
+
 @Route('api/v1')
 @Tags('v1')
 export class Solana implements BaseAPI, API {
   static baseFee = '5000'
-
-  private tokens: Record<string, Token> = {}
 
   /**
    * Get information about the running coinstack
@@ -412,7 +412,7 @@ export class Solana implements BaseAPI, API {
    *
    * @returns {Promise<Token>} token details
    *
-   * @example pubkey "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+   * @example id "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
    */
   @Example<Token>({
     id: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
@@ -426,7 +426,7 @@ export class Solana implements BaseAPI, API {
   @Get('/token/{id}')
   async getToken(@Path() id: string): Promise<Token> {
     try {
-      if (this.tokens[id]) return this.tokens.id
+      if (tokens[id]) return tokens[id]
 
       const asset = await heliusSdk.rpc.getAsset({ id })
 
@@ -441,7 +441,7 @@ export class Solana implements BaseAPI, API {
         type: asset.interface,
       }
 
-      this.tokens[id] = token
+      tokens[id] = token
 
       return token
     } catch (err) {

--- a/node/coinstacks/solana/api/src/controller.ts
+++ b/node/coinstacks/solana/api/src/controller.ts
@@ -35,6 +35,8 @@ const heliusSdk = new Helius(RPC_API_KEY)
 export class Solana implements BaseAPI, API {
   static baseFee = '5000'
 
+  private tokens: Record<string, Token> = {}
+
   /**
    * Get information about the running coinstack
    *
@@ -424,18 +426,24 @@ export class Solana implements BaseAPI, API {
   @Get('/token/{id}')
   async getToken(@Path() id: string): Promise<Token> {
     try {
+      if (this.tokens[id]) return this.tokens.id
+
       const asset = await heliusSdk.rpc.getAsset({ id })
 
       if (asset.content?.metadata === undefined) throw new Error('token metadata undefined')
       if (asset.token_info?.decimals === undefined) throw new Error('token decimals undefined')
 
-      return {
+      const token: Token = {
         id: asset.id,
         name: asset.content.metadata.name,
         symbol: asset.content.metadata.symbol,
         decimals: asset.token_info.decimals,
         type: asset.interface,
       }
+
+      this.tokens[id] = token
+
+      return token
     } catch (err) {
       throw handleError(err)
     }

--- a/node/coinstacks/solana/api/src/models.ts
+++ b/node/coinstacks/solana/api/src/models.ts
@@ -63,10 +63,10 @@ export interface PriorityFees {
  */
 export type EstimateFeesBody =
   | {
-      serializedTx: string
+      serializedTx?: string
     }
   | {
-      message: string
+      message?: string
     }
 
 /**

--- a/node/coinstacks/solana/api/src/swagger.json
+++ b/node/coinstacks/solana/api/src/swagger.json
@@ -2032,6 +2032,70 @@
 					}
 				}
 			}
+		},
+		"/api/v1/token/{id}": {
+			"get": {
+				"operationId": "GetToken",
+				"responses": {
+					"200": {
+						"description": "token details",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Token"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"id": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+											"name": "USD Coin",
+											"symbol": "USDC",
+											"decimals": 6,
+											"type": "FungibleToken"
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token details",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "token id",
+						"in": "path",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
 		}
 	},
 	"servers": [

--- a/node/coinstacks/solana/api/src/swagger.json
+++ b/node/coinstacks/solana/api/src/swagger.json
@@ -1289,9 +1289,6 @@
 								"type": "string"
 							}
 						},
-						"required": [
-							"serializedTx"
-						],
 						"type": "object"
 					},
 					{
@@ -1300,9 +1297,6 @@
 								"type": "string"
 							}
 						},
-						"required": [
-							"message"
-						],
 						"type": "object"
 					}
 				],

--- a/node/coinstacks/solana/api/src/swagger.json
+++ b/node/coinstacks/solana/api/src/swagger.json
@@ -2092,7 +2092,8 @@
 						"required": true,
 						"schema": {
 							"type": "string"
-						}
+						},
+						"example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 					}
 				]
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7735,10 +7735,10 @@ hdr-histogram-percentiles-obj@^3.0.0:
   resolved "https://registry.yarnpkg.com/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz#9409f4de0c2dda78e61de2d9d78b1e9f3cba283c"
   integrity sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==
 
-helius-sdk@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/helius-sdk/-/helius-sdk-1.3.6.tgz#7c399cabe6b2621df671aea44a20fd957e3539b2"
-  integrity sha512-pJUF+1Tw6cF4X5GWNEmUxTG4NLLlyYs4PwZmaJMfQkjamgP0AFaDSnMCvEVpkcoObcNuyN6tDdoz9shhLAAe3g==
+helius-sdk@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/helius-sdk/-/helius-sdk-1.4.0.tgz#41a4f9b33e640357f733ff8928c85353bdfcd608"
+  integrity sha512-caxvgR27ohkE8UVz2o9ayrMN21kbO5c7N+wT+X7kVjbmZCcJ2cgiycK4Ev5Gzl3eulcZo8LnAozhdfhPiq0mCQ==
   dependencies:
     "@irys/sdk" "^0.2.10"
     "@metaplex-foundation/mpl-token-metadata" "^2.5.2"


### PR DESCRIPTION
- `getToken` endpoint to allow us to get token information like 'decimals', 'name', 'symbol' which are not present on the transaction history responses
- cache tokens to improve performance