### PR TITLE
fix: ipfs pinata peering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -481,8 +481,6 @@ aliases:
     rpc-api-key: $NOW_NODES_API_KEY_DEV
     api-replicas: 1
     api-max-replicas: 2
-    api-cpu-limit: 250m
-    api-memory-limit: 250Mi
 
   - &polygon
     assetName: polygon

--- a/pulumi/src/ipfs/configure-ipfs.sh
+++ b/pulumi/src/ipfs/configure-ipfs.sh
@@ -24,6 +24,7 @@ ipfs config --json Internal.Bitswap.EngineTaskWorkerCount 500
 ipfs config --json Internal.Bitswap.MaxOutstandingBytesPerPeer 1048576
 ipfs config --json Internal.Bitswap.TaskWorkerCount 500
 ipfs config --json Datastore.BloomFilterSize 1048576
+ipfs config --json Peering.Peers '[{ "ID": "Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn", "Addrs": ["/dnsaddr/bitswap.pinata.cloud"] }]'
 ipfs config Datastore.StorageMax 100GB
 
 chown -R "$user" /data/ipfs


### PR DESCRIPTION
There is an issue with IPNI preventing automatic peering with pinata and the inabilty to fetch content pinned via pinata. Manually peer to to enable fetching of pinata content again.