### PR TITLE
chore: point bch to liquify (prod)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,11 +319,11 @@ aliases:
     assetName: bitcoincash
     pulumi-stack: public-us-east-2
     pulumi-dir: coinstacks/bitcoincash/pulumi
-    indexer-url: https://bchbook.nownodes.io
-    indexer-ws-url: wss://bchbook.nownodes.io/wss
-    indexer-api-key: $NOW_NODES_API_KEY
-    rpc-url: https://bch.nownodes.io
-    rpc-api-key: $NOW_NODES_API_KEY
+    indexer-url: https://gateway.liquify.com
+    indexer-ws-url: wss://gateway.liquify.com
+    indexer-api-key: $LIQUIFY_INDEXER_API_KEY_BCH
+    rpc-url: https://gateway.liquify.com
+    rpc-api-key: $LIQUIFY_RPC_API_KEY_BCH
     api-autoscaling: true
     api-replicas: 2
     api-max-replicas: 4
@@ -335,11 +335,6 @@ aliases:
     <<: *bitcoincash
     environment: dev
     pulumi-stack: public-dev-us-east-2
-    indexer-url: https://gateway.liquify.com
-    indexer-ws-url: wss://gateway.liquify.com
-    indexer-api-key: $LIQUIFY_INDEXER_API_KEY_BCH
-    rpc-url: https://gateway.liquify.com
-    rpc-api-key: $LIQUIFY_RPC_API_KEY_BCH
     api-replicas: 1
     api-max-replicas: 2
     api-cpu-limit: 250m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - None.

- Chores
  - Migrated the Bitcoin Cash network provider to Liquify for indexing and RPC, standardizing configuration across environments. Users may see improved reliability and performance for Bitcoin Cash operations. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->