### PR TITLE
feat: nownodes utxo migration

### DIFF
--- a/node/coinstacks/bitcoin/api/src/app.ts
+++ b/node/coinstacks/bitcoin/api/src/app.ts
@@ -15,9 +15,7 @@ const INDEXER_WS_URL = process.env.INDEXER_WS_URL
 const INDEXER_API_KEY = process.env.INDEXER_API_KEY
 
 if (!INDEXER_WS_URL) throw new Error('INDEXER_WS_URL env var not set')
-
-const IS_LIQUIFY = INDEXER_WS_URL.toLowerCase().includes('liquify')
-const IS_NOWNODES = INDEXER_WS_URL.toLowerCase().includes('nownodes')
+if (!INDEXER_API_KEY) throw new Error('INDEXER_API_KEY env var not set')
 
 const logger = new Logger({
   namespace: ['unchained', 'coinstacks', 'bitcoin', 'api'],
@@ -70,15 +68,12 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
-const wsUrl = INDEXER_API_KEY && IS_LIQUIFY ? `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}` : INDEXER_WS_URL
-const apiKey = INDEXER_API_KEY && IS_NOWNODES ? INDEXER_API_KEY : undefined
-
 const blockbook = new WebsocketClient(
-  wsUrl,
+  INDEXER_WS_URL,
   {
     blockHandler: registry.onBlock.bind(registry),
     transactionHandler: registry.onTransaction.bind(registry),
-    apiKey,
+    apiKey: INDEXER_API_KEY,
   },
   { resetInterval: 15 * 60 * 1000 } // 15 minutes
 )

--- a/node/coinstacks/bitcoin/api/src/app.ts
+++ b/node/coinstacks/bitcoin/api/src/app.ts
@@ -71,9 +71,9 @@ const registry = new Registry({ addressFormatter: formatAddress, blockHandler, t
 const blockbook = new WebsocketClient(
   INDEXER_WS_URL,
   {
+    apiKey: INDEXER_API_KEY,
     blockHandler: registry.onBlock.bind(registry),
     transactionHandler: registry.onTransaction.bind(registry),
-    apiKey: INDEXER_API_KEY,
   },
   { resetInterval: 15 * 60 * 1000 } // 15 minutes
 )

--- a/node/coinstacks/bitcoin/api/src/controller.ts
+++ b/node/coinstacks/bitcoin/api/src/controller.ts
@@ -23,11 +23,7 @@ export const logger = new Logger({
   level: process.env.LOG_LEVEL,
 })
 
-const httpURL = `${INDEXER_URL}/api=${INDEXER_API_KEY}`
-const wsURL = `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}`
-const rpcUrl = `${RPC_URL}/api=${RPC_API_KEY}`
-
-const blockbook = new Blockbook({ httpURL, wsURL, logger })
+const blockbook = new Blockbook({ httpURL: INDEXER_URL, wsURL: INDEXER_WS_URL, apiKey: INDEXER_API_KEY, logger })
 
 const isXpub = (pubkey: string): boolean => {
   return pubkey.startsWith('xpub') || pubkey.startsWith('ypub') || pubkey.startsWith('zpub')
@@ -41,7 +37,8 @@ export const formatAddress = (address: string): string => {
 
 export const service = new Service({
   blockbook,
-  rpcUrl,
+  rpcUrl: RPC_URL,
+  rpcApiKey: RPC_API_KEY,
   isXpub,
   addressFormatter: formatAddress,
 })

--- a/node/coinstacks/bitcoin/sample.env
+++ b/node/coinstacks/bitcoin/sample.env
@@ -3,8 +3,8 @@ INDEXER_API_KEY=
 RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
-INDEXER_URL=https://gateway.liquify.com
-INDEXER_WS_URL=wss://gateway.liquify.com
+INDEXER_URL=https://btcbook.nownodes.io
+INDEXER_WS_URL=wss://btcbook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
-RPC_URL=https://gateway.liquify.com
+RPC_URL=https://btc.nownodes.io

--- a/node/coinstacks/bitcoincash/api/src/app.ts
+++ b/node/coinstacks/bitcoincash/api/src/app.ts
@@ -15,9 +15,7 @@ const INDEXER_WS_URL = process.env.INDEXER_WS_URL
 const INDEXER_API_KEY = process.env.INDEXER_API_KEY
 
 if (!INDEXER_WS_URL) throw new Error('INDEXER_WS_URL env var not set')
-
-const IS_LIQUIFY = INDEXER_WS_URL.toLowerCase().includes('liquify')
-const IS_NOWNODES = INDEXER_WS_URL.toLowerCase().includes('nownodes')
+if (!INDEXER_API_KEY) throw new Error('INDEXER_API_KEY env var not set')
 
 const logger = new Logger({
   namespace: ['unchained', 'coinstacks', 'bitcoincash', 'api'],
@@ -72,13 +70,10 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
-const wsUrl = INDEXER_API_KEY && IS_LIQUIFY ? `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}` : INDEXER_WS_URL
-const apiKey = INDEXER_API_KEY && IS_NOWNODES ? INDEXER_API_KEY : undefined
-
 const blockbook = new WebsocketClient(
-  wsUrl,
+  INDEXER_WS_URL,
   {
-    apiKey,
+    apiKey: INDEXER_API_KEY,
     blockHandler: registry.onBlock.bind(registry),
     transactionHandler: registry.onTransaction.bind(registry),
   },

--- a/node/coinstacks/bitcoincash/api/src/controller.ts
+++ b/node/coinstacks/bitcoincash/api/src/controller.ts
@@ -23,11 +23,7 @@ export const logger = new Logger({
   level: process.env.LOG_LEVEL,
 })
 
-const httpURL = `${INDEXER_URL}/api=${INDEXER_API_KEY}`
-const wsURL = `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}`
-const rpcUrl = `${RPC_URL}/api=${RPC_API_KEY}`
-
-const blockbook = new Blockbook({ httpURL, wsURL, logger })
+const blockbook = new Blockbook({ httpURL: INDEXER_URL, wsURL: INDEXER_WS_URL, apiKey: INDEXER_API_KEY, logger })
 
 const isXpub = (pubkey: string): boolean => {
   return pubkey.startsWith('xpub') || pubkey.startsWith('ypub') || pubkey.startsWith('zpub')
@@ -51,7 +47,8 @@ export const formatAddress = (address: string): string => {
 
 export const service = new Service({
   blockbook,
-  rpcUrl,
+  rpcUrl: RPC_URL,
+  rpcApiKey: RPC_API_KEY,
   isXpub,
   addressFormatter: formatAddress,
 })

--- a/node/coinstacks/bitcoincash/sample.env
+++ b/node/coinstacks/bitcoincash/sample.env
@@ -3,8 +3,8 @@ INDEXER_API_KEY=
 RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
-INDEXER_URL=https://gateway.liquify.com
-INDEXER_WS_URL=wss://gateway.liquify.com
+INDEXER_URL=https://bchbook.nownodes.io
+INDEXER_WS_URL=wss://bchbook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
-RPC_URL=https://gateway.liquify.com
+RPC_URL=https://bch.nownodes.io

--- a/node/coinstacks/common/api/src/middleware.ts
+++ b/node/coinstacks/common/api/src/middleware.ts
@@ -6,11 +6,9 @@ import cors from 'cors'
 import { ValidateError } from 'tsoa'
 import { ApiError, NotFoundError } from '.'
 
-export function errorHandler(err: Error, req: Request, res: Response, next: NextFunction): Response | void {
+export function errorHandler(err: Error, _: Request, res: Response, next: NextFunction): Response | void {
   if (err instanceof ValidateError) {
     const e = err as ValidateError
-
-    console.warn(`Caught Validation Error for ${req.path}:`, e.fields)
 
     return res.status(422).json({
       message: 'Validation Failed',

--- a/node/coinstacks/dogecoin/api/src/app.ts
+++ b/node/coinstacks/dogecoin/api/src/app.ts
@@ -15,9 +15,7 @@ const INDEXER_WS_URL = process.env.INDEXER_WS_URL
 const INDEXER_API_KEY = process.env.INDEXER_API_KEY
 
 if (!INDEXER_WS_URL) throw new Error('INDEXER_WS_URL env var not set')
-
-const IS_LIQUIFY = INDEXER_WS_URL.toLowerCase().includes('liquify')
-const IS_NOWNODES = INDEXER_WS_URL.toLowerCase().includes('nownodes')
+if (!INDEXER_API_KEY) throw new Error('INDEXER_API_KEY env var not set')
 
 const logger = new Logger({
   namespace: ['unchained', 'coinstacks', 'dogecoin', 'api'],
@@ -72,13 +70,10 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
-const wsUrl = INDEXER_API_KEY && IS_LIQUIFY ? `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}` : INDEXER_WS_URL
-const apiKey = INDEXER_API_KEY && IS_NOWNODES ? INDEXER_API_KEY : undefined
-
 const blockbook = new WebsocketClient(
-  wsUrl,
+  INDEXER_WS_URL,
   {
-    apiKey,
+    apiKey: INDEXER_API_KEY,
     blockHandler: registry.onBlock.bind(registry),
     transactionHandler: registry.onTransaction.bind(registry),
   },

--- a/node/coinstacks/dogecoin/api/src/controller.ts
+++ b/node/coinstacks/dogecoin/api/src/controller.ts
@@ -22,11 +22,7 @@ export const logger = new Logger({
   level: process.env.LOG_LEVEL,
 })
 
-const httpURL = `${INDEXER_URL}/api=${INDEXER_API_KEY}`
-const wsURL = `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}`
-const rpcUrl = `${RPC_URL}/api=${RPC_API_KEY}`
-
-const blockbook = new Blockbook({ httpURL, wsURL, logger })
+const blockbook = new Blockbook({ httpURL: INDEXER_URL, wsURL: INDEXER_WS_URL, apiKey: INDEXER_API_KEY, logger })
 
 const isXpub = (pubkey: string): boolean => {
   return pubkey.startsWith('dgub')
@@ -36,7 +32,8 @@ export const formatAddress = (address: string): string => address
 
 export const service = new Service({
   blockbook,
-  rpcUrl,
+  rpcUrl: RPC_URL,
+  rpcApiKey: RPC_API_KEY,
   isXpub,
   addressFormatter: formatAddress,
 })

--- a/node/coinstacks/dogecoin/sample.env
+++ b/node/coinstacks/dogecoin/sample.env
@@ -3,8 +3,8 @@ INDEXER_API_KEY=
 RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
-INDEXER_URL=https://gateway.liquify.com
-INDEXER_WS_URL=wss://gateway.liquify.com
+INDEXER_URL=https://dogebook.nownodes.io
+INDEXER_WS_URL=wss://dogebook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
-RPC_URL=https://gateway.liquify.com
+RPC_URL=https://doge.nownodes.io

--- a/node/coinstacks/litecoin/api/src/app.ts
+++ b/node/coinstacks/litecoin/api/src/app.ts
@@ -15,9 +15,7 @@ const INDEXER_WS_URL = process.env.INDEXER_WS_URL
 const INDEXER_API_KEY = process.env.INDEXER_API_KEY
 
 if (!INDEXER_WS_URL) throw new Error('INDEXER_WS_URL env var not set')
-
-const IS_LIQUIFY = INDEXER_WS_URL.toLowerCase().includes('liquify')
-const IS_NOWNODES = INDEXER_WS_URL.toLowerCase().includes('nownodes')
+if (!INDEXER_API_KEY) throw new Error('INDEXER_API_KEY env var not set')
 
 const logger = new Logger({
   namespace: ['unchained', 'coinstacks', 'litecoin', 'api'],
@@ -72,13 +70,10 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
-const wsUrl = INDEXER_API_KEY && IS_LIQUIFY ? `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}` : INDEXER_WS_URL
-const apiKey = INDEXER_API_KEY && IS_NOWNODES ? INDEXER_API_KEY : undefined
-
 const blockbook = new WebsocketClient(
-  wsUrl,
+  INDEXER_WS_URL,
   {
-    apiKey,
+    apiKey: INDEXER_API_KEY,
     blockHandler: registry.onBlock.bind(registry),
     transactionHandler: registry.onTransaction.bind(registry),
   },

--- a/node/coinstacks/litecoin/api/src/controller.ts
+++ b/node/coinstacks/litecoin/api/src/controller.ts
@@ -23,11 +23,7 @@ export const logger = new Logger({
   level: process.env.LOG_LEVEL,
 })
 
-const httpURL = `${INDEXER_URL}/api=${INDEXER_API_KEY}`
-const wsURL = `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}`
-const rpcUrl = `${RPC_URL}/api=${RPC_API_KEY}`
-
-const blockbook = new Blockbook({ httpURL, wsURL, logger })
+const blockbook = new Blockbook({ httpURL: INDEXER_URL, wsURL: INDEXER_WS_URL, apiKey: INDEXER_API_KEY, logger })
 
 const isXpub = (pubkey: string): boolean => {
   return pubkey.startsWith('Ltub') || pubkey.startsWith('Mtub') || pubkey.startsWith('zpub')
@@ -41,7 +37,8 @@ export const formatAddress = (address: string): string => {
 
 export const service = new Service({
   blockbook,
-  rpcUrl,
+  rpcUrl: RPC_URL,
+  rpcApiKey: RPC_API_KEY,
   isXpub,
   addressFormatter: formatAddress,
 })

--- a/node/coinstacks/litecoin/sample.env
+++ b/node/coinstacks/litecoin/sample.env
@@ -3,8 +3,8 @@ INDEXER_API_KEY=
 RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
-INDEXER_URL=https://gateway.liquify.com
-INDEXER_WS_URL=wss://gateway.liquify.com
+INDEXER_URL=https://ltcbook.nownodes.io
+INDEXER_WS_URL=wss://ltcbook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
-RPC_URL=https://gateway.liquify.com
+RPC_URL=https://ltc.nownodes.io

--- a/node/coinstacks/zcash/api/src/app.ts
+++ b/node/coinstacks/zcash/api/src/app.ts
@@ -69,8 +69,9 @@ const transactionHandler: TransactionHandler<BlockbookTx, utxo.Tx> = async (bloc
 const registry = new Registry({ addressFormatter: formatAddress, blockHandler, transactionHandler })
 
 const blockbook = new WebsocketClient(
-  `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}`,
+  INDEXER_WS_URL,
   {
+    apiKey: INDEXER_API_KEY,
     blockHandler: registry.onBlock.bind(registry),
     transactionHandler: registry.onTransaction.bind(registry),
   },

--- a/node/coinstacks/zcash/api/src/controller.ts
+++ b/node/coinstacks/zcash/api/src/controller.ts
@@ -22,11 +22,7 @@ export const logger = new Logger({
   level: process.env.LOG_LEVEL,
 })
 
-const httpURL = `${INDEXER_URL}/api=${INDEXER_API_KEY}`
-const wsURL = `${INDEXER_WS_URL}/api=${INDEXER_API_KEY}`
-const rpcUrl = `${RPC_URL}/api=${RPC_API_KEY}`
-
-const blockbook = new Blockbook({ httpURL, wsURL, logger })
+const blockbook = new Blockbook({ httpURL: INDEXER_URL, wsURL: INDEXER_WS_URL, apiKey: INDEXER_API_KEY, logger })
 
 const isXpub = (pubkey: string): boolean => {
   return pubkey.startsWith('xpub')
@@ -36,7 +32,8 @@ export const formatAddress = (address: string): string => address
 
 export const service = new Service({
   blockbook,
-  rpcUrl,
+  rpcUrl: RPC_URL,
+  rpcApiKey: RPC_API_KEY,
   isXpub,
   addressFormatter: formatAddress,
 })

--- a/node/coinstacks/zcash/sample.env
+++ b/node/coinstacks/zcash/sample.env
@@ -3,8 +3,8 @@ INDEXER_API_KEY=
 RPC_API_KEY=
 
 # ENVIRONMENT VARIABLES
-INDEXER_URL=https://gateway.liquify.com
-INDEXER_WS_URL=wss://gateway.liquify.com
+INDEXER_URL=https://zecbook.nownodes.io
+INDEXER_WS_URL=wss://zecbook.nownodes.io/wss
 LOG_LEVEL=debug
 NETWORK=mainnet
-RPC_URL=https://gateway.liquify.com
+RPC_URL=https://zec.nownodes.io

--- a/node/packages/blockbook/src/controller.ts
+++ b/node/packages/blockbook/src/controller.ts
@@ -5,23 +5,15 @@ import type { Address, BalanceHistory, Block, BlockbookArgs, BlockIndex, Info, S
 import { ApiError } from './models'
 import { Logger } from '@shapeshiftoss/logger'
 
-const defaultArgs: BlockbookArgs = {
-  httpURL: 'https://indexer.ethereum.shapeshift.com',
-  wsURL: 'wss://indexer.ethereum.shapeshift.com/websocket',
-  logger: new Logger({ namespace: ['unchained', 'blockbook'], level: process.env.LOG_LEVEL }),
-}
-
 @Route('api/v2')
 @Tags('v2')
 export class Blockbook extends Controller {
   instance: AxiosInstance
-  wsURL: string
   logger: Logger
 
-  constructor(args: BlockbookArgs = defaultArgs, timeout?: number, retries = 3) {
+  constructor(args: BlockbookArgs = { httpURL: '', wsURL: '', logger: new Logger() }, timeout?: number, retries = 3) {
     super()
     this.logger = args.logger.child({ namespace: ['blockbook'] })
-    this.wsURL = args.apiKey ? `${args.wsURL}/${args.apiKey}` : args.wsURL
     this.instance = axios.create({
       timeout: timeout ?? 10000,
       baseURL: args.httpURL,

--- a/node/packages/websocket/src/websocket.ts
+++ b/node/packages/websocket/src/websocket.ts
@@ -60,7 +60,7 @@ export abstract class BaseWebsocketClient {
       this.logger.error({ error, fn: 'ws.onerror' }, 'websocket error')
     }
     this.socket.onclose = ({ code, reason }) => {
-      this.logger.error({ code, reason, fn: 'ws.close' }, 'websocket closed')
+      this.logger.debug({ code, reason, fn: 'ws.close' }, 'websocket closed')
       this.close(code)
     }
     this.socket.onmessage = (msg) => this.onMessage(msg)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated service endpoints for Bitcoin, Bitcoin Cash, Dogecoin, Litecoin, and Zcash across HTTP, WebSocket, and RPC connections.
  * API key authentication now handled separately from endpoint URLs for improved security.
  * `INDEXER_API_KEY` is now required for Bitcoin, Bitcoin Cash, Dogecoin, and Litecoin stacks.

* **Improvements**
  * Simplified WebSocket connection configuration and error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->