### PR TITLE
fix(cosmossdk): reject malformed tx history cursor at request boundary

### DIFF
--- a/go/shared/cosmossdk/api.go
+++ b/go/shared/cosmossdk/api.go
@@ -85,6 +85,22 @@ func (a *API) Root(w http.ResponseWriter, r *http.Request) {
 func (a *API) ValidatePagingParams(w http.ResponseWriter, r *http.Request, defaultPageSize int, maxPageSize *int) (string, int, error) {
 	cursor := r.URL.Query().Get("cursor")
 
+	if cursor != "" {
+		c := &Cursor{}
+		if err := c.Decode(cursor); err != nil {
+			api.HandleError(w, http.StatusBadRequest, "invalid cursor")
+			return cursor, 0, fmt.Errorf("invalid cursor: %w", err)
+		}
+
+		// reject nil state entries to avoid a downstream nil pointer dereference
+		for source, state := range c.State {
+			if state == nil {
+				api.HandleError(w, http.StatusBadRequest, "invalid cursor")
+				return cursor, 0, fmt.Errorf("invalid cursor: nil state for source %q", source)
+			}
+		}
+	}
+
 	pageSizeQ := r.URL.Query().Get("pageSize")
 	if pageSizeQ == "" {
 		pageSizeQ = strconv.Itoa(defaultPageSize)


### PR DESCRIPTION
## Description

A caller-supplied `cursor` is unmarshalled into the server-initialized pagination state. `json.Unmarshal` stores a JSON `null` state value as a nil `*CursorState`. `filterByCursor` later iterates `Cursor.State` and dereferences each entry — and that dereference runs in an `errgroup` worker goroutine, so the resulting panic is **not** recovered by `net/http` (it only recovers the request handler goroutine). One crafted, unauthenticated request therefore crashes the whole process instead of failing a single request.

This validates the cursor at the request boundary so a malformed value can never reach the crash path:

- `ValidatePagingParams` decodes the cursor and rejects any nil state entry, returning **400 Bad Request** before any source state is built or worker goroutine is spawned.
- `Cursor.Decode` stays a pure decode; `filterByCursor`/`history.go` are left untouched.

## Verification

Didn't run `go build`/tests locally per the repo CLAUDE.md (CI handles build validation). Well-formed cursors are unaffected; only structurally-invalid cursors (bad base64/JSON or a null state entry) now get a 400 instead of reaching pagination.