### PR TITLE
fix: ethereum debug/trace on liquify

### DIFF
--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -5,7 +5,7 @@ import BigNumber from 'bignumber.js'
 import { erc1155Abi, erc721Abi, getAddress, getContract, isHex, parseUnits, PublicClient, toHex } from 'viem'
 import type { BadRequestError, BaseAPI, EstimateGasBody, RPCRequest, RPCResponse, SendTxBody } from '../'
 import { ApiError } from '../'
-import { createAxiosRetry, exponentialDelay, handleError, validatePageSize } from '../utils'
+import { createAxiosRetry, exponentialDelay, handleError, rpcId, validatePageSize } from '../utils'
 import type {
   Account,
   API,
@@ -300,7 +300,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     try {
       const request: RPCRequest = {
         jsonrpc: '2.0',
-        id: Date.now(),
+        id: rpcId(),
         method: 'eth_sendRawTransaction',
         params: [body.hex],
       }
@@ -335,7 +335,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   ): Promise<Record<string, Array<InternalTx> | undefined>> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
-      id: Date.now(),
+      id: rpcId(),
       method: 'debug_traceBlockByHash',
       params: [blockHash, { tracer: 'callTracer' }],
     }
@@ -364,7 +364,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   ): Promise<Record<string, Array<InternalTx> | undefined>> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
-      id: Date.now(),
+      id: rpcId(),
       method: 'trace_block',
       params: [blockHash],
     }
@@ -482,7 +482,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   private async fetchInternalTxsByTxTrace(txid: string, retryCount = 0): Promise<Array<InternalTx> | undefined> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
-      id: Date.now(),
+      id: rpcId(),
       method: 'trace_transaction',
       params: [txid],
     }
@@ -506,7 +506,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   private async fetchInternalTxsByTxDebug(txid: string, retryCount = 0): Promise<Array<InternalTx> | undefined> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
-      id: Date.now(),
+      id: rpcId(),
       method: 'debug_traceTransaction',
       params: [txid, { tracer: 'callTracer' }],
     }

--- a/node/coinstacks/common/api/src/evm/service.ts
+++ b/node/coinstacks/common/api/src/evm/service.ts
@@ -300,7 +300,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     try {
       const request: RPCRequest = {
         jsonrpc: '2.0',
-        id: 'eth_sendRawTransaction',
+        id: Date.now(),
         method: 'eth_sendRawTransaction',
         params: [body.hex],
       }
@@ -335,7 +335,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   ): Promise<Record<string, Array<InternalTx> | undefined>> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
-      id: `debug_traceBlockByHash${blockHash}`,
+      id: Date.now(),
       method: 'debug_traceBlockByHash',
       params: [blockHash, { tracer: 'callTracer' }],
     }
@@ -364,7 +364,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   ): Promise<Record<string, Array<InternalTx> | undefined>> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
-      id: `trace_block${blockHash}`,
+      id: Date.now(),
       method: 'trace_block',
       params: [blockHash],
     }
@@ -482,7 +482,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   private async fetchInternalTxsByTxTrace(txid: string, retryCount = 0): Promise<Array<InternalTx> | undefined> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
-      id: `trace_transaction${txid}`,
+      id: Date.now(),
       method: 'trace_transaction',
       params: [txid],
     }
@@ -506,7 +506,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
   private async fetchInternalTxsByTxDebug(txid: string, retryCount = 0): Promise<Array<InternalTx> | undefined> {
     const request: RPCRequest = {
       jsonrpc: '2.0',
-      id: `debug_traceTransaction${txid}`,
+      id: Date.now(),
       method: 'debug_traceTransaction',
       params: [txid, { tracer: 'callTracer' }],
     }

--- a/node/coinstacks/common/api/src/utils.ts
+++ b/node/coinstacks/common/api/src/utils.ts
@@ -59,3 +59,10 @@ export const createAxiosRetry = (config: RetryConfig, axiosParams?: CreateAxiosD
 
 export const exponentialDelay = async (retryCount: number) =>
   new Promise((resolve) => setTimeout(resolve, axiosRetry.exponentialDelay(retryCount, undefined, 500)))
+
+let _rpcId = Math.floor(Math.random() * 1e6)
+export const rpcId = (): number => {
+  _rpcId = (_rpcId + 1) & 0x7fffffff
+  if (_rpcId === 0) _rpcId = 1
+  return _rpcId
+}

--- a/node/coinstacks/common/api/src/utxo/service.ts
+++ b/node/coinstacks/common/api/src/utxo/service.ts
@@ -4,7 +4,7 @@ import type { Blockbook, Tx as BlockbookTx } from '@shapeshiftoss/blockbook'
 import type { AddressFormatter, BadRequestError, BaseAPI, RPCRequest, RPCResponse, SendTxBody } from '../'
 import { ApiError } from '../'
 import type { Account, Address, API, NetworkFee, NetworkFees, RawTx, Tx, TxHistory, Utxo } from './models'
-import { handleError, validatePageSize } from '../utils'
+import { handleError, rpcId, validatePageSize } from '../utils'
 import type { Cursor } from './types'
 
 const axiosNoRetry = axios.create({ timeout: 5000 })
@@ -161,7 +161,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     try {
       const request: RPCRequest = {
         jsonrpc: '2.0',
-        id: Date.now(),
+        id: rpcId(),
         method: 'sendrawtransaction',
         params: [body.hex],
       }

--- a/node/coinstacks/common/api/src/utxo/service.ts
+++ b/node/coinstacks/common/api/src/utxo/service.ts
@@ -161,7 +161,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
     try {
       const request: RPCRequest = {
         jsonrpc: '2.0',
-        id: 'sendrawtransaction',
+        id: Date.now(),
         method: 'sendrawtransaction',
         params: [body.hex],
       }

--- a/node/coinstacks/ethereum/api/src/app.ts
+++ b/node/coinstacks/ethereum/api/src/app.ts
@@ -84,7 +84,7 @@ const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx:
 
 const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (blockbookTx) => {
   const tx = IS_LIQUIFY
-    ? await service.handleTransactionWithInternalTrace(blockbookTx, 'debug_traceTransaction')
+    ? await service.handleTransactionWithInternalTrace(blockbookTx, 'trace_transaction')
     : await service.handleTransactionWithInternalTrace(blockbookTx)
 
   const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])

--- a/node/coinstacks/ethereum/api/src/app.ts
+++ b/node/coinstacks/ethereum/api/src/app.ts
@@ -85,7 +85,7 @@ const blockHandler: BlockHandler<NewBlock, Array<{ addresses: Array<string>; tx:
 const transactionHandler: TransactionHandler<BlockbookTx, evm.Tx> = async (blockbookTx) => {
   const tx = IS_LIQUIFY
     ? await service.handleTransactionWithInternalTrace(blockbookTx, 'trace_transaction')
-    : await service.handleTransactionWithInternalTrace(blockbookTx)
+    : await service.handleTransactionWithInternalTrace(blockbookTx, 'debug_traceTransaction')
 
   const internalAddresses = (tx.internalTxs ?? []).reduce<Array<string>>((prev, tx) => [...prev, tx.to, tx.from], [])
   const addresses = [...new Set([...getAddresses(blockbookTx), ...internalAddresses])]


### PR DESCRIPTION
- reduce size of jsonrpc `id` to prevent rejection server side
- use parity trace methods for liquify (running nethermind)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved internal transaction processing by dynamically selecting the method for fetching and tracing internal transactions based on environment settings.

* **Bug Fixes**
  * Ensured all outgoing JSON-RPC requests now use unique numeric IDs, enhancing compatibility with various RPC endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->