### PR TITLE
feat: include BIP44 derivation path on utxo xpub addresses

### DIFF
--- a/node/coinstacks/bitcoin/api/src/swagger.json
+++ b/node/coinstacks/bitcoin/api/src/swagger.json
@@ -28,6 +28,10 @@
 					},
 					"pubkey": {
 						"type": "string"
+					},
+					"path": {
+						"type": "string",
+						"description": "BIP44 derivation path for the address (e.g. `m/84'/0'/0'/0/3`).\nPresent only for xpub-derived addresses."
 					}
 				},
 				"required": [

--- a/node/coinstacks/bitcoincash/api/src/swagger.json
+++ b/node/coinstacks/bitcoincash/api/src/swagger.json
@@ -28,6 +28,10 @@
 					},
 					"pubkey": {
 						"type": "string"
+					},
+					"path": {
+						"type": "string",
+						"description": "BIP44 derivation path for the address (e.g. `m/84'/0'/0'/0/3`).\nPresent only for xpub-derived addresses."
 					}
 				},
 				"required": [

--- a/node/coinstacks/common/api/src/utxo/models.ts
+++ b/node/coinstacks/common/api/src/utxo/models.ts
@@ -106,6 +106,11 @@ export interface Utxo {
 export interface Address {
   balance: string
   pubkey: string
+  /**
+   * BIP44 derivation path for the address (e.g. `m/84'/0'/0'/0/3`).
+   * Present only for xpub-derived addresses.
+   */
+  path?: string
 }
 
 /**

--- a/node/coinstacks/common/api/src/utxo/service.ts
+++ b/node/coinstacks/common/api/src/utxo/service.ts
@@ -50,6 +50,7 @@ export class Service implements Omit<BaseAPI, 'getInfo'>, API {
       const addresses = data.tokens?.map<Address>((token) => ({
         balance: token.balance ?? '0',
         pubkey: token.name,
+        path: token.path,
       })) ?? [
         {
           balance: data.balance,

--- a/node/coinstacks/dogecoin/api/src/swagger.json
+++ b/node/coinstacks/dogecoin/api/src/swagger.json
@@ -28,6 +28,10 @@
 					},
 					"pubkey": {
 						"type": "string"
+					},
+					"path": {
+						"type": "string",
+						"description": "BIP44 derivation path for the address (e.g. `m/84'/0'/0'/0/3`).\nPresent only for xpub-derived addresses."
 					}
 				},
 				"required": [

--- a/node/coinstacks/litecoin/api/src/swagger.json
+++ b/node/coinstacks/litecoin/api/src/swagger.json
@@ -28,6 +28,10 @@
 					},
 					"pubkey": {
 						"type": "string"
+					},
+					"path": {
+						"type": "string",
+						"description": "BIP44 derivation path for the address (e.g. `m/84'/0'/0'/0/3`).\nPresent only for xpub-derived addresses."
 					}
 				},
 				"required": [

--- a/node/coinstacks/zcash/api/src/swagger.json
+++ b/node/coinstacks/zcash/api/src/swagger.json
@@ -28,6 +28,10 @@
 					},
 					"pubkey": {
 						"type": "string"
+					},
+					"path": {
+						"type": "string",
+						"description": "BIP44 derivation path for the address (e.g. `m/84'/0'/0'/0/3`).\nPresent only for xpub-derived addresses."
 					}
 				},
 				"required": [


### PR DESCRIPTION
## Summary
- Add optional `path` field to the UTXO `Address` model exposing the BIP44 derivation path (e.g. `m/84'/0'/0'/0/3`) for xpub-derived addresses
- Populate `path` from the upstream Blockbook `token.path` when building the address list in the UTXO service

## Test plan
- [ ] Query an xpub account on a UTXO coinstack and verify each derived address includes `path`
- [ ] Query a single address (non-xpub) and verify `path` is omitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address records now optionally include a BIP44 derivation path for xpub-derived addresses.
  * This path is returned in API responses and address lists for supported chains (e.g., Bitcoin, Bitcoin Cash, Litecoin, Dogecoin, Zcash), allowing clients to show or use address derivation details when available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/unchained/pull/1275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->