### PR TITLE
fix: pass data to onUnsubscribe in BaseConnectionHandler

### DIFF
--- a/node/packages/websocket/src/connectionHandler.ts
+++ b/node/packages/websocket/src/connectionHandler.ts
@@ -31,7 +31,7 @@ export abstract class BaseConnectionHandler {
   protected subscriptionIds = new Set<string>()
 
   abstract onSubscribe(subscriptionId: string, data?: unknown): void
-  abstract onUnsubscribe(subscriptionId: string): void
+  abstract onUnsubscribe(subscriptionId: string, data?: unknown): void
   abstract onClose(): void
 
   constructor(websocket: WebSocket, prometheus: Prometheus, logger: Logger) {
@@ -92,7 +92,7 @@ export abstract class BaseConnectionHandler {
           this.onSubscribe(payload.subscriptionId, payload.data)
           return
         case 'unsubscribe':
-          this.onUnsubscribe(payload.subscriptionId)
+          this.onUnsubscribe(payload.subscriptionId, payload.data)
           return
       }
     } catch (err) {


### PR DESCRIPTION
The unsubscribe message handler was dropping payload.data, causing onUnsubscribe implementations that rely on data (e.g. to determine topic) to always receive undefined and error with "no topic specified".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced WebSocket unsubscribe event handling to support optional data parameters. The connection handler now accepts additional context information during subscription termination, enabling more flexible and context-aware event processing for applications managing WebSocket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->