### PR TITLE
chore: tighten retry config

### DIFF
--- a/node/coinstacks/common/api/src/utils.ts
+++ b/node/coinstacks/common/api/src/utils.ts
@@ -42,7 +42,7 @@ export const createAxiosRetry = (config: RetryConfig, axiosParams?: CreateAxiosD
 
   axiosRetry(axiosWithRetry, {
     shouldResetTimeout: true,
-    retries: config.retries ?? 5,
+    retries: config.retries ?? 3,
     retryDelay: (retryCount, err) => {
       // don't add delay on top of request timeout
       if (err.code === 'ECONNABORTED') return 0
@@ -51,7 +51,8 @@ export const createAxiosRetry = (config: RetryConfig, axiosParams?: CreateAxiosD
     },
     retryCondition: (err) =>
       isNetworkOrIdempotentRequestError(err) ||
-      (!!err.response && err.response.status >= 400 && err.response.status < 600),
+      (err.response && err.response.status > 404 && err.response.status < 600) ||
+      err.code === 'ECONNABORTED',
   })
 
   return axiosWithRetry

--- a/node/packages/blockbook/src/controller.ts
+++ b/node/packages/blockbook/src/controller.ts
@@ -18,7 +18,7 @@ export class Blockbook extends Controller {
   wsURL: string
   logger: Logger
 
-  constructor(args: BlockbookArgs = defaultArgs, timeout?: number, retries = 5) {
+  constructor(args: BlockbookArgs = defaultArgs, timeout?: number, retries = 3) {
     super()
     this.logger = args.logger.child({ namespace: ['blockbook'] })
     this.wsURL = args.apiKey ? `${args.wsURL}/${args.apiKey}` : args.wsURL
@@ -42,7 +42,7 @@ export class Blockbook extends Controller {
       },
       retryCondition: (err) =>
         isNetworkOrIdempotentRequestError(err) ||
-        (!!err.response && err.response.status >= 400 && err.response.status < 600) ||
+        (err.response && err.response.status > 404 && err.response.status < 600) ||
         err.code === 'ECONNABORTED',
     })
   }


### PR DESCRIPTION
- shorter default retry count to reduce response times
- don't retry non retryable error codes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Reduced default retry attempts from 5 to 3 for faster feedback and fewer redundant requests.
  - More precise retry behavior: client errors 400–404 no longer retried; retries continue for 405–599 and network/timeouts.
  - Enhanced resilience by retrying on aborted connection errors.
  - Blockbook connections now use the updated retry defaults for more responsive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->