### PR TITLE
chore: right size cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -697,13 +697,13 @@ jobs:
             pulumi config set --path unchained:common.eks.cidrBlock 10.0.0.0/16
             pulumi config set --path unchained:common.eks.nodeGroups[0].name spot
             pulumi config set --path unchained:common.eks.nodeGroups[0].type SPOT
-            pulumi config set --path unchained:common.eks.nodeGroups[0].desired 4
-            pulumi config set --path unchained:common.eks.nodeGroups[0].minSize 4
-            pulumi config set --path unchained:common.eks.nodeGroups[0].maxSize 4
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[0] r7a.4xlarge
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[1] r6a.4xlarge
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[2] r6i.4xlarge
-            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[3] r6in.4xlarge
+            pulumi config set --path unchained:common.eks.nodeGroups[0].desired 6
+            pulumi config set --path unchained:common.eks.nodeGroups[0].minSize 6
+            pulumi config set --path unchained:common.eks.nodeGroups[0].maxSize 6
+            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[0] m8g.xlarge
+            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[1] m8i.xlarge
+            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[2] m7a.xlarge
+            pulumi config set --path unchained:common.eks.nodeGroups[0].instanceTypes[3] m6a.xlarge
             pulumi config set --path unchained:common.eks.traefik.autoscaling.enabled true
             pulumi config set --path unchained:common.eks.traefik.autoscaling.memoryThreshold 50
             pulumi config set --path unchained:common.eks.traefik.autoscaling.cpuThreshold 80


### PR DESCRIPTION
With us no longer needing to run our own nodes/indexers, we can scale down our cluster significantly to further reduce overall aws cost.

This update changes our existing 4 (4xlarge) instances to 6 (xlarge) instances providing a better spread across spot instances to reduce potential downtimes when we are occasionally evicted due to reduce availability.

We are also switching to general purpose instances from the previous memory optimized instances which should perform better for our api needs.

I prioritized performance along with stability over price. Here is a breakdown of the instance types:
|Instance Type|Cost Per Hour|Eviction Frequency|
|------|-------|----------------------------|
|m8g.xlarge|$0.0690|(5-10%)|
|m8i.xlarge|Not Listed|(5-10%)|
|m8a.xlarge|$0.0764|(15-20%)|
|m7g.xlarge|$0.0544|(15-20%)|
|m7i.xlarge|$0.0796|(15-20%)|
|m7a.xlarge|$0.0817|(5-10%)|
|m6g.xlarge|$0.0427|(>20%)|
|m6i.xlarge|$0.0713|(>20%)|
|m6a.xlarge|$0.0757|(10-15%)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Infrastructure and deployment configuration enhancements have been implemented to improve system performance, scalability, and operational efficiency.
* Resource allocation and scaling improvements enable better system capacity management and reliability.
* These updates support enhanced operational resilience and system stability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->