### PR TITLE
chore: infra updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ aliases:
     api-memory-request: 1Gi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-3.1.1
+    service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-3.2.0
     service-cpu-limit-1: "2"
     service-cpu-request-1: "1"
     service-memory-limit-1: 16Gi
@@ -401,7 +401,7 @@ aliases:
     service-memory-limit-2: 8Gi
     service-storage-size-2: 400Gi
     service-name-3: indexer
-    service-image-3: registry.gitlab.com/thorchain/midgard:2.29.4
+    service-image-3: registry.gitlab.com/thorchain/midgard:2.29.5
     service-cpu-limit-3: "2"
     service-cpu-request-3: "1"
     service-memory-limit-3: 2Gi
@@ -639,22 +639,22 @@ aliases:
     api-memory-request: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.4
-    service-cpu-limit-1: "8"
-    service-cpu-request-1: "4"
+    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.6
+    service-cpu-limit-1: "4"
+    service-cpu-request-1: "2"
     service-memory-limit-1: 32Gi
     service-storage-size-1: 750Gi
     service-name-2: op-node
-    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.10.2
+    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.10.3
     service-cpu-limit-2: "2"
     service-cpu-request-2: "1"
     service-memory-limit-2: 2Gi
     service-storage-size-2: 1Gi
     service-name-3: indexer
     service-image-3: shapeshiftdao/unchained-blockbook:base-pub-new-block-txs-932b4b5
-    service-cpu-limit-3: "8"
-    service-cpu-request-3: "4"
-    service-memory-limit-3: 32Gi
+    service-cpu-limit-3: "4"
+    service-cpu-request-3: "2"
+    service-memory-limit-3: 24Gi
     service-storage-size-3: 100Gi
 
   - &base-dev


### PR DESCRIPTION
- https://github.com/ethereum/go-ethereum/releases/tag/v1.15.0
- https://gitlab.com/thorchain/thornode/-/releases/v3.2.0
- https://gitlab.com/thorchain/midgard/-/releases/2.29.5
- https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.6
- https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.10.3
- Right size base daemon and indexer