### PR TITLE
chore: reduce cluster resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -787,15 +787,13 @@ jobs:
             pulumi config set --path unchained:common.eks.cidrBlock 10.0.0.0/16
             pulumi config set --path unchained:common.eks.nodeGroups[0].name spot
             pulumi config set --path unchained:common.eks.nodeGroups[0].type SPOT
-            pulumi config set --path unchained:common.eks.nodeGroups[0].desired 5
-            pulumi config set --path unchained:common.eks.nodeGroups[0].minSize 5
-            pulumi config set --path unchained:common.eks.nodeGroups[0].maxSize 5
+            pulumi config set --path unchained:common.eks.nodeGroups[0].desired 4
+            pulumi config set --path unchained:common.eks.nodeGroups[0].minSize 4
+            pulumi config set --path unchained:common.eks.nodeGroups[0].maxSize 4
             pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[0] r7a.4xlarge
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[1] r7i.4xlarge
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[2] r7iz.4xlarge
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[3] r6a.4xlarge
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[4] r6i.4xlarge
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[5] r6in.4xlarge
+            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[1] r6a.4xlarge
+            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[2] r6i.4xlarge
+            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[3] r6in.4xlarge
             pulumi config set --path unchained:common.eks.traefik.autoscaling.enabled true
             pulumi config set --path unchained:common.eks.traefik.autoscaling.memoryThreshold 50
             pulumi config set --path unchained:common.eks.traefik.autoscaling.cpuThreshold 80


### PR DESCRIPTION
- scale down cluster size now that we are not running base
- prune more expensive instance types to save on cost

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure scaling settings: reduced desired/min/max capacity for a spot compute group from 5 to 4.
  * Streamlined the set of allowable compute instance options for that group to simplify resource selection.
  * Retained existing autoscaling thresholds and related settings.
  * No user-facing functionality changes; behavior and performance should remain consistent while background capacity management is adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->