### PR TITLE
chore: upgrade backend to latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,13 +172,13 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 1
     service-name-1: daemon
-    service-image-1: shapeshiftdao/bitcoin-core:27.1
+    service-image-1: shapeshiftdao/bitcoin-core:28.0
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 8Gi
     service-storage-size-1: 650Gi
     service-name-2: indexer
-    service-image-2: shapeshiftdao/unchained-blockbook:e9a0858
+    service-image-2: shapeshiftdao/unchained-blockbook:1fe4ee0
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 32Gi
@@ -219,7 +219,7 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: ethereum/client-go:v1.14.11
+    service-image-1: ethereum/client-go:v1.14.12
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 24Gi
@@ -231,7 +231,7 @@ aliases:
     service-memory-limit-2: 12Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
-    service-image-3: shapeshiftdao/unchained-blockbook:e9a0858
+    service-image-3: shapeshiftdao/unchained-blockbook:1fe4ee0
     service-cpu-limit-3: "2"
     service-cpu-request-3: "1"
     service-memory-limit-3: 12Gi
@@ -389,7 +389,7 @@ aliases:
     api-memory-request: 1Gi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-2.137.2
+    service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-2.137.3
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 16Gi
@@ -401,7 +401,7 @@ aliases:
     service-memory-limit-2: 8Gi
     service-storage-size-2: 400Gi
     service-name-3: indexer
-    service-image-3: registry.gitlab.com/thorchain/midgard:2.25.1
+    service-image-3: registry.gitlab.com/thorchain/midgard:2.26.0
     service-cpu-limit-3: "2"
     service-cpu-request-3: "1"
     service-memory-limit-3: 2Gi
@@ -568,7 +568,7 @@ aliases:
     service-memory-limit-1: 6Gi
     service-storage-size-1: 750Gi
     service-name-2: daemon-beacon
-    service-image-2: sigp/lighthouse:v5.3.0
+    service-image-2: sigp/lighthouse:v6.0.0
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 4Gi
@@ -639,13 +639,13 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.0
+    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.2
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 18Gi
     service-storage-size-1: 750Gi
     service-name-2: op-node
-    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.9.4
+    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.10.0
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 2Gi

--- a/node/packages/blockbook/Dockerfile
+++ b/node/packages/blockbook/Dockerfile
@@ -24,7 +24,7 @@ RUN cd /opt && git clone -b $ROCKSDB_VERSION --depth 1 https://github.com/facebo
 RUN cd /opt/rocksdb && CFLAGS=-fPIC CXXFLAGS=-fPIC PORTABLE=$PORTABLE_ROCKSDB make -j 4 static_lib
 
 ENV BLOCKBOOK_VERSION=master
-ENV BLOCKBOOK_COMMIT=e9a0858
+ENV BLOCKBOOK_COMMIT=1fe4ee0
 ENV BLOCKBOOK_URL=https://github.com/trezor/blockbook.git
 
 # set up blockbook


### PR DESCRIPTION
- Upgrade blockbook to latest main commit (supports bitcoin upgrade)
- https://github.com/bitcoin/bitcoin/releases/tag/v28.0
- https://github.com/ethereum/go-ethereum/releases/tag/v1.14.12
- https://gitlab.com/thorchain/thornode/-/releases/v2.137.3
- https://gitlab.com/thorchain/midgard/-/releases/2.26.0
- https://github.com/sigp/lighthouse/releases/tag/v6.0.0
- https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.2
- https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.10.0