### PR TITLE
fix: bitcoin deprecatedrpc warnings

### DIFF
--- a/node/coinstacks/bitcoin/daemon/init.sh
+++ b/node/coinstacks/bitcoin/daemon/init.sh
@@ -18,7 +18,8 @@ start_coin() {
     -zmqpubhashblock=tcp://127.0.0.1:28332 \
     -rpcworkqueue=1100 \
     -maxmempool=2000 \
-    -dbcache=4000 &
+    -dbcache=4000 \
+    -deprecatedrpc=warnings &
   PID="$!"
 }
 


### PR DESCRIPTION
Blockbook is not handling the new rpc updates as of v28.0. Make sure deprecated rpc endpoint only return warnings so blockbook can still sync.