### PR TITLE
fix(evm): halve stream webhook validations and jitter init retries

### DIFF
--- a/node/coinstacks/common/api/src/evm/moralisService.ts
+++ b/node/coinstacks/common/api/src/evm/moralisService.ts
@@ -46,6 +46,8 @@ const STREAM_ADD_INTERVAL = STREAM_ADD_WINDOW / STREAM_ADD_LIMIT
 const STREAM_REMOVE_INTERVAL = 60_000
 const STREAM_RETRY_INTERVAL = 5_000
 
+const jitter = (ms: number): number => Math.round(ms / 2 + Math.random() * ms)
+
 // moralis wraps request failures in a CoreError, exposing the http status on details
 const isRateLimitError = (err: unknown): boolean => {
   if (!(err instanceof Error)) return false
@@ -132,12 +134,12 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
     }
 
     try {
-      // region is a request rather than local config, so it is applied and retried alongside the stream
       await Moralis.Streams.setSettings({ region: 'us-east-1' })
 
-      const existing = await Moralis.Streams.add(args)
+      const streams = await Moralis.Streams.getAll({ limit: 100, networkType: 'evm' })
 
-      await Moralis.Streams.delete({ id: existing.result.id, networkType: 'evm' })
+      const existing = streams.result.find((stream) => stream.tag === args.tag)
+      if (existing) await Moralis.Streams.delete({ id: existing.id, networkType: 'evm' })
 
       const stream = await Moralis.Streams.add(args)
 
@@ -149,6 +151,8 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
       } else {
         this.logger.error('failed to initialize stream')
       }
+
+      this.nextStreamUpdate = Date.now() + jitter(STREAM_ADD_INTERVAL)
 
       throw err
     }
@@ -860,7 +864,7 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
         toAdd.forEach((addr) => this.streamAddresses.add(addr))
       }
     } catch (err) {
-      this.nextStreamUpdate = Date.now() + STREAM_ADD_INTERVAL
+      this.nextStreamUpdate = Date.now() + jitter(STREAM_ADD_INTERVAL)
 
       const rateLimited = isRateLimitError(err)
       const currentAddresses = Array.from(this.currentAddresses)


### PR DESCRIPTION
Follow-up to #1286.

## Problem

Deploying the EVM services together rate limited them all on startup:

```
failed to initialize stream
[C0006] Request failed, Too Many Requests(429): Too many webhook validation requests. Please slow down.
```

This is a **different limit** from the one #1286 addressed. Creating a stream makes Moralis validate the `webhookUrl`, and that limit is shared across every coinstack on the account — so N services booting at once contend with each other.

Two things made it worse:

1. `initializeStream` called `Moralis.Streams.add` **twice** — once to get the existing stream, once to recreate it after the delete. Each creation spends a validation, so #1286 doubled the cost per boot.
2. Retries were synchronized. Every service boots together, fails together, and retried on a flat 60s cadence with no jitter, so they kept colliding instead of draining. The constructor's failure path also didn't set a backoff, so the first retry landed 5s after boot for all of them at once.

## Changes

- **Look the existing stream up with `getAll` instead of creating it.** `getAll` is a plain request, not a validation, so a boot now spends one validation instead of two. One page covers the handful of streams on the account, so there's no pagination loop.
- **Jitter the retry backoff** (`interval/2 + random × interval`, so ~30–90s) so services deployed together desynchronize within a round or two.
- **Back off from a failed `initializeStream` too.** The constructor path never reaches `updateStream`'s catch, so a failed boot previously retried 5s later with no delay.

## Notes

Recovery already worked before this — `streamId` stays unset, `updateStream` retries init at the top of its try, and it converges. This makes it converge quickly and quietly instead of via a thundering herd.

The address-add rate limit is untouched. This log is specific to webhook validation; there's no evidence yet that the 5-per-5-minutes address limit is also account-wide. If it is, it would show up as `rateLimited: true` on `failed to update stream` and the add interval would need scaling by the number of live coinstacks.

## Testing

Typechecks clean. Not exercised against the live API — the deploy is the test, and the signal to watch is whether `failed to initialize stream` clears within a couple of retry rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stream setup reliability by preventing duplicate stream registrations.
  - Enhanced recovery after temporary service interruptions with more resilient retry timing.
  - Reduced synchronized retry attempts, helping stream initialization and updates complete more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->