### PR TITLE
fix: configure ipfs from init container

### DIFF
--- a/pulumi/src/ipfs/configure-ipfs.sh
+++ b/pulumi/src/ipfs/configure-ipfs.sh
@@ -1,31 +1,27 @@
 #!/bin/sh
 
-set -e
-set -x
+set -ex
 
 user=ipfs
 
-# This is a custom entrypoint for k8s designed to run ipfs nodes in an appropriate
-# setup for production scenarios.
+mkdir -p /data/ipfs && chown -R "$user" /data/ipfs
 
-mkdir -p /data/ipfs && chown -R ipfs /data/ipfs
-
-if [ -f /data/ipfs/config ]; then
+if [ ! -f /data/ipfs/config ]; then
+  ipfs init --profile=server
+else
   if [ -f /data/ipfs/repo.lock ]; then
     rm /data/ipfs/repo.lock
   fi
-  exit 0
-fi
 
-ipfs init --profile=server
-ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
-ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
-ipfs config --json Swarm.ConnMgr.HighWater 10000
-ipfs config --json Swarm.ConnMgr.LowWater 2500
-ipfs config --json Swarm.ConnMgr.GracePeriod 20s
-ipfs config --json Internal.Bitswap.EngineBlockstoreWorkerCount 2500
-ipfs config --json Internal.Bitswap.EngineTaskWorkerCount 500
-ipfs config --json Internal.Bitswap.MaxOutstandingBytesPerPeer 1048576
-ipfs config --json Internal.Bitswap.TaskWorkerCount 500
-ipfs config --json Datastore.BloomFilterSize 1048576
-ipfs config Datastore.StorageMax 100GB
+  ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
+  ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
+  ipfs config Swarm.ConnMgr.GracePeriod 20s
+  ipfs config --json Swarm.ConnMgr.HighWater 10000
+  ipfs config --json Swarm.ConnMgr.LowWater 2500
+  ipfs config --json Internal.Bitswap.EngineBlockstoreWorkerCount 2500
+  ipfs config --json Internal.Bitswap.EngineTaskWorkerCount 500
+  ipfs config --json Internal.Bitswap.MaxOutstandingBytesPerPeer 1048576
+  ipfs config --json Internal.Bitswap.TaskWorkerCount 500
+  ipfs config --json Datastore.BloomFilterSize 1048576
+  ipfs config Datastore.StorageMax 100GB
+fi


### PR DESCRIPTION
Previously we were exiting if an ipfs config already existed resulting in the inability to reconfigure ipfs. Update logic to init config if it doesn't exist and still allow for updating/changing config thereafter.