### PR TITLE
feat: index affiliate revs by asset

### DIFF
--- a/go/coinstacks/thorchain/api/swagger.json
+++ b/go/coinstacks/thorchain/api/swagger.json
@@ -335,7 +335,8 @@
       "type": "object",
       "required": [
         "addresses",
-        "amount"
+        "amount",
+        "revenue"
       ],
       "properties": {
         "addresses": {
@@ -350,6 +351,14 @@
           "description": "Amount earned (RUNE)",
           "type": "string",
           "x-go-name": "Amount"
+        },
+        "revenue": {
+          "description": "Revenue earned by denom",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Revenue"
         }
       },
       "x-go-package": "github.com/shapeshift/unchained/coinstacks/thorchain/api"

--- a/go/pkg/thorchain/events.go
+++ b/go/pkg/thorchain/events.go
@@ -30,6 +30,15 @@ type EventOutbound struct {
 	Memo   string `json:"memo"`
 }
 
+type EventSwap struct {
+	Pool  string `json:"pool"`
+	Id    string `json:"id"`
+	Chain string `json:"chain"`
+	From  string `json:"from"`
+	To    string `json:"to"`
+	Memo  string `json:"memo"`
+}
+
 func ParseBlockEvents(blockEvents []cosmos.ABCIEvent) (cosmos.EventsByMsgIndex, []TypedEvent, error) {
 	typedEvents := make([]TypedEvent, len(blockEvents))
 	eventsByMsgIndex := cosmos.EventsByMsgIndex{}
@@ -41,6 +50,8 @@ func ParseBlockEvents(blockEvents []cosmos.ABCIEvent) (cosmos.EventsByMsgIndex, 
 			typedEvent = &EventFee{}
 		case "outbound":
 			typedEvent = &EventOutbound{}
+		case "swap":
+			typedEvent = &EventSwap{}
 		default:
 			continue
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Affiliate revenue endpoint now includes a per-asset breakdown via a new “revenue” field, alongside total amount and addresses.
  - Swap events are now captured to enable more accurate affiliate fee correlation.

- Bug Fixes
  - Improved accuracy of affiliate fee aggregation by correlating outbound and swap events to avoid double counting and exclude affiliate-owned swap outputs.

- Documentation
  - API specification updated to document the new “revenue” field and mark it as required in the AffiliateRevenue schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->