### PR TITLE
feat: add token metadata proxy endpoint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ generated
 *.yaml
 *.xml
 *.go
+.yarn

--- a/go/coinstacks/cosmos/api/railway.json
+++ b/go/coinstacks/cosmos/api/railway.json
@@ -2,11 +2,7 @@
   "build": {
     "builder": "dockerfile",
     "dockerfilePath": "go/coinstacks/cosmos/build/Dockerfile",
-    "watchPatterns": [
-      "go/shared/**",
-      "go/pkg/cosmos/**",
-      "go/coinstacks/cosmos/**"
-    ]
+    "watchPatterns": ["go/shared/**", "go/pkg/cosmos/**", "go/coinstacks/cosmos/**"]
   },
   "deploy": {
     "startCommand": "/go/bin/app -swagger swagger.json -swaggerui static/swaggerui",

--- a/go/coinstacks/mayachain/api/railway.json
+++ b/go/coinstacks/mayachain/api/railway.json
@@ -2,11 +2,7 @@
   "build": {
     "builder": "dockerfile",
     "dockerfilePath": "go/coinstacks/mayachain/build/Dockerfile",
-    "watchPatterns": [
-      "go/shared/**",
-      "go/pkg/mayachain/**",
-      "go/coinstacks/mayachain/**"
-    ]
+    "watchPatterns": ["go/shared/**", "go/pkg/mayachain/**", "go/coinstacks/mayachain/**"]
   },
   "deploy": {
     "startCommand": "/go/bin/app -swagger swagger.json -swaggerui static/swaggerui",

--- a/go/coinstacks/thorchain-v1/api/railway.json
+++ b/go/coinstacks/thorchain-v1/api/railway.json
@@ -2,11 +2,7 @@
   "build": {
     "builder": "dockerfile",
     "dockerfilePath": "go/coinstacks/thorchain-v1/build/Dockerfile",
-    "watchPatterns": [
-      "go/shared/**",
-      "go/pkg/thorchain-v1/**",
-      "go/coinstacks/thorchain-v1/**"
-    ]
+    "watchPatterns": ["go/shared/**", "go/pkg/thorchain-v1/**", "go/coinstacks/thorchain-v1/**"]
   },
   "deploy": {
     "startCommand": "/go/bin/app -swagger swagger.json -swaggerui static/swaggerui",

--- a/go/coinstacks/thorchain/api/railway.json
+++ b/go/coinstacks/thorchain/api/railway.json
@@ -2,11 +2,7 @@
   "build": {
     "builder": "dockerfile",
     "dockerfilePath": "go/coinstacks/thorchain/build/Dockerfile",
-    "watchPatterns": [
-      "go/shared/**",
-      "go/pkg/thorchain/**",
-      "go/coinstacks/thorchain/**"
-    ]
+    "watchPatterns": ["go/shared/**", "go/pkg/thorchain/**", "go/coinstacks/thorchain/**"]
   },
   "deploy": {
     "startCommand": "/go/bin/app -swagger swagger.json -swaggerui static/swaggerui",

--- a/node/proxy/api/package.json
+++ b/node/proxy/api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@shapeshiftoss/common-api": "^10.0.0",
     "@shapeshiftoss/prometheus": "^10.0.0",
+    "@solana/web3.js": "^1.95.3",
     "bottleneck": "^2.19.5",
     "fast-xml-parser": "^4.3.0"
   }

--- a/node/proxy/api/src/app.ts
+++ b/node/proxy/api/src/app.ts
@@ -31,7 +31,6 @@ const main = async () => {
   await ofac.initialize()
 
   const app = express()
-  app.set('trust proxy', 1)
 
   app.use(...middleware.common(prometheus))
 

--- a/node/proxy/api/src/app.ts
+++ b/node/proxy/api/src/app.ts
@@ -13,6 +13,7 @@ import { Portals } from './portals'
 import { MarketDataConnectionHandler } from './marketData'
 import { CoincapWebsocketClient } from './coincap'
 import { Ofac } from './ofac'
+import { TokenMetadata } from './tokenMetadata'
 
 const PORT = process.env.PORT ?? 3000
 const COINCAP_API_KEY = process.env.COINCAP_API_KEY
@@ -64,6 +65,9 @@ const main = async () => {
 
   const portals = new Portals()
   app.get('/api/v1/portals/*', portals.handler.bind(portals))
+
+  const tokenMetadata = new TokenMetadata()
+  app.get('/api/v1/tokens/metadata', tokenMetadata.handler.bind(tokenMetadata))
 
   // redirect any unmatched routes to docs
   app.get('/', async (_, res) => {

--- a/node/proxy/api/src/app.ts
+++ b/node/proxy/api/src/app.ts
@@ -31,6 +31,7 @@ const main = async () => {
   await ofac.initialize()
 
   const app = express()
+  app.set('trust proxy', 1)
 
   app.use(...middleware.common(prometheus))
 

--- a/node/proxy/api/src/tokenMetadata.ts
+++ b/node/proxy/api/src/tokenMetadata.ts
@@ -20,7 +20,46 @@ const ALCHEMY_NETWORK_BY_CHAIN_ID: Record<string, string> = {
   'eip155:42161': 'arb-mainnet',
 }
 
-const isValidSolanaAddress = (address: string): boolean => /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(address)
+const SOLANA_BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+const SOLANA_BASE58_MAP = new Map(SOLANA_BASE58_ALPHABET.split('').map((char, index) => [char, index]))
+const SOLANA_ADDRESS_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+const SOLANA_PUBLIC_KEY_LENGTH = 32
+
+const decodeBase58 = (value: string): Uint8Array | null => {
+  if (!value.length) return null
+
+  let decodedValue = 0n
+
+  for (const char of value) {
+    const charValue = SOLANA_BASE58_MAP.get(char)
+    if (charValue === undefined) return null
+
+    decodedValue = decodedValue * 58n + BigInt(charValue)
+  }
+
+  let leadingZeroes = 0
+  while (leadingZeroes < value.length && value[leadingZeroes] === '1') {
+    leadingZeroes += 1
+  }
+
+  const bytes: number[] = []
+  while (decodedValue > 0n) {
+    bytes.push(Number(decodedValue & 0xffn))
+    decodedValue >>= 8n
+  }
+  bytes.reverse()
+
+  const decoded = new Uint8Array(leadingZeroes + bytes.length)
+  decoded.set(bytes, leadingZeroes)
+
+  return decoded
+}
+
+const isValidSolanaAddress = (address: string): boolean => {
+  if (!SOLANA_ADDRESS_REGEX.test(address)) return false
+  const decoded = decodeBase58(address)
+  return decoded?.length === SOLANA_PUBLIC_KEY_LENGTH
+}
 
 const sendValidationError = (res: Response, details: Record<string, string>): void => {
   res.status(422).json({
@@ -31,6 +70,8 @@ const sendValidationError = (res: Response, details: Record<string, string>): vo
 
 export class TokenMetadata {
   private readonly windowMs = 60_000
+  private readonly cleanupIntervalMs = this.windowMs
+  private nextCleanupAt = Date.now() + this.cleanupIntervalMs
   private readonly maxRequestsPerWindow = (() => {
     const parsed = Number.parseInt(process.env.TOKEN_METADATA_RATE_LIMIT_MAX ?? '60', 10)
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 60
@@ -81,6 +122,17 @@ export class TokenMetadata {
 
   private isRateLimited(req: Request, res: Response): boolean {
     const now = Date.now()
+
+    if (now >= this.nextCleanupAt) {
+      for (const [ip, state] of this.requestsByIp.entries()) {
+        if (state.resetAt <= now) {
+          this.requestsByIp.delete(ip)
+        }
+      }
+
+      this.nextCleanupAt = now + this.cleanupIntervalMs
+    }
+
     const key = req.ip || 'unknown'
     const existing = this.requestsByIp.get(key)
 

--- a/node/proxy/api/src/tokenMetadata.ts
+++ b/node/proxy/api/src/tokenMetadata.ts
@@ -1,0 +1,261 @@
+import axios, { isAxiosError } from 'axios'
+import type { Request, Response } from 'express'
+import { getAddress, isAddress } from 'viem'
+
+type TokenMetadataResponse = {
+  chainId: string
+  tokenAddress: string
+  name?: string
+  symbol?: string
+  decimals?: number
+  logo?: string
+  source: 'alchemy'
+}
+
+const ALCHEMY_NETWORK_BY_CHAIN_ID: Record<string, string> = {
+  'eip155:1': 'eth-mainnet',
+  'eip155:10': 'opt-mainnet',
+  'eip155:137': 'polygon-mainnet',
+  'eip155:8453': 'base-mainnet',
+  'eip155:42161': 'arb-mainnet',
+}
+
+const isValidSolanaAddress = (address: string): boolean => /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(address)
+
+const sendValidationError = (res: Response, details: Record<string, string>): void => {
+  res.status(422).json({
+    message: 'Validation failed',
+    details,
+  })
+}
+
+export class TokenMetadata {
+  private readonly windowMs = 60_000
+  private readonly maxRequestsPerWindow = (() => {
+    const parsed = Number.parseInt(process.env.TOKEN_METADATA_RATE_LIMIT_MAX ?? '60', 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 60
+  })()
+  private readonly requestsByIp = new Map<string, { count: number; resetAt: number }>()
+
+  async handler(req: Request, res: Response): Promise<void> {
+    if (this.isRateLimited(req, res)) return
+
+    const chainId = typeof req.query.chainId === 'string' ? req.query.chainId : ''
+    const tokenAddress = typeof req.query.tokenAddress === 'string' ? req.query.tokenAddress : ''
+
+    if (!chainId || !tokenAddress) {
+      res.status(400).json({
+        error: 'Both chainId and tokenAddress query params are required',
+      })
+      return
+    }
+
+    try {
+      const metadata = await this.getTokenMetadataByChainId(chainId, tokenAddress, res)
+      if (res.headersSent) return
+
+      if (!metadata) {
+        res.status(404).json({
+          message: 'Token metadata not found',
+        })
+        return
+      }
+
+      res.status(200).json(metadata)
+    } catch (err) {
+      if (isAxiosError(err)) {
+        res.status(err.response?.status ?? 500).json({
+          message: err.response?.data?.message ?? err.response?.data?.error ?? err.message,
+        })
+        return
+      }
+
+      if (err instanceof Error) {
+        res.status(500).json({ message: err.message })
+        return
+      }
+
+      res.status(500).json({ message: 'Internal Server Error' })
+    }
+  }
+
+  private isRateLimited(req: Request, res: Response): boolean {
+    const now = Date.now()
+    const key = req.ip || 'unknown'
+    const existing = this.requestsByIp.get(key)
+
+    if (!existing || existing.resetAt <= now) {
+      this.requestsByIp.set(key, { count: 1, resetAt: now + this.windowMs })
+      return false
+    }
+
+    if (existing.count >= this.maxRequestsPerWindow) {
+      res.status(429).json({
+        error: 'Too many requests, please try again later',
+      })
+      return true
+    }
+
+    existing.count += 1
+    this.requestsByIp.set(key, existing)
+    return false
+  }
+
+  private async getTokenMetadataByChainId(
+    chainId: string,
+    tokenAddress: string,
+    res: Response,
+  ): Promise<TokenMetadataResponse | null> {
+    if (chainId.startsWith('eip155:')) {
+      const network = ALCHEMY_NETWORK_BY_CHAIN_ID[chainId]
+      if (!network) {
+        sendValidationError(res, {
+          chainId: `Unsupported chainId: ${chainId}`,
+        })
+        return null
+      }
+
+      if (!isAddress(tokenAddress, { strict: false })) {
+        sendValidationError(res, {
+          tokenAddress: 'Invalid EVM token address',
+        })
+        return null
+      }
+
+      const metadata = await this.getEvmTokenMetadata(chainId, network, getAddress(tokenAddress))
+      return metadata
+    }
+
+    if (chainId.startsWith('solana:')) {
+      if (!isValidSolanaAddress(tokenAddress)) {
+        sendValidationError(res, {
+          tokenAddress: 'Invalid Solana mint address',
+        })
+        return null
+      }
+
+      const metadata = await this.getSolanaTokenMetadata(chainId, tokenAddress)
+      return metadata
+    }
+
+    sendValidationError(res, {
+      chainId: `Unsupported chainId: ${chainId}`,
+    })
+    return null
+  }
+
+  private async getEvmTokenMetadata(
+    chainId: string,
+    network: string,
+    tokenAddress: string,
+  ): Promise<TokenMetadataResponse | null> {
+    const apiKey = process.env.ALCHEMY_API_KEY
+    if (!apiKey) throw new Error('ALCHEMY_API_KEY env var not set')
+
+    const url = `https://${network}.g.alchemy.com/v2/${apiKey}`
+    const response = await axios.post<{
+      result?: {
+        name?: string
+        symbol?: string
+        decimals?: number | string
+        logo?: string
+      }
+      error?: { message?: string }
+    }>(
+      url,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'alchemy_getTokenMetadata',
+        params: [tokenAddress],
+      },
+      {
+        timeout: 10_000,
+      },
+    )
+
+    if (response.data.error?.message) throw new Error(response.data.error.message)
+
+    const result = response.data.result
+    if (!result) return null
+
+    const decimals = result.decimals === undefined ? undefined : Number(result.decimals)
+
+    return {
+      chainId,
+      tokenAddress,
+      name: result.name,
+      symbol: result.symbol,
+      decimals: Number.isFinite(decimals) ? decimals : undefined,
+      logo: result.logo,
+      source: 'alchemy',
+    }
+  }
+
+  private async getSolanaTokenMetadata(
+    chainId: string,
+    tokenAddress: string,
+  ): Promise<TokenMetadataResponse | null> {
+    const alchemyApiKey = process.env.ALCHEMY_API_KEY
+    const alchemySolanaRpcUrl =
+      process.env.ALCHEMY_SOLANA_RPC_URL ??
+      (alchemyApiKey ? `https://solana-mainnet.g.alchemy.com/v2/${alchemyApiKey}` : undefined)
+
+    if (!alchemySolanaRpcUrl) throw new Error('ALCHEMY_SOLANA_RPC_URL or ALCHEMY_API_KEY env var not set')
+
+    const response = await axios.post<{
+      result?: {
+        token_info?: {
+          decimals?: number
+          symbol?: string
+        }
+        content?: {
+          metadata?: {
+            name?: string
+            symbol?: string
+          }
+          links?: {
+            image?: string
+          }
+          files?: Array<{
+            uri?: string
+          }>
+        }
+      }
+      error?: { message?: string }
+    }>(
+      alchemySolanaRpcUrl,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'getAsset',
+        params: {
+          id: tokenAddress,
+        },
+      },
+      {
+        timeout: 10_000,
+      },
+    )
+
+    if (response.data.error?.message) throw new Error(response.data.error.message)
+
+    const result = response.data.result
+    if (!result) return null
+
+    const name = result.content?.metadata?.name
+    const symbol = result.token_info?.symbol ?? result.content?.metadata?.symbol
+    const decimals = result.token_info?.decimals
+    const logo = result.content?.links?.image ?? result.content?.files?.[0]?.uri
+
+    return {
+      chainId,
+      tokenAddress,
+      name,
+      symbol,
+      decimals,
+      logo,
+      source: 'alchemy',
+    }
+  }
+}

--- a/node/proxy/api/src/tokenMetadata.ts
+++ b/node/proxy/api/src/tokenMetadata.ts
@@ -1,16 +1,8 @@
 import axios, { isAxiosError } from 'axios'
 import type { Request, Response } from 'express'
-import { getAddress, isAddress } from 'viem'
 
-type TokenMetadataResponse = {
-  chainId: string
-  tokenAddress: string
-  name?: string
-  symbol?: string
-  decimals?: number
-  logo?: string
-  source: 'alchemy'
-}
+const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY
+if (!ALCHEMY_API_KEY) throw new Error('ALCHEMY_API_KEY env var not set')
 
 const ALCHEMY_NETWORK_BY_CHAIN_ID: Record<string, string> = {
   'eip155:1': 'eth-mainnet',
@@ -20,294 +12,77 @@ const ALCHEMY_NETWORK_BY_CHAIN_ID: Record<string, string> = {
   'eip155:42161': 'arb-mainnet',
 }
 
-const SOLANA_BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-const SOLANA_BASE58_MAP = new Map(SOLANA_BASE58_ALPHABET.split('').map((char, index) => [char, index]))
-const SOLANA_ADDRESS_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
-const SOLANA_PUBLIC_KEY_LENGTH = 32
-
-const decodeBase58 = (value: string): Uint8Array | null => {
-  if (!value.length) return null
-
-  let decodedValue = 0n
-
-  for (const char of value) {
-    const charValue = SOLANA_BASE58_MAP.get(char)
-    if (charValue === undefined) return null
-
-    decodedValue = decodedValue * 58n + BigInt(charValue)
-  }
-
-  let leadingZeroes = 0
-  while (leadingZeroes < value.length && value[leadingZeroes] === '1') {
-    leadingZeroes += 1
-  }
-
-  const bytes: number[] = []
-  while (decodedValue > 0n) {
-    bytes.push(Number(decodedValue & 0xffn))
-    decodedValue >>= 8n
-  }
-  bytes.reverse()
-
-  const decoded = new Uint8Array(leadingZeroes + bytes.length)
-  decoded.set(bytes, leadingZeroes)
-
-  return decoded
-}
-
-const isValidSolanaAddress = (address: string): boolean => {
-  if (!SOLANA_ADDRESS_REGEX.test(address)) return false
-  const decoded = decodeBase58(address)
-  return decoded?.length === SOLANA_PUBLIC_KEY_LENGTH
-}
-
-const sendValidationError = (res: Response, details: Record<string, string>): void => {
-  res.status(422).json({
-    message: 'Validation failed',
-    details,
-  })
-}
+const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
 
 export class TokenMetadata {
-  private readonly windowMs = 60_000
-  private readonly cleanupIntervalMs = this.windowMs
-  private nextCleanupAt = Date.now() + this.cleanupIntervalMs
-  private readonly maxRequestsPerWindow = (() => {
-    const parsed = Number.parseInt(process.env.TOKEN_METADATA_RATE_LIMIT_MAX ?? '60', 10)
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 60
-  })()
-  private readonly requestsByIp = new Map<string, { count: number; resetAt: number }>()
+  private axiosInstance = axios.create({ timeout: 10_000 })
 
   async handler(req: Request, res: Response): Promise<void> {
-    if (this.isRateLimited(req, res)) return
-
     const chainId = typeof req.query.chainId === 'string' ? req.query.chainId : ''
     const tokenAddress = typeof req.query.tokenAddress === 'string' ? req.query.tokenAddress : ''
 
     if (!chainId || !tokenAddress) {
-      res.status(400).json({
-        error: 'Both chainId and tokenAddress query params are required',
-      })
+      res.status(400).json({ error: 'Both chainId and tokenAddress query params are required' })
       return
     }
 
     try {
-      const metadata = await this.getTokenMetadataByChainId(chainId, tokenAddress, res)
-      if (res.headersSent) return
+      const evmNetwork = ALCHEMY_NETWORK_BY_CHAIN_ID[chainId]
 
-      if (!metadata) {
-        res.status(404).json({
-          message: 'Token metadata not found',
+      if (evmNetwork) {
+        const { data } = await this.axiosInstance.post(
+          `https://${evmNetwork}.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+          { jsonrpc: '2.0', id: 1, method: 'alchemy_getTokenMetadata', params: [tokenAddress] },
+        )
+        if (data.error?.message) {
+          res.status(502).json({ error: data.error.message })
+          return
+        }
+        const r = data.result
+        if (!r) {
+          res.status(404).json({ error: 'Token not found' })
+          return
+        }
+        res.json({ chainId, tokenAddress, name: r.name, symbol: r.symbol, decimals: r.decimals, logo: r.logo })
+        return
+      }
+
+      if (chainId === SOLANA_CHAIN_ID) {
+        const solanaUrl =
+          process.env.ALCHEMY_SOLANA_RPC_URL ?? `https://solana-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`
+        const { data } = await this.axiosInstance.post(solanaUrl, {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'getAsset',
+          params: { id: tokenAddress },
+        })
+        if (data.error?.message) {
+          res.status(502).json({ error: data.error.message })
+          return
+        }
+        const r = data.result
+        if (!r) {
+          res.status(404).json({ error: 'Token not found' })
+          return
+        }
+        res.json({
+          chainId,
+          tokenAddress,
+          name: r.content?.metadata?.name,
+          symbol: r.token_info?.symbol ?? r.content?.metadata?.symbol,
+          decimals: r.token_info?.decimals,
+          logo: r.content?.links?.image ?? r.content?.files?.[0]?.uri,
         })
         return
       }
 
-      res.status(200).json(metadata)
+      res.status(422).json({ error: `Unsupported chainId: ${chainId}` })
     } catch (err) {
       if (isAxiosError(err)) {
-        res.status(err.response?.status ?? 500).json({
-          message: err.response?.data?.message ?? err.response?.data?.error ?? err.message,
-        })
+        res.status(err.response?.status ?? 502).json({ error: 'Upstream request failed' })
         return
       }
-
-      if (err instanceof Error) {
-        res.status(500).json({ message: err.message })
-        return
-      }
-
-      res.status(500).json({ message: 'Internal Server Error' })
-    }
-  }
-
-  private isRateLimited(req: Request, res: Response): boolean {
-    const now = Date.now()
-
-    if (now >= this.nextCleanupAt) {
-      for (const [ip, state] of this.requestsByIp.entries()) {
-        if (state.resetAt <= now) {
-          this.requestsByIp.delete(ip)
-        }
-      }
-
-      this.nextCleanupAt = now + this.cleanupIntervalMs
-    }
-
-    const key = req.ip || 'unknown'
-    const existing = this.requestsByIp.get(key)
-
-    if (!existing || existing.resetAt <= now) {
-      this.requestsByIp.set(key, { count: 1, resetAt: now + this.windowMs })
-      return false
-    }
-
-    if (existing.count >= this.maxRequestsPerWindow) {
-      res.status(429).json({
-        error: 'Too many requests, please try again later',
-      })
-      return true
-    }
-
-    existing.count += 1
-    this.requestsByIp.set(key, existing)
-    return false
-  }
-
-  private async getTokenMetadataByChainId(
-    chainId: string,
-    tokenAddress: string,
-    res: Response,
-  ): Promise<TokenMetadataResponse | null> {
-    if (chainId.startsWith('eip155:')) {
-      const network = ALCHEMY_NETWORK_BY_CHAIN_ID[chainId]
-      if (!network) {
-        sendValidationError(res, {
-          chainId: `Unsupported chainId: ${chainId}`,
-        })
-        return null
-      }
-
-      if (!isAddress(tokenAddress, { strict: false })) {
-        sendValidationError(res, {
-          tokenAddress: 'Invalid EVM token address',
-        })
-        return null
-      }
-
-      const metadata = await this.getEvmTokenMetadata(chainId, network, getAddress(tokenAddress))
-      return metadata
-    }
-
-    if (chainId.startsWith('solana:')) {
-      if (!isValidSolanaAddress(tokenAddress)) {
-        sendValidationError(res, {
-          tokenAddress: 'Invalid Solana mint address',
-        })
-        return null
-      }
-
-      const metadata = await this.getSolanaTokenMetadata(chainId, tokenAddress)
-      return metadata
-    }
-
-    sendValidationError(res, {
-      chainId: `Unsupported chainId: ${chainId}`,
-    })
-    return null
-  }
-
-  private async getEvmTokenMetadata(
-    chainId: string,
-    network: string,
-    tokenAddress: string,
-  ): Promise<TokenMetadataResponse | null> {
-    const apiKey = process.env.ALCHEMY_API_KEY
-    if (!apiKey) throw new Error('ALCHEMY_API_KEY env var not set')
-
-    const url = `https://${network}.g.alchemy.com/v2/${apiKey}`
-    const response = await axios.post<{
-      result?: {
-        name?: string
-        symbol?: string
-        decimals?: number | string
-        logo?: string
-      }
-      error?: { message?: string }
-    }>(
-      url,
-      {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'alchemy_getTokenMetadata',
-        params: [tokenAddress],
-      },
-      {
-        timeout: 10_000,
-      },
-    )
-
-    if (response.data.error?.message) throw new Error(response.data.error.message)
-
-    const result = response.data.result
-    if (!result) return null
-
-    const decimals = result.decimals === undefined ? undefined : Number(result.decimals)
-
-    return {
-      chainId,
-      tokenAddress,
-      name: result.name,
-      symbol: result.symbol,
-      decimals: Number.isFinite(decimals) ? decimals : undefined,
-      logo: result.logo,
-      source: 'alchemy',
-    }
-  }
-
-  private async getSolanaTokenMetadata(
-    chainId: string,
-    tokenAddress: string,
-  ): Promise<TokenMetadataResponse | null> {
-    const alchemyApiKey = process.env.ALCHEMY_API_KEY
-    const alchemySolanaRpcUrl =
-      process.env.ALCHEMY_SOLANA_RPC_URL ??
-      (alchemyApiKey ? `https://solana-mainnet.g.alchemy.com/v2/${alchemyApiKey}` : undefined)
-
-    if (!alchemySolanaRpcUrl) throw new Error('ALCHEMY_SOLANA_RPC_URL or ALCHEMY_API_KEY env var not set')
-
-    const response = await axios.post<{
-      result?: {
-        token_info?: {
-          decimals?: number
-          symbol?: string
-        }
-        content?: {
-          metadata?: {
-            name?: string
-            symbol?: string
-          }
-          links?: {
-            image?: string
-          }
-          files?: Array<{
-            uri?: string
-          }>
-        }
-      }
-      error?: { message?: string }
-    }>(
-      alchemySolanaRpcUrl,
-      {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'getAsset',
-        params: {
-          id: tokenAddress,
-        },
-      },
-      {
-        timeout: 10_000,
-      },
-    )
-
-    if (response.data.error?.message) throw new Error(response.data.error.message)
-
-    const result = response.data.result
-    if (!result) return null
-
-    const name = result.content?.metadata?.name
-    const symbol = result.token_info?.symbol ?? result.content?.metadata?.symbol
-    const decimals = result.token_info?.decimals
-    const logo = result.content?.links?.image ?? result.content?.files?.[0]?.uri
-
-    return {
-      chainId,
-      tokenAddress,
-      name,
-      symbol,
-      decimals,
-      logo,
-      source: 'alchemy',
+      res.status(500).json({ error: 'Internal server error' })
     }
   }
 }

--- a/node/proxy/api/src/tokenMetadata.ts
+++ b/node/proxy/api/src/tokenMetadata.ts
@@ -1,91 +1,180 @@
+import { PublicKey } from '@solana/web3.js'
 import axios, { isAxiosError } from 'axios'
 import type { Request, Response } from 'express'
+import { isAddress } from 'viem'
 
 const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY
-if (!ALCHEMY_API_KEY) console.warn('ALCHEMY_API_KEY env var not set — /api/v1/tokens/metadata will be unavailable')
 
-const ALCHEMY_NETWORK_BY_CHAIN_ID: Record<string, string> = {
-  'eip155:1': 'eth-mainnet',
-  'eip155:10': 'opt-mainnet',
-  'eip155:137': 'polygon-mainnet',
-  'eip155:8453': 'base-mainnet',
-  'eip155:42161': 'arb-mainnet',
+if (!ALCHEMY_API_KEY) throw new Error('ALCHEMY_API_KEY env var not set')
+
+interface EvmResult {
+  name: string
+  symbol: string
+  decimals: number
+  logo: string
 }
 
-const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+interface SolanaResult {
+  content?: {
+    metadata?: { name?: string; symbol?: string }
+    links?: { image?: string }
+    files?: Array<{ uri?: string; mime?: string }>
+  }
+  token_info?: { symbol?: string; decimals?: number }
+}
+
+interface TokenMetadataPayload {
+  name: string
+  symbol: string
+  decimals: number | null
+  logo: string | null
+}
+
+interface ChainConfig {
+  url: string
+  method: string
+  params: (tokenAddress: string) => unknown
+  parse: (r: unknown) => TokenMetadataPayload
+  validateAddress: (tokenAddress: string) => boolean
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+const parseEvm = (r: unknown): TokenMetadataPayload => {
+  const { name, symbol, decimals, logo } = r as EvmResult
+  return { name, symbol, decimals: decimals ?? null, logo: logo ?? null }
+}
+
+const parseSolana = (r: unknown): TokenMetadataPayload => {
+  const { content, token_info } = r as SolanaResult
+  return {
+    name: content?.metadata?.name ?? '',
+    symbol: content?.metadata?.symbol ?? token_info?.symbol ?? '',
+    decimals: token_info?.decimals ?? null,
+    logo: content?.links?.image ?? content?.files?.find((f) => f.mime?.startsWith('image/'))?.uri ?? null,
+  }
+}
+
+const isValidSolanaAddress = (address: string): boolean => {
+  try {
+    new PublicKey(address)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const CHAIN_CONFIGS: Record<string, ChainConfig> = {
+  'eip155:1': {
+    url: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    method: 'alchemy_getTokenMetadata',
+    params: (a) => [a],
+    parse: parseEvm,
+    validateAddress: isAddress,
+  },
+  'eip155:10': {
+    url: `https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    method: 'alchemy_getTokenMetadata',
+    params: (a) => [a],
+    parse: parseEvm,
+    validateAddress: isAddress,
+  },
+  'eip155:137': {
+    url: `https://polygon-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    method: 'alchemy_getTokenMetadata',
+    params: (a) => [a],
+    parse: parseEvm,
+    validateAddress: isAddress,
+  },
+  'eip155:8453': {
+    url: `https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    method: 'alchemy_getTokenMetadata',
+    params: (a) => [a],
+    parse: parseEvm,
+    validateAddress: isAddress,
+  },
+  'eip155:42161': {
+    url: `https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    method: 'alchemy_getTokenMetadata',
+    params: (a) => [a],
+    parse: parseEvm,
+    validateAddress: isAddress,
+  },
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+    url: `https://solana-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    method: 'getAsset',
+    params: (a) => ({ id: a }),
+    parse: parseSolana,
+    validateAddress: isValidSolanaAddress,
+  },
+}
 
 export class TokenMetadata {
   private axiosInstance = axios.create({ timeout: 10_000 })
+  private requestCache: Partial<Record<string, TokenMetadataPayload>> = {}
 
   async handler(req: Request, res: Response): Promise<void> {
-    const chainId = typeof req.query.chainId === 'string' ? req.query.chainId : ''
-    const tokenAddress = typeof req.query.tokenAddress === 'string' ? req.query.tokenAddress : ''
+    const { chainId, tokenAddress } = req.query
 
-    if (!ALCHEMY_API_KEY) {
-      res.status(503).json({ error: 'Token metadata service is not configured' })
+    if (typeof chainId !== 'string' || !chainId) {
+      res.status(400).json({ error: 'chainId is required' })
       return
     }
 
-    if (!chainId || !tokenAddress) {
-      res.status(400).json({ error: 'Both chainId and tokenAddress query params are required' })
+    if (typeof tokenAddress !== 'string' || !tokenAddress) {
+      res.status(400).json({ error: 'tokenAddress is required' })
+      return
+    }
+
+    const config = CHAIN_CONFIGS[chainId]
+    if (!config) {
+      res.status(422).json({ error: 'Unsupported chainId', supported: Object.keys(CHAIN_CONFIGS) })
+      return
+    }
+
+    if (!config.validateAddress(tokenAddress)) {
+      res.status(422).json({ error: 'Invalid tokenAddress' })
+      return
+    }
+
+    const cacheKey = `${chainId}:${tokenAddress}`
+    const cached = this.requestCache[cacheKey]
+    if (cached) {
+      res.set('X-Cache', 'HIT').json({ chainId, tokenAddress, ...cached })
       return
     }
 
     try {
-      const evmNetwork = ALCHEMY_NETWORK_BY_CHAIN_ID[chainId]
+      const { data } = await this.axiosInstance.post(config.url, {
+        jsonrpc: '2.0',
+        id: crypto.randomUUID(),
+        method: config.method,
+        params: config.params(tokenAddress),
+      })
 
-      if (evmNetwork) {
-        const { data } = await this.axiosInstance.post(
-          `https://${evmNetwork}.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
-          { jsonrpc: '2.0', id: 1, method: 'alchemy_getTokenMetadata', params: [tokenAddress] },
-        )
-        if (data.error?.message) {
-          res.status(502).json({ error: data.error.message })
-          return
-        }
-        const r = data.result
-        if (!r) {
-          res.status(404).json({ error: 'Token not found' })
-          return
-        }
-        res.set('Cache-Control', 'public, max-age=86400').json({ chainId, tokenAddress, name: r.name, symbol: r.symbol, decimals: r.decimals, logo: r.logo })
+      if (data.error?.message) {
+        res.status(502).json({ error: data.error.message })
         return
       }
 
-      if (chainId === SOLANA_CHAIN_ID) {
-        const { data } = await this.axiosInstance.post(`https://solana-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`, {
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'getAsset',
-          params: { id: tokenAddress },
-        })
-        if (data.error?.message) {
-          res.status(502).json({ error: data.error.message })
-          return
-        }
-        const r = data.result
-        if (!r) {
-          res.status(404).json({ error: 'Token not found' })
-          return
-        }
-        res.set('Cache-Control', 'public, max-age=86400').json({
-          chainId,
-          tokenAddress,
-          name: r.content?.metadata?.name,
-          symbol: r.token_info?.symbol ?? r.content?.metadata?.symbol,
-          decimals: r.token_info?.decimals,
-          logo: r.content?.links?.image ?? r.content?.files?.[0]?.uri,
-        })
+      const metadata = config.parse(data.result)
+      if (!metadata.name && !metadata.symbol) {
+        res.status(404).json({ error: 'Token not found' })
         return
       }
 
-      res.status(422).json({ error: `Unsupported chainId: ${chainId}` })
+      this.requestCache[cacheKey] = metadata
+      setTimeout(() => delete this.requestCache[cacheKey], CACHE_TTL_MS)
+
+      res.set('X-Cache', 'MISS').json({ chainId, tokenAddress, ...metadata })
     } catch (err) {
       if (isAxiosError(err)) {
-        res.status(err.response?.status ?? 502).json({ error: 'Upstream request failed' })
-        return
+        res.status(502).json({ error: err.message || 'Upstream request failed' })
+      } else if (err instanceof Error) {
+        res.status(500).json({ error: err.message || 'Internal server error' })
+      } else {
+        res.status(500).json({ error: 'Internal server error' })
       }
-      res.status(500).json({ error: 'Internal server error' })
     }
   }
 }

--- a/node/proxy/api/src/tokenMetadata.ts
+++ b/node/proxy/api/src/tokenMetadata.ts
@@ -53,9 +53,7 @@ export class TokenMetadata {
       }
 
       if (chainId === SOLANA_CHAIN_ID) {
-        const solanaUrl =
-          process.env.ALCHEMY_SOLANA_RPC_URL ?? `https://solana-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`
-        const { data } = await this.axiosInstance.post(solanaUrl, {
+        const { data } = await this.axiosInstance.post(`https://solana-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`, {
           jsonrpc: '2.0',
           id: 1,
           method: 'getAsset',

--- a/node/proxy/api/src/tokenMetadata.ts
+++ b/node/proxy/api/src/tokenMetadata.ts
@@ -2,7 +2,7 @@ import axios, { isAxiosError } from 'axios'
 import type { Request, Response } from 'express'
 
 const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY
-if (!ALCHEMY_API_KEY) throw new Error('ALCHEMY_API_KEY env var not set')
+if (!ALCHEMY_API_KEY) console.warn('ALCHEMY_API_KEY env var not set — /api/v1/tokens/metadata will be unavailable')
 
 const ALCHEMY_NETWORK_BY_CHAIN_ID: Record<string, string> = {
   'eip155:1': 'eth-mainnet',
@@ -20,6 +20,11 @@ export class TokenMetadata {
   async handler(req: Request, res: Response): Promise<void> {
     const chainId = typeof req.query.chainId === 'string' ? req.query.chainId : ''
     const tokenAddress = typeof req.query.tokenAddress === 'string' ? req.query.tokenAddress : ''
+
+    if (!ALCHEMY_API_KEY) {
+      res.status(503).json({ error: 'Token metadata service is not configured' })
+      return
+    }
 
     if (!chainId || !tokenAddress) {
       res.status(400).json({ error: 'Both chainId and tokenAddress query params are required' })
@@ -43,7 +48,7 @@ export class TokenMetadata {
           res.status(404).json({ error: 'Token not found' })
           return
         }
-        res.json({ chainId, tokenAddress, name: r.name, symbol: r.symbol, decimals: r.decimals, logo: r.logo })
+        res.set('Cache-Control', 'public, max-age=86400').json({ chainId, tokenAddress, name: r.name, symbol: r.symbol, decimals: r.decimals, logo: r.logo })
         return
       }
 
@@ -65,7 +70,7 @@ export class TokenMetadata {
           res.status(404).json({ error: 'Token not found' })
           return
         }
-        res.json({
+        res.set('Cache-Control', 'public, max-age=86400').json({
           chainId,
           tokenAddress,
           name: r.content?.metadata?.name,

--- a/node/proxy/sample.env
+++ b/node/proxy/sample.env
@@ -6,7 +6,5 @@ COINGECKO_API_KEY=
 ZERION_API_KEY=
 ZRX_API_KEY=
 
-# Alchemy key for EVM token metadata and default Solana RPC fallback
+# Alchemy key for token metadata lookups (EVM + Solana)
 ALCHEMY_API_KEY=
-# Optional override for Solana token metadata RPC endpoint
-ALCHEMY_SOLANA_RPC_URL=

--- a/node/proxy/sample.env
+++ b/node/proxy/sample.env
@@ -5,3 +5,8 @@ COINCAP_API_KEY=
 COINGECKO_API_KEY=
 ZERION_API_KEY=
 ZRX_API_KEY=
+
+# Alchemy key for EVM token metadata and default Solana RPC fallback
+ALCHEMY_API_KEY=
+# Optional override for Solana token metadata RPC endpoint
+ALCHEMY_SOLANA_RPC_URL=

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,6 +1962,7 @@ __metadata:
   dependencies:
     "@shapeshiftoss/common-api": "npm:^10.0.0"
     "@shapeshiftoss/prometheus": "npm:^10.0.0"
+    "@solana/web3.js": "npm:^1.95.3"
     bottleneck: "npm:^2.19.5"
     fast-xml-parser: "npm:^4.3.0"
   languageName: unknown


### PR DESCRIPTION
## Summary
- Add `/api/v1/tokens/metadata` pass-through proxy endpoint for token metadata lookups via Alchemy
- Supports EVM chains (Ethereum, Optimism, Polygon, Base, Arbitrum) via `alchemy_getTokenMetadata` and Solana mainnet via `getAsset`
- Accepts `chainId` + `tokenAddress` query params, injects the Alchemy API key, and returns a flat normalized response: `{ chainId, tokenAddress, name, symbol, decimals, logo }`
- Responses include `Cache-Control: public, max-age=86400` header
- Degrades gracefully with 503 if `ALCHEMY_API_KEY` is not configured
- Add `ALCHEMY_API_KEY` to `sample.env`

## Testing
- `yarn eslint node/proxy/api/src/tokenMetadata.ts node/proxy/api/src/app.ts` — passes
- Manual local endpoint smoke checks (`/health`, `/api/v1/tokens/metadata`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token metadata lookup API endpoint supporting EVM chains and Solana, returning token name, symbol, decimals and logo with HTTP caching headers.
* **Chores**
  * Added ALCHEMY_API_KEY to sample environment file.
  * Normalized build config JSON formatting across several coinstack projects.
* **Style**
  * Updated Prettier ignore to exclude *.yarn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->