### PR TITLE
fix: patch moralis sdk to handle empty value in internal transactions

### DIFF
--- a/.yarn/patches/@moralisweb3-common-evm-utils-npm-2.27.2-e6cbe4fc9a.patch
+++ b/.yarn/patches/@moralisweb3-common-evm-utils-npm-2.27.2-e6cbe4fc9a.patch
@@ -1,8 +1,8 @@
 diff --git a/lib/cjs/index.cjs b/lib/cjs/index.cjs
-index 3890ff00a2affac86818f839ef8a23e1b04b937e..50ae5d395eb90663fb1d883e0032c15a3f564ec6 100644
+index 3890ff00a2affac86818f839ef8a23e1b04b937e..1b02607801203ab2706dc27ef391f9e91c3d00ec 100644
 --- a/lib/cjs/index.cjs
 +++ b/lib/cjs/index.cjs
-@@ -4136,7 +4136,7 @@ var EvmInternalTransaction = /** @class */ (function () {
+@@ -4136,11 +4136,11 @@ var EvmInternalTransaction = /** @class */ (function () {
          transactionHash: data.transactionHash,
          gas: commonCore.BigNumber.create(data.gas),
          gasUsed: commonCore.BigNumber.create(data.gasUsed),
@@ -11,6 +11,11 @@ index 3890ff00a2affac86818f839ef8a23e1b04b937e..50ae5d395eb90663fb1d883e0032c15a
          blockHash: data.blockHash,
          input: data.input,
          output: data.output,
+-        value: commonCore.BigNumber.create(data.value),
++        value: commonCore.BigNumber.create(data.value || '0'),
+         type: data.type,
+     }); };
+     return EvmInternalTransaction;
 @@ -4197,6 +4197,7 @@ var EvmTransaction = /** @class */ (function () {
                  return EvmInternalTransaction.create(transaction);
              }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,13 +1263,13 @@ __metadata:
 
 "@moralisweb3/common-evm-utils@patch:@moralisweb3/common-evm-utils@npm%3A2.27.2#~/.yarn/patches/@moralisweb3-common-evm-utils-npm-2.27.2-e6cbe4fc9a.patch":
   version: 2.27.2
-  resolution: "@moralisweb3/common-evm-utils@patch:@moralisweb3/common-evm-utils@npm%3A2.27.2#~/.yarn/patches/@moralisweb3-common-evm-utils-npm-2.27.2-e6cbe4fc9a.patch::version=2.27.2&hash=b56468"
+  resolution: "@moralisweb3/common-evm-utils@patch:@moralisweb3/common-evm-utils@npm%3A2.27.2#~/.yarn/patches/@moralisweb3-common-evm-utils-npm-2.27.2-e6cbe4fc9a.patch::version=2.27.2&hash=47145c"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bytes": "npm:^5.7.0"
     "@ethersproject/transactions": "npm:^5.7.0"
     "@moralisweb3/common-core": "npm:^2.27.2"
-  checksum: 10c0/854983e47d6172344429057ae6d877c9411ce223a3d79e3b5150a706b007b6983c0a2047a315672f1c677d7a87bfd070623efd176496833bf71730a8dff7759d
+  checksum: 10c0/9e97f5510c4b3046ed5e7246d6137e5b17f954cacfe3c945eacfc213654813b83facd822b25c48d86dfc793f1a0f40ebf6228fbfe16d0ca62fa58ce450d10e79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Patches `@moralisweb3/common-evm-utils` to handle empty string `value` fields in internal transactions
- `STATICCALL` type internal transactions return `""` for `value`, causing `[C0500] Value is empty` error in the SDK's `BigNumberParser.parseInt`
- Falls back to `'0'` for empty values: `commonCore.BigNumber.create(data.value || '0')`

## Test plan
- [ ] Verify `getTransaction` no longer throws `[C0500] Value is empty` for transactions with `STATICCALL` internal transactions
- [ ] Verify existing transaction fetching still works for normal internal transactions with non-empty values

🤖 Generated with [Claude Code](https://claude.com/claude-code)