### PR TITLE
fix: use confirmed commit level for logsSubscribe

### DIFF
--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -31,7 +31,7 @@ import { ERC1155_ABI } from './abi/erc1155'
 import { ERC721_ABI } from './abi/erc721'
 
 const axiosNoRetry = axios.create({ timeout: 5000 })
-const axiosWithRetry = createAxiosRetry({ timeout: 10000 })
+const axiosWithRetry = createAxiosRetry({}, { timeout: 10000 })
 
 type InternalTxFetchMethod = 'trace_transaction' | 'debug_traceTransaction'
 

--- a/node/coinstacks/solana/api/src/utils.ts
+++ b/node/coinstacks/solana/api/src/utils.ts
@@ -10,7 +10,14 @@ if (!INDEXER_URL) throw new Error('INDEXER_URL env var not set')
 if (!RPC_API_KEY) throw new Error('RPC_API_KEY env var not set')
 
 export const axiosNoRetry = axios.create({ timeout: 5000, params: { 'api-key': RPC_API_KEY } })
-export const axiosWithRetry = createAxiosRetry({ timeout: 10000, params: { 'api-key': RPC_API_KEY } })
+
+// Amounts to ~1 minutes worth of potential retries to account for logsSubscribe "confirmed" commit level
+// and /transactions only returning "finalized" transactions. The "confirmed" commit level is required for logsSubscribe
+// because "finalized" commit level is not stable and misses logs frequently.
+export const axiosWithRetry = createAxiosRetry(
+  { retries: 6, delayFactor: 1000 },
+  { timeout: 10000, params: { 'api-key': RPC_API_KEY } }
+)
 
 export const getTransaction = async (txid: string, shouldRetry?: boolean, retryCount = 0): Promise<Tx> => {
   try {

--- a/node/coinstacks/solana/api/src/websocket.ts
+++ b/node/coinstacks/solana/api/src/websocket.ts
@@ -91,7 +91,7 @@ export class WebsocketClient extends BaseWebsocketClient {
         jsonrpc: '2.0',
         id: this.currentId.toString(),
         method: 'logsSubscribe',
-        params: [{ mentions: [address] }],
+        params: [{ mentions: [address] }, { commitment: 'confirmed' }],
       }
 
       try {


### PR DESCRIPTION
Use of `finalized` commit level on `logsSubscribe` subscription resulted in frequent missed transactions logs. Update to use `confirmed` commit level to ensure stable transaction log subscriptions and increase the retry for `getTransaction` to allot up to 1 minutes of retries to ensure there is time for the transaction to be finalized on chain and subsequently returned from the helius `/transactions` endpoint.