### PR TITLE
fix: downgrade prysm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ aliases:
     service-memory-limit-1: 32Gi
     service-storage-size-1: 1500Gi
     service-name-2: daemon-beacon
-    service-image-2: gcr.io/prysmaticlabs/prysm/beacon-chain:v6.1.2
+    service-image-2: gcr.io/prysmaticlabs/prysm/beacon-chain:v6.0.5
     service-cpu-limit-2: "2"
     service-memory-limit-2: 16Gi
     service-storage-size-2: 600Gi


### PR DESCRIPTION
The latest version of prysm which claimed to have improved peering, broke peering causing our etheereum nodes to fall out of sync. Downgrade to last working version: https://github.com/OffchainLabs/prysm/releases/tag/v6.0.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->