### PR TITLE
Typo fix Update remote-deployment.md

### DIFF
--- a/docs/self-hosting/remote-deployment.md
+++ b/docs/self-hosting/remote-deployment.md
@@ -1,6 +1,6 @@
 # Remote Unchained Deployment
 
-run your own [uncahined api](https://api.ethereum.shapeshift.com/docs/#/)
+run your own [unchained api](https://api.ethereum.shapeshift.com/docs/#/)
 
 ### dependencies:
 


### PR DESCRIPTION
**Description:**

Typo in the documentation where "uncahined api" was used instead of "unchained api". 

The correct term, **"unchained api"**, refers to the actual API endpoint and service, and using the incorrect spelling could lead to confusion or misdirect users searching for the proper documentation or API endpoint.

By fixing this typo, we ensure that users can find the correct resources without confusion.