### PR TITLE
chore: update ipfs config

### DIFF
--- a/pulumi/src/ipfs/entrypoint.sh
+++ b/pulumi/src/ipfs/entrypoint.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-user=ipfs
+set -x
 
-# This is a custom entrypoint for k8s designed to connect to the bootstrap
-# node running in the cluster. It has been set up using a configmap to
-# allow changes on the fly.
+user=ipfs
 
 if [ ! -f /data/ipfs-cluster/service.json ]; then
   ipfs-cluster-service init
@@ -12,17 +10,10 @@ fi
 
 PEER_HOSTNAME=`cat /proc/sys/kernel/hostname`
 
-grep -q ".*ipfs-cluster-0.*" /proc/sys/kernel/hostname
+grep -q ".*ipfs-0.*" /proc/sys/kernel/hostname
 
 if [ $? -eq 0 ]; then
   exec ipfs-cluster-service daemon --upgrade
 else
-  BOOTSTRAP_ADDR=/dns4/${SVC_NAME}-0/tcp/9096/ipfs/${CLUSTER_ID}
-
-  if [ -z $BOOTSTRAP_ADDR ]; then
-    exit 1
-  fi
-
-  # Only ipfs user can get here
-  exec ipfs-cluster-service daemon --upgrade --bootstrap $BOOTSTRAP_ADDR --leave
+  exec ipfs-cluster-service daemon --upgrade --bootstrap /dns4/${SVC_NAME}-0/tcp/9096/ipfs/${CLUSTER_ID} --leave
 fi

--- a/pulumi/src/ipfs/ipfs.ts
+++ b/pulumi/src/ipfs/ipfs.ts
@@ -123,7 +123,7 @@ export function deployIpfs({ namespace, provider, domain, additionalDomain }: Ip
             },
             {
               name: 'SVC_NAME',
-              value: name,
+              value: `${name}-svc.${namespace}.svc.cluster.local`,
             },
           ],
           ports: [


### PR DESCRIPTION
ipfs cluster peering has recently died resulting in the inability to fetch new ipfs content. first attempt fix at dns bootstrapping.