### PR TITLE
fix(solana): preflight sendTx at confirmed commitment

### DIFF
--- a/node/coinstacks/solana/api/src/controller.ts
+++ b/node/coinstacks/solana/api/src/controller.ts
@@ -305,7 +305,11 @@ export class Solana implements BaseAPI, API {
   @Post('send/')
   async sendTx(@Body() body: SendTxBody): Promise<string> {
     try {
-      const txSig = await heliusSdk.connection.sendRawTransaction(Buffer.from(body.hex, 'base64'))
+      // Preflight against the confirmed bank - provider built txs (e.g. across) pin blockhashes at
+      // confirmed commitment, which the default finalized preflight won't know for ~30s
+      const txSig = await heliusSdk.connection.sendRawTransaction(Buffer.from(body.hex, 'base64'), {
+        preflightCommitment: 'confirmed',
+      })
 
       return txSig
     } catch (err) {


### PR DESCRIPTION
## Description

`sendRawTransaction` inherited the Helius connection's default commitment (finalized) for preflight simulation. Provider-built transactions with blockhashes pinned at confirmed commitment — e.g. Across SVM swaps, which arrive pre-signed with a fresh blockhash — failed preflight with `Blockhash not found` for the ~30 seconds until that blockhash finalized. Broadcasting promptly after quoting was exactly what triggered it: the failure window was the *first* ~30s, then a brief working window until the blockhash expired at ~90s.

Verified empirically: a fresh Across-issued blockhash checks `isBlockhashValid` true at `processed`/`confirmed` and false at `finalized`; an Across SVM swap broadcast through this endpoint failed when signed immediately and succeeded when signed after a ~30s wait.

Preflighting at `confirmed` is strictly widening: finalized blockhashes (everything web's chain-adapter builds via `getLatestBlockhash()`) remain valid at confirmed, so existing sends are unaffected.

## Testing

- Broadcast an Across SVM swap (solana USDC → EVM USDC) signed immediately after quoting — previously `Blockhash not found`, now lands.
- Regular native/SPL sends unaffected (finalized blockhash ⊂ confirmed validity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction submission reliability by applying confirmed preflight checks before broadcasting transactions.
  * Transaction signatures and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->