### PR TITLE
fix(evm): buffer arbitrum gasPrice/maxFeePerGas to prevent base-fee-drift tx failures

### DIFF
--- a/node/coinstacks/arbitrum/api/src/controller.ts
+++ b/node/coinstacks/arbitrum/api/src/controller.ts
@@ -34,7 +34,15 @@ const alchemyClient = createPublicClient({
   transport: http(`https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`),
 })
 
-export const service = new MoralisService({ chain: EvmChain.ARBITRUM, logger, client, rpcUrl })
+export const service = new MoralisService({
+  chain: EvmChain.ARBITRUM,
+  logger,
+  client,
+  rpcUrl,
+  baseFeeMultiplier: [1.5, 2, 3],
+  gasPriceMultiplier: [1.1, 1.2, 1.5],
+})
+
 export const cache = new EventCache({ client, alchemyClient, logger })
 
 // assign service to be used for all instances of EVM

--- a/node/coinstacks/common/api/src/evm/moralisService.ts
+++ b/node/coinstacks/common/api/src/evm/moralisService.ts
@@ -30,10 +30,10 @@ const FEE_HISTORY_BLOCK_COUNT = 100
 const REWARD_PERCENTILES = [50, 70, 90]
 
 // default per-tier multipliers [slow, average, fast] for base fee
-const DEFAULT_BASE_FEE_MULTIPLIER = [2, 2, 2]
+const DEFAULT_BASE_FEE_MULTIPLIER: [number, number, number] = [2, 2, 2]
 
 // default per-tier multipliers [slow, average, fast] for gas price
-const DEFAULT_GAS_PRICE_MULTIPLIER = [1, 1, 1]
+const DEFAULT_GAS_PRICE_MULTIPLIER: [number, number, number] = [1, 1, 1]
 
 // drop priority fees above the median by this factor to keep outliers (mev/overpayers) from skewing estimates
 const OUTLIER_THRESHOLD_MULTIPLIER = 10
@@ -55,8 +55,8 @@ export interface MoralisServiceArgs {
   rpcUrl: string
   explorerApiUrl?: URL
   minPriorityFee?: string
-  baseFeeMultiplier?: number[]
-  gasPriceMultiplier?: number[]
+  baseFeeMultiplier?: [number, number, number]
+  gasPriceMultiplier?: [number, number, number]
 }
 
 export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSubscriptionClient {
@@ -66,8 +66,8 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
   private readonly rpcUrl: string
   private readonly explorerApiUrl: URL
   private readonly minPriorityFee: string
-  private readonly baseFeeMultiplier: number[]
-  private readonly gasPriceMultiplier: number[]
+  private readonly baseFeeMultiplier: [number, number, number]
+  private readonly gasPriceMultiplier: [number, number, number]
 
   private secret?: string
   private streamId?: string

--- a/node/coinstacks/common/api/src/evm/moralisService.ts
+++ b/node/coinstacks/common/api/src/evm/moralisService.ts
@@ -29,8 +29,11 @@ const FEE_HISTORY_BLOCK_COUNT = 100
 // reward percentiles used to estimate [slow, average, fast] priority fees respectively
 const REWARD_PERCENTILES = [50, 70, 90]
 
-// multiplier applied to the next base fee when calculating maxFeePerGas so the tx stays valid as the base fee rises
-const BASE_FEE_MULTIPLIER = 2
+// default per-tier multipliers [slow, average, fast] for base fee
+const DEFAULT_BASE_FEE_MULTIPLIER = [2, 2, 2]
+
+// default per-tier multipliers [slow, average, fast] for gas price
+const DEFAULT_GAS_PRICE_MULTIPLIER = [1, 1, 1]
 
 // drop priority fees above the median by this factor to keep outliers (mev/overpayers) from skewing estimates
 const OUTLIER_THRESHOLD_MULTIPLIER = 10
@@ -52,6 +55,8 @@ export interface MoralisServiceArgs {
   rpcUrl: string
   explorerApiUrl?: URL
   minPriorityFee?: string
+  baseFeeMultiplier?: number[]
+  gasPriceMultiplier?: number[]
 }
 
 export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSubscriptionClient {
@@ -61,6 +66,8 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
   private readonly rpcUrl: string
   private readonly explorerApiUrl: URL
   private readonly minPriorityFee: string
+  private readonly baseFeeMultiplier: number[]
+  private readonly gasPriceMultiplier: number[]
 
   private secret?: string
   private streamId?: string
@@ -82,6 +89,8 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
     this.rpcUrl = args.rpcUrl
     this.explorerApiUrl = args.explorerApiUrl ?? new URL('about:blank')
     this.minPriorityFee = args.minPriorityFee ?? '0'
+    this.baseFeeMultiplier = args.baseFeeMultiplier ?? DEFAULT_BASE_FEE_MULTIPLIER
+    this.gasPriceMultiplier = args.gasPriceMultiplier ?? DEFAULT_GAS_PRICE_MULTIPLIER
 
     void Moralis.start({ evmApiBaseUrl: INDEXER_URL, apiKey: INDEXER_API_KEY })
     void Moralis.Streams.setSettings({ region: 'us-east-1' })
@@ -386,10 +395,11 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
       let maxPriorityFeePerGas = BigNumber(this.minPriorityFee)
       const [slow, average, fast] = REWARD_PERCENTILES.map((_, index): Fees => {
         maxPriorityFeePerGas = BigNumber.max(estimatePriorityFee(index), maxPriorityFeePerGas)
-        const maxFeePerGas = baseFeePerGas.times(BASE_FEE_MULTIPLIER).plus(maxPriorityFeePerGas)
+        const maxFeePerGas = baseFeePerGas.times(this.baseFeeMultiplier[index]).plus(maxPriorityFeePerGas)
+        const gasPrice = baseFeePerGas.times(this.gasPriceMultiplier[index]).plus(maxPriorityFeePerGas)
 
         return {
-          gasPrice: baseFeePerGas.plus(maxPriorityFeePerGas).toFixed(0),
+          gasPrice: gasPrice.toFixed(0),
           maxFeePerGas: maxFeePerGas.toFixed(0),
           maxPriorityFeePerGas: maxPriorityFeePerGas.toFixed(0),
         }


### PR DESCRIPTION
## Problem

Arbitrum `/fees` was occasionally returning suspect data (identical slow/average/fast tiers, `maxPriorityFeePerGas: 0`), and clients were hitting transaction failures:

```
max fee per gas less than block base fee: maxFeePerGas: 20072000 baseFee: 20110000
```

## Root cause

Arbitrum's sequencer orders transactions **first-come-first-served** and ignores priority fees, so `eth_feeHistory` reports **0 rewards at every percentile** (confirmed against a live RPC — 0/100 blocks non-zero at percentiles 50/70/90). Two consequences in `getGasFees`:

1. `maxPriorityFeePerGas` falls back to `minPriorityFee` (`0` for Arbitrum), collapsing all three tiers to identical values.
2. `gasPrice = baseFee + 0 = baseFee` — pinned to the bare base fee with **zero headroom**. Arbitrum's base fee jitters ~1% block-to-block, so any upward tick between estimation and inclusion rejects the tx. The rejected value `20072000` matches `gasPrice` exactly (not `maxFeePerGas`, which was `baseFee × 2 ≈ 40M`), confirming the client consumes the `gasPrice` field for Arbitrum.

This is a regression from the Blocknative → `eth_feeHistory` swap (#1281); Blocknative's `price` carried predictive headroom.

## Fix

Make the base-fee and gas-price tier multipliers configurable per chain (same pattern as `minPriorityFee`), **defaulting to the exact prior behavior** so no other coinstack changes. Arbitrum opts into per-tier buffers:

- `gasPriceMultiplier: [1.1, 1.2, 1.5]` — modest headroom so legacy/gasPrice txs stay above the base fee as it drifts, without meaningfully overpaying (gasPrice is the amount actually paid).
- `baseFeeMultiplier: [1.5, 2, 3]` — larger cap-only headroom on `maxFeePerGas` (a cap, so no overpay) and restores tier differentiation.

In the failing scenario, `slow.gasPrice` becomes `22079200`, comfortably above the `20110000` base fee that rejected the tx. Invariants verified: `maxFeePerGas ≥ gasPrice`, `gasPrice > baseFee`, and tiers monotonically increasing.

## Scope

Validated against live RPCs that **Optimism and Base are unaffected** — both show non-zero priority fees at every percentile (100/100 blocks) and stable base fees, so `gasPrice` already has ample headroom there. Change is Arbitrum-only; all other chains keep their current behavior via the defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated gas fee estimates to use tier-specific multipliers for slow, average, and fast transaction speeds.
  * Improved gas price and maximum fee calculations for Arbitrum transactions.
  * Arbitrum gas-related endpoints now provide more differentiated fee estimates across speed options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->