### PR TITLE
fix(evm): stop moralis stream address sync from exhausting rate limits

### DIFF
--- a/node/coinstacks/common/api/src/evm/moralisService.ts
+++ b/node/coinstacks/common/api/src/evm/moralisService.ts
@@ -38,6 +38,20 @@ const DEFAULT_GAS_PRICE_MULTIPLIER: [number, number, number] = [1, 1, 1]
 // drop priority fees above the median by this factor to keep outliers (mev/overpayers) from skewing estimates
 const OUTLIER_THRESHOLD_MULTIPLIER = 10
 
+// moralis caps adding addresses to a stream at 5 requests per 5 minutes, removals are not rate limited
+// https://docs.moralis.com/streams/streams-concepts/rate-limits
+const STREAM_ADD_LIMIT = 5
+const STREAM_ADD_WINDOW = 300_000
+const STREAM_ADD_INTERVAL = STREAM_ADD_WINDOW / STREAM_ADD_LIMIT
+const STREAM_RETRY_INTERVAL = 5_000
+
+// moralis wraps request failures in a CoreError, exposing the http status on details
+const isRateLimitError = (err: unknown): boolean => {
+  if (!(err instanceof Error)) return false
+  const { details } = err as { details?: { status?: number } }
+  return details?.status === 429
+}
+
 type TransactionHandler = (tx: Tx) => Promise<void>
 
 interface Cursor {
@@ -73,7 +87,10 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
   private streamId?: string
   private queue = new PQueue({ concurrency: 1 })
   private currentAddresses = new Set<string>()
-  private canUpdateStream = true
+  private streamAddresses = new Set<string>()
+  private nextStreamAdd = 0
+  private nextStreamRemove = 0
+  private nextStreamUpdate = 0
 
   transactionHandler?: TransactionHandler
 
@@ -93,35 +110,49 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
     this.gasPriceMultiplier = args.gasPriceMultiplier ?? DEFAULT_GAS_PRICE_MULTIPLIER
 
     void Moralis.start({ evmApiBaseUrl: INDEXER_URL, apiKey: INDEXER_API_KEY })
-    void Moralis.Streams.setSettings({ region: 'us-east-1' })
 
-    setInterval(async () => {
-      this.canUpdateStream = true
-      await this.updateStream()
-    }, 60_000)
+    // settings are applied before the stream is created, region is a request and not local config
+    this.queue
+      .add(async () => {
+        await Moralis.Streams.setSettings({ region: 'us-east-1' })
+        await this.initializeStream()
+      })
+      .catch(() => undefined)
+
+    setInterval(() => {
+      this.queue.add(() => this.updateStream()).catch(() => undefined)
+    }, STREAM_RETRY_INTERVAL)
   }
 
   private async initializeStream() {
+    const args = {
+      chains: [this.chain],
+      description: this.chain.display(),
+      tag: `${this.chain.display()} - ${ENVIRONMENT}`,
+      webhookUrl: WEBHOOK_URL,
+      includeNativeTxs: true,
+      includeInternalTxs: true,
+      includeContractLogs: true,
+      networkType: 'evm' as const,
+    }
+
     try {
-      const stream = await Moralis.Streams.add({
-        chains: [this.chain],
-        description: this.chain.display(),
-        tag: `${this.chain.display()} - ${ENVIRONMENT}`,
-        webhookUrl: WEBHOOK_URL,
-        includeNativeTxs: true,
-        includeInternalTxs: true,
-        includeContractLogs: true,
-        networkType: 'evm',
-      })
+      const existing = await Moralis.Streams.add(args)
+
+      await Moralis.Streams.delete({ id: existing.result.id, networkType: 'evm' })
+
+      const stream = await Moralis.Streams.add(args)
 
       this.streamId = stream.result.id
+      this.streamAddresses = new Set()
     } catch (err) {
       if (err instanceof Error) {
-        this.logger.error({ error: err.message }, 'Failed to initialize MoralisService')
+        this.logger.error({ error: err.message }, 'failed to initialize stream')
       } else {
-        this.logger.error('Failed to initialize MoralisService')
+        this.logger.error('failed to initialize stream')
       }
-      process.exit(1)
+
+      throw err
     }
   }
 
@@ -791,10 +822,12 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
   }
 
   subscribeAddresses(addresses: Array<string>): void {
-    this.queue.add(async () => {
-      this.currentAddresses = new Set(addresses)
-      await this.updateStream()
-    })
+    this.queue
+      .add(async () => {
+        this.currentAddresses = new Set(addresses)
+        await this.updateStream()
+      })
+      .catch(() => undefined)
   }
 
   unsubscribeAddresses(addresses: Array<string>): void {
@@ -802,38 +835,49 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
   }
 
   async updateStream() {
-    try {
-      if (!this.canUpdateStream) return
+    if (Date.now() < this.nextStreamUpdate) return
 
+    try {
       if (!this.streamId) await this.initializeStream()
 
+      const { toAdd, toRemove } = this.diffStream()
+
+      const canAdd = toAdd.length > 0 && Date.now() >= this.nextStreamAdd
+      const canRemove = toRemove.length > 0 && Date.now() >= this.nextStreamRemove
+
+      if (!canAdd && !canRemove) return
+
       const baseArgs = { id: this.streamId!, networkType: 'evm' } as const
-      let response = await Moralis.Streams.getAddresses({ ...baseArgs, limit: 100 })
 
-      const existingAddresses = new Set(response.result.flatMap(({ address }) => address?.checksum ?? []))
-      while (response.pagination.cursor) {
-        response = await response.next()
-        response.result.forEach(({ address }) => address && existingAddresses.add(address.checksum))
+      if (canRemove) {
+        this.nextStreamRemove = Date.now() + STREAM_ADD_INTERVAL
+        await Moralis.Streams.deleteAddress({ ...baseArgs, address: toRemove })
+        toRemove.forEach((addr) => this.streamAddresses.delete(addr))
       }
 
-      const toAdd = Array.from(this.currentAddresses).filter((addr) => !existingAddresses.has(addr))
-      const toRemove = Array.from(existingAddresses).filter((addr) => !this.currentAddresses.has(addr))
-
-      if (!toAdd.length && !toRemove.length) return
-
-      if (toRemove.length) await Moralis.Streams.deleteAddress({ ...baseArgs, address: toRemove })
-      if (toAdd.length) await Moralis.Streams.addAddress({ ...baseArgs, address: toAdd })
-
-      this.canUpdateStream = false
+      if (canAdd) {
+        this.nextStreamAdd = Date.now() + STREAM_ADD_INTERVAL
+        await Moralis.Streams.addAddress({ ...baseArgs, address: toAdd })
+        toAdd.forEach((addr) => this.streamAddresses.add(addr))
+      }
     } catch (err) {
+      this.nextStreamUpdate = Date.now() + STREAM_ADD_INTERVAL
+
+      const rateLimited = isRateLimitError(err)
+      const currentAddresses = Array.from(this.currentAddresses)
+
       if (err instanceof Error) {
-        this.logger.error(
-          { error: err.message, currentAddresses: Array.from(this.currentAddresses) },
-          'failed to update stream'
-        )
+        this.logger.error({ error: err.message, rateLimited, currentAddresses }, 'failed to update stream')
       } else {
-        this.logger.error({ currentAddresses: Array.from(this.currentAddresses) }, 'failed to update stream')
+        this.logger.error({ currentAddresses }, 'failed to update stream')
       }
+    }
+  }
+
+  private diffStream(): { toAdd: Array<string>; toRemove: Array<string> } {
+    return {
+      toAdd: Array.from(this.currentAddresses).filter((addr) => !this.streamAddresses.has(addr)),
+      toRemove: Array.from(this.streamAddresses).filter((addr) => !this.currentAddresses.has(addr)),
     }
   }
 }

--- a/node/coinstacks/common/api/src/evm/moralisService.ts
+++ b/node/coinstacks/common/api/src/evm/moralisService.ts
@@ -43,6 +43,7 @@ const OUTLIER_THRESHOLD_MULTIPLIER = 10
 const STREAM_ADD_LIMIT = 5
 const STREAM_ADD_WINDOW = 300_000
 const STREAM_ADD_INTERVAL = STREAM_ADD_WINDOW / STREAM_ADD_LIMIT
+const STREAM_REMOVE_INTERVAL = 60_000
 const STREAM_RETRY_INTERVAL = 5_000
 
 // moralis wraps request failures in a CoreError, exposing the http status on details
@@ -111,13 +112,7 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
 
     void Moralis.start({ evmApiBaseUrl: INDEXER_URL, apiKey: INDEXER_API_KEY })
 
-    // settings are applied before the stream is created, region is a request and not local config
-    this.queue
-      .add(async () => {
-        await Moralis.Streams.setSettings({ region: 'us-east-1' })
-        await this.initializeStream()
-      })
-      .catch(() => undefined)
+    this.queue.add(() => this.initializeStream()).catch(() => undefined)
 
     setInterval(() => {
       this.queue.add(() => this.updateStream()).catch(() => undefined)
@@ -137,6 +132,9 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
     }
 
     try {
+      // region is a request rather than local config, so it is applied and retried alongside the stream
+      await Moralis.Streams.setSettings({ region: 'us-east-1' })
+
       const existing = await Moralis.Streams.add(args)
 
       await Moralis.Streams.delete({ id: existing.result.id, networkType: 'evm' })
@@ -849,8 +847,9 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
 
       const baseArgs = { id: this.streamId!, networkType: 'evm' } as const
 
+      // removals go first so the add reloads a smaller stream
       if (canRemove) {
-        this.nextStreamRemove = Date.now() + STREAM_ADD_INTERVAL
+        this.nextStreamRemove = Date.now() + STREAM_REMOVE_INTERVAL
         await Moralis.Streams.deleteAddress({ ...baseArgs, address: toRemove })
         toRemove.forEach((addr) => this.streamAddresses.delete(addr))
       }
@@ -869,7 +868,7 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
       if (err instanceof Error) {
         this.logger.error({ error: err.message, rateLimited, currentAddresses }, 'failed to update stream')
       } else {
-        this.logger.error({ currentAddresses }, 'failed to update stream')
+        this.logger.error({ rateLimited, currentAddresses }, 'failed to update stream')
       }
     }
   }


### PR DESCRIPTION
## Problem

Ethereum mainnet API was continuously logging `failed to update stream` with `[C0006] Request failed, Too Many Requests(429)`.

## Root cause

`canUpdateStream` was only cleared **after a successful mutation**, so the "already in sync" path and the error path both returned with it still `true`:

```ts
if (!toAdd.length && !toRemove.length) return   // ← no throttle applied
...
this.canUpdateStream = false                    // ← only reached after a mutation
```

Since "already in sync" is the steady state, every websocket subscribe/unsubscribe kicked off a fresh paginated `getAddresses`. The prod stream had accumulated **64,001 addresses**, which is **641 requests per event** at `limit: 100` — and `@moralisweb3/common-core` retries GET 429s twice more with no backoff.

The sync never got past pagination to reach the diff, which is also why nothing was ever cleaned up. The stream had been growing since it was created in March.

## Changes

- **No more reading the address list back.** `getAddresses` is gone. `initializeStream` recreates the stream on startup, so the locally tracked `streamAddresses` starts from a known-empty set and stays authoritative.
- **Adds paced at one request per minute**, matching the [documented](https://docs.moralis.com/streams/streams-concepts/rate-limits) 5 per 5 minutes. Pacing rather than bursting caps the wait for a new subscription at one interval instead of the remainder of the window; batching makes it free, since every pending address rides the next request.
- **Removals paced on their own interval.** Not rate limited, but every mutation reloads the stream before new blocks are processed for it, so this keeps reloads to at most two a minute. The deadline is separate from adds so cleanup never delays a newly subscribed address.
- **Back off on any failed request**, not just 429s, so a persistent failure can't retry every interval.
- **Initialization is no longer fatal.** It previously called `process.exit(1)`; now it logs and retries, since exiting would just restart into the same rate limit. Log message changed from `Failed to initialize MoralisService` to `failed to initialize stream`.
- Added `rateLimited` to the `failed to update stream` log so 429s are distinguishable from other failures.

Convergence is structural rather than bookkeeping: every pass re-derives the diff from `currentAddresses` vs `streamAddresses`, so there's no queued work that can go stale. A deferred or failed request simply reappears in the next diff, and both mutations are idempotent.

## Testing

- Typechecks clean.
- **Not** exercised against the live API. Suggest deploying to dev first — its stream currently has 0 addresses, so it validates the init path with nothing at risk.
- Watch the new `rateLimited` log field and the stream's address count, which should track live connection count rather than climb.

## Open question

Every EVM coinstack points at the same `INDEXER_URL`. If they also share one `INDEXER_API_KEY` and the limit is per-key rather than per-stream, the 60s pacing is too generous by the number of live coinstacks. That would show up as continued 429s with `rateLimited: true`, and the fix is to divide the interval accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blockchain stream synchronization to handle rate limits more reliably.
  * Stream updates now retry automatically after temporary service failures instead of stopping unexpectedly.
  * Address additions and removals are tracked more accurately, reducing unnecessary synchronization requests.
  * Improved handling of regional stream settings and recovery during stream reinitialization.
  * Added clearer rate-limit status reporting for improved operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->