### PR TITLE
chore: node version updates and switch base from op-geth to reth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,12 +197,12 @@ aliases:
     api-memory-limit: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: ethereum/client-go:v1.15.11
+    service-image-1: ethereum/client-go:v1.16.1
     service-cpu-limit-1: "2"
     service-memory-limit-1: 32Gi
     service-storage-size-1: 1500Gi
     service-name-2: daemon-beacon
-    service-image-2: gcr.io/prysmaticlabs/prysm/beacon-chain:v6.0.3
+    service-image-2: gcr.io/prysmaticlabs/prysm/beacon-chain:v6.0.4
     service-cpu-limit-2: "2"
     service-memory-limit-2: 16Gi
     service-storage-size-2: 600Gi
@@ -363,7 +363,7 @@ aliases:
     api-memory-limit: 1Gi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-3.6.1
+    service-image-1: registry.gitlab.com/thorchain/thornode:mainnet-3.7.0
     service-cpu-limit-1: "2"
     service-memory-limit-1: 12Gi
     service-storage-size-1: 1250Gi
@@ -373,7 +373,7 @@ aliases:
     service-memory-limit-2: 6Gi
     service-storage-size-2: 500Gi
     service-name-3: indexer
-    service-image-3: registry.gitlab.com/thorchain/midgard:2.32.4
+    service-image-3: registry.gitlab.com/thorchain/midgard:2.32.6
     service-cpu-limit-3: "2"
     service-memory-limit-3: 2Gi
     service-storage-size-3: 500Gi
@@ -527,7 +527,7 @@ aliases:
     api-memory-limit: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: nethermind/nethermind:1.31.11
+    service-image-1: nethermind/nethermind:1.32.2
     service-cpu-limit-1: "2"
     service-memory-limit-1: 8Gi
     service-storage-size-1: 750Gi
@@ -600,12 +600,12 @@ aliases:
     api-memory-limit: 500Mi
     stateful-service-replicas: 2
     service-name-1: daemon
-    service-image-1: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101511.0
+    service-image-1: ghcr.io/paradigmxyz/op-reth:v1.5.0
     service-cpu-limit-1: "4"
     service-memory-limit-1: 48Gi
     service-storage-size-1: 4000Gi
     service-name-2: op-node
-    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.3
+    service-image-2: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.4
     service-cpu-limit-2: "2"
     service-memory-limit-2: 4Gi
     service-storage-size-2: 1Gi

--- a/node/coinstacks/base/op-node/init.sh
+++ b/node/coinstacks/base/op-node/init.sh
@@ -18,7 +18,7 @@ start() {
     --l1.rpckind debug_geth \
     --l2 http://localhost:8551 \
     --l2.jwt-secret /jwt.hex \
-    --l2.enginekind geth \
+    --l2.enginekind reth \
     --rollup.load-protocol-versions=true \
     --syncmode=execution-layer \
     --verifier.l1-confs 4 \

--- a/node/coinstacks/base/pulumi/index.ts
+++ b/node/coinstacks/base/pulumi/index.ts
@@ -15,7 +15,7 @@ export = async (): Promise<Outputs> => {
       case 'daemon':
         return {
           ...service,
-          env: { SNAPSHOT: 'https://mainnet-full-snapshots.base.org/base-mainnet-full-1714543184.tar.gz' },
+          env: { SNAPSHOT: 'https://mainnet-reth-archive-snapshots.base.org/base-mainnet-reth-1749714759.tar.zst' },
           ports: {
             'daemon-rpc': { port: 8545 },
             'daemon-ws': { port: 8546, pathPrefix: '/websocket', stripPathPrefix: true },


### PR DESCRIPTION
- https://gitlab.com/thorchain/thornode/-/releases/v3.7.0
- https://gitlab.com/thorchain/midgard/-/releases/2.32.6
- https://github.com/ethereum/go-ethereum/releases/tag/v1.16.1
- https://github.com/OffchainLabs/prysm/releases/tag/v6.0.4
- https://github.com/NethermindEth/nethermind/releases/tag/1.32.2
- https://github.com/paradigmxyz/reth/releases/tag/v1.5.0
- https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.13.4