### PR TITLE
fix: inline StakingDuration schema in Arbitrum swagger.json

### DIFF
--- a/node/coinstacks/arbitrum/api/src/swagger.json
+++ b/node/coinstacks/arbitrum/api/src/swagger.json
@@ -549,7 +549,9 @@
 				"description": "Construct a type with a set of properties K of type T"
 			},
 			"StakingDuration": {
-				"$ref": "#/components/schemas/Record_string.number_"
+				"properties": {},
+				"type": "object",
+				"description": "Mapping of staking contract addresses to their duration values in seconds"
 			}
 		},
 		"securitySchemes": {}


### PR DESCRIPTION
## Problem

The Arbitrum swagger.json contains a `StakingDuration` schema that uses a pure `$ref` without any inline properties:

```json
"StakingDuration": {
  "$ref": "#/components/schemas/Record_string.number_"
}
```

This causes OpenAPI Generator 6.1.0 (used by downstream consumers like shapeshift/web) to fail with:

```
Exception in thread "main" java.lang.RuntimeException: Could not process model 'StakingDuration'
Caused by: java.lang.NullPointerException: Cannot invoke "io.swagger.v3.oas.models.media.Schema.getType()" because "schema" is null
```

## Solution

Replace the pure `$ref` alias with an inline schema definition:

```json
"StakingDuration": {
  "properties": {},
  "type": "object",
  "description": "Mapping of staking contract addresses to their duration values in seconds"
}
```

This inlines the schema definition from `Record_string.number_` directly into `StakingDuration`, which:
- Is valid OpenAPI 3.0.0 
- Generates correctly with OpenAPI Generator 6.1.0
- Maintains the same runtime behavior

## Background

According to the OpenAPI 3.0 spec, pure `$ref` aliases are technically valid, but some tools don't handle them well. OpenAPI 3.1 allows combining `$ref` with other properties (like `description`), but this swagger.json uses OpenAPI 3.0.0 where sibling properties alongside `$ref` are ignored.

The issue was introduced in commit 08ce999 when rFOX staking functionality was added to Arbitrum.

## Impact

This fixes build failures in shapeshift/web and any other downstream consumers that generate TypeScript clients from this swagger spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced API schema definitions for improved consistency in staking-related data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->