### PR TITLE
fix: timeout handling

### DIFF
--- a/node/coinstacks/common/api/src/evm/blockbookService.ts
+++ b/node/coinstacks/common/api/src/evm/blockbookService.ts
@@ -312,7 +312,7 @@ export class BlockbookService implements Omit<BaseAPI, 'getInfo'>, API {
       }
 
       const config = this.rpcApiKey ? { headers: { 'api-key': this.rpcApiKey } } : undefined
-      const { data } = await axiosNoRetry.post<RPCResponse>(this.rpcUrl, request, config)
+      const { data } = await axiosNoRetry.post<RPCResponse>(this.rpcUrl, request, { ...config, timeout: 0 })
 
       if (!data.result) throw new Error(JSON.stringify(data.error))
 

--- a/node/coinstacks/common/api/src/evm/moralisService.ts
+++ b/node/coinstacks/common/api/src/evm/moralisService.ts
@@ -399,7 +399,7 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
         params: [body.hex],
       }
 
-      const { data } = await axiosNoRetry.post<RPCResponse>(this.rpcUrl, request)
+      const { data } = await axiosNoRetry.post<RPCResponse>(this.rpcUrl, request, { timeout: 0 })
 
       if (!data.result) throw new Error(JSON.stringify(data.error))
 

--- a/node/coinstacks/common/api/src/utils.ts
+++ b/node/coinstacks/common/api/src/utils.ts
@@ -14,6 +14,10 @@ export const handleError = (err: unknown): ApiError => {
   if (err instanceof ApiError) return err
 
   if (isAxiosError(err)) {
+    if (err.code === 'ECONNABORTED' || err.code === 'ETIMEDOUT') {
+      return new ApiError('Gateway Timeout', 504, err.message || 'Request timeout')
+    }
+
     return new ApiError(
       err.response?.statusText || 'Internal Server Error',
       err.response?.status ?? 500,


### PR DESCRIPTION
- Remove axios timeout on `sendTx` endpoint to avoid false negatives on slow RPC responses
- Handle timeout errors and respond with a more appropriate 504 Gateway Timeout error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Modified blockchain transaction submission configuration to handle extended processing times and prevent timeout-related failures
* Enhanced error handling with improved messaging for connection timeout scenarios during transaction processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->