### PR TITLE
feat: add address lookup table infos endpoint to solana

### DIFF
--- a/node/coinstacks/solana/api/src/controller.ts
+++ b/node/coinstacks/solana/api/src/controller.ts
@@ -1,5 +1,5 @@
 import { validatePageSize } from '@shapeshiftoss/common-api'
-import { VersionedTransaction } from '@solana/web3.js'
+import { AccountInfo, PublicKey, VersionedTransaction } from '@solana/web3.js'
 import { DAS, EnrichedTransaction, Helius, Interface, Source, TransactionType } from 'helius-sdk'
 import { Body, Example, Get, Path, Post, Query, Response, Route, Tags } from 'tsoa'
 import {
@@ -111,6 +111,30 @@ export class Solana implements BaseAPI, API {
         unconfirmedBalance: '0',
         tokens,
       }
+    } catch (err) {
+      throw handleError(err)
+    }
+  }
+
+  /**
+   * Get multiple accounts infos to construct any address lookup table accounts
+   *
+   * @param {string[]} addresses all the addresses of the accounts container in the address lookup table
+   *
+   * @returns {Promise<(AccountInfo<Buffer> | null)[]>} account infos
+   *
+   */
+  @Response<BadRequestError>(400, 'Bad Request')
+  @Response<ValidationError>(422, 'Validation Error')
+  @Response<InternalServerError>(500, 'Internal Server Error')
+  @Get('accounts-info')
+  async getAddressLookupTableAccounts(@Query() addresses: string[]): Promise<(AccountInfo<Buffer> | null)[]> {
+    try {
+      const addressLookupTableAccountInfos = await heliusSdk.connection.getMultipleAccountsInfo(
+        addresses.map((key) => new PublicKey(key))
+      )
+
+      return addressLookupTableAccountInfos
     } catch (err) {
       throw handleError(err)
     }

--- a/node/coinstacks/solana/api/src/swagger.json
+++ b/node/coinstacks/solana/api/src/swagger.json
@@ -130,6 +130,45 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"PublicKey": {
+				"type": "string",
+				"description": "A public key"
+			},
+			"AccountInfo_Buffer_": {
+				"properties": {
+					"rentEpoch": {
+						"type": "number",
+						"format": "double",
+						"description": "Optional rent epoch info for account"
+					},
+					"data": {
+						"type": "string",
+						"format": "byte",
+						"description": "Optional data assigned to the account"
+					},
+					"lamports": {
+						"type": "number",
+						"format": "double",
+						"description": "Number of lamports assigned to the account"
+					},
+					"owner": {
+						"$ref": "#/components/schemas/PublicKey",
+						"description": "Identifier of the program that owns the account"
+					},
+					"executable": {
+						"type": "boolean",
+						"description": "`true` if this account's data contains a loaded program"
+					}
+				},
+				"required": [
+					"data",
+					"lamports",
+					"owner",
+					"executable"
+				],
+				"type": "object",
+				"description": "Information describing an account"
+			},
 			"BaseTx": {
 				"description": "Contains base transaction details",
 				"properties": {
@@ -1497,6 +1536,80 @@
 							"type": "string"
 						},
 						"example": "2bUNK6eVUmXyxeSDURsWdqi1KK8BYu4egnzyi3xDYc9M"
+					}
+				]
+			}
+		},
+		"/api/v1/accounts-info": {
+			"get": {
+				"operationId": "GetAddressLookupTableAccounts",
+				"responses": {
+					"200": {
+						"description": "account infos",
+						"content": {
+							"application/json": {
+								"schema": {
+									"items": {
+										"allOf": [
+											{
+												"$ref": "#/components/schemas/AccountInfo_Buffer_"
+											}
+										],
+										"nullable": true
+									},
+									"type": "array"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get multiple accounts infos to construct any address lookup table accounts",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "all the addresses of the accounts container in the address lookup table",
+						"in": "query",
+						"name": "addresses",
+						"required": true,
+						"schema": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
 					}
 				]
 			}


### PR DESCRIPTION
In order to avoid sending too much data inside solana requests causing a Uint8Array overflow

<img width="309" alt="image" src="https://github.com/user-attachments/assets/dda2d4a5-b844-4a34-a53a-2f7277a51b1f">

We need to be able to build the address lookup table (Sometime jupiter uses 64 accounts leading to very big TXs)