### PR TITLE
fix(cosmossdk): guard nil cursor state in tx history pagination

### DIFF
--- a/go/shared/cosmossdk/cursor.go
+++ b/go/shared/cosmossdk/cursor.go
@@ -40,5 +40,14 @@ func (c *Cursor) Decode(b64 string) error {
 		return errors.Wrapf(err, "failed to unmarshal cursor: %s", bytes)
 	}
 
+	// json.Unmarshal into the existing State map keeps caller-supplied keys and stores a JSON
+	// null pointer value as a nil *CursorState. Drop those nil entries so a malformed cursor
+	// (e.g. {"state":{"x":null}}) can't leave a nil pointer to be dereferenced downstream.
+	for source, state := range c.State {
+		if state == nil {
+			delete(c.State, source)
+		}
+	}
+
 	return nil
 }

--- a/go/shared/cosmossdk/history.go
+++ b/go/shared/cosmossdk/history.go
@@ -81,6 +81,9 @@ func (h *History) filterByCursor(txs []HistoryTx) ([]HistoryTx, error) {
 		if tx.GetHeight() == h.Cursor.BlockHeight {
 			found := false
 			for _, s := range h.Cursor.State {
+				if s == nil {
+					continue
+				}
 				if tx.GetTxID() == s.TxID {
 					found = true
 					break


### PR DESCRIPTION
## Description

A caller-supplied `cursor` is unmarshalled into the server-initialized pagination state. `json.Unmarshal` into the existing `State` map keeps unexpected keys and stores a JSON `null` value as a nil `*CursorState`. `filterByCursor` then iterates `Cursor.State` and dereferences each entry, so a cursor carrying a null state value hits a nil pointer. That dereference runs in an `errgroup` worker goroutine, so the panic isn't recovered by the request handler and takes down the process instead of just failing the one request.

- `Cursor.Decode` drops nil `*CursorState` entries left by a malformed cursor.
- `filterByCursor` skips nil entries defensively.

## Verification

Didn't run `go build`/tests locally per the repo CLAUDE.md (CI handles build validation). It's a nil check plus dropping nil map values; no behaviour change on well-formed cursors.
