### PR TITLE
fix: handle send errors when unsubscribing solana logs

### DIFF
--- a/node/coinstacks/solana/api/src/websocket.ts
+++ b/node/coinstacks/solana/api/src/websocket.ts
@@ -107,13 +107,17 @@ export class WebsocketClient extends AddressSubscriptionWebsocketClient {
   }
 
   private unsubscribe(subscriptionId: number): void {
-    this.socket?.send(
-      JSON.stringify({
-        jsonrpc: '2.0',
-        id: 'unsubscribe',
-        method: 'logsUnsubscribe',
-        params: [subscriptionId],
-      })
-    )
+    try {
+      this.socket?.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'unsubscribe',
+          method: 'logsUnsubscribe',
+          params: [subscriptionId],
+        })
+      )
+    } catch (err) {
+      this.logger.debug(err, `failed to unsubscribe subscription: ${subscriptionId}`)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Wraps the `logsUnsubscribe` send in `unsubscribe()` with a try/catch, matching the pattern already used in `subscribeAddresses`.
- Prevents an unhandled exception (e.g. send on a non-OPEN socket) from crashing the solana coinstack.
- No retry needed — the base `AddressSubscriptionWebsocketClient` auto-reconnects on close and replays subscriptions via `onOpen`, which calls `subscribeAddresses(this.addresses)`. Stale subscription IDs on the old socket are abandoned with the old connection.

## Test plan
- [ ] Confirm solana websocket continues handling messages after a transient send failure during unsubscribe
- [ ] Verify subscriptions are restored after a reconnect cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket subscription management with enhanced error handling and diagnostic logging to prevent unhandled exceptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/unchained/pull/1274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->