### PR TITLE
fix: ipfs cluster config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -726,7 +726,6 @@ commands:
             echo 'export ADDITIONAL_ROOT_DOMAIN_NAME=$<< parameters.organization >>_ADDITIONAL_ROOT_DOMAIN_NAME' >> $BASH_ENV
             echo 'export PULUMI_ACCESS_TOKEN=$<< parameters.organization >>_PULUMI_ACCESS_TOKEN' >> $BASH_ENV
             echo 'export IPFS_CLUSTER_SECRET=$IPFS_CLUSTER_SECRET' >> $BASH_ENV
-            echo 'export IPFS_CLUSTER_PRIV_KEY=$IPFS_CLUSTER_PRIV_KEY' >> $BASH_ENV
       - run:
           name: install tools
           command: |

--- a/pulumi/src/ipfs/entrypoint.sh
+++ b/pulumi/src/ipfs/entrypoint.sh
@@ -15,5 +15,5 @@ grep -q ".*ipfs-0.*" /proc/sys/kernel/hostname
 if [ $? -eq 0 ]; then
   exec ipfs-cluster-service daemon --upgrade
 else
-  exec ipfs-cluster-service daemon --upgrade --bootstrap /dns4/${SVC_NAME}-0/tcp/9096/ipfs/${CLUSTER_ID} --leave
+  exec ipfs-cluster-service daemon --upgrade --bootstrap /dns4/ipfs-0.${SVC_NAME}/tcp/9096/p2p/${BOOTSTRAP_PEER_ID} --leave
 fi

--- a/pulumi/src/statefulService.ts
+++ b/pulumi/src/statefulService.ts
@@ -297,7 +297,10 @@ export async function deployStatefulService(
         name: `${assetName}-sts`,
         namespace: namespace,
         labels: labels,
-        annotations: { 'pulumi.com/skipAwait': 'true' },
+        annotations: {
+          'pulumi.com/patchForce': 'true',
+          'pulumi.com/skipAwait': 'true',
+        },
       },
       spec: {
         selector: { matchLabels: labels },


### PR DESCRIPTION
- Our ipfs cluster was broken after recent updates to `go-ipfs` and `ipfs-cluster`. These updates configure the cluster correctly to ensure bootstrapping works as intended and fetching ipfs content is happy again.
- Add `patchForce` pulumi annotation to our stateful sets, to allow updates against state that has been changed by another controller (CI fix)