### PR TITLE
fix(evm): subscribe addresses immediately, adds are not rate limited

### DIFF
--- a/node/coinstacks/common/api/src/evm/moralisService.ts
+++ b/node/coinstacks/common/api/src/evm/moralisService.ts
@@ -38,12 +38,10 @@ const DEFAULT_GAS_PRICE_MULTIPLIER: [number, number, number] = [1, 1, 1]
 // drop priority fees above the median by this factor to keep outliers (mev/overpayers) from skewing estimates
 const OUTLIER_THRESHOLD_MULTIPLIER = 10
 
-// moralis caps adding addresses to a stream at 5 requests per 5 minutes, removals are not rate limited
-// https://docs.moralis.com/streams/streams-concepts/rate-limits
-const STREAM_ADD_LIMIT = 5
-const STREAM_ADD_WINDOW = 300_000
-const STREAM_ADD_INTERVAL = STREAM_ADD_WINDOW / STREAM_ADD_LIMIT
+// removals are paced because every mutation reloads the stream
 const STREAM_REMOVE_INTERVAL = 60_000
+// stream creation triggers a webhook validation, which is rate limited across the whole account
+const STREAM_INIT_BACKOFF = 60_000
 const STREAM_RETRY_INTERVAL = 5_000
 
 const jitter = (ms: number): number => Math.round(ms / 2 + Math.random() * ms)
@@ -91,7 +89,6 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
   private queue = new PQueue({ concurrency: 1 })
   private currentAddresses = new Set<string>()
   private streamAddresses = new Set<string>()
-  private nextStreamAdd = 0
   private nextStreamRemove = 0
   private nextStreamUpdate = 0
 
@@ -152,7 +149,7 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
         this.logger.error('failed to initialize stream')
       }
 
-      this.nextStreamUpdate = Date.now() + jitter(STREAM_ADD_INTERVAL)
+      this.nextStreamUpdate = Date.now() + jitter(STREAM_INIT_BACKOFF)
 
       throw err
     }
@@ -844,28 +841,23 @@ export class MoralisService implements Omit<BaseAPI, 'getInfo'>, API, AddressSub
 
       const { toAdd, toRemove } = this.diffStream()
 
-      const canAdd = toAdd.length > 0 && Date.now() >= this.nextStreamAdd
       const canRemove = toRemove.length > 0 && Date.now() >= this.nextStreamRemove
 
-      if (!canAdd && !canRemove) return
+      if (!toAdd.length && !canRemove) return
 
       const baseArgs = { id: this.streamId!, networkType: 'evm' } as const
 
-      // removals go first so the add reloads a smaller stream
+      if (toAdd.length) {
+        await Moralis.Streams.addAddress({ ...baseArgs, address: toAdd })
+        toAdd.forEach((addr) => this.streamAddresses.add(addr))
+      }
+
       if (canRemove) {
         this.nextStreamRemove = Date.now() + STREAM_REMOVE_INTERVAL
         await Moralis.Streams.deleteAddress({ ...baseArgs, address: toRemove })
         toRemove.forEach((addr) => this.streamAddresses.delete(addr))
       }
-
-      if (canAdd) {
-        this.nextStreamAdd = Date.now() + STREAM_ADD_INTERVAL
-        await Moralis.Streams.addAddress({ ...baseArgs, address: toAdd })
-        toAdd.forEach((addr) => this.streamAddresses.add(addr))
-      }
     } catch (err) {
-      this.nextStreamUpdate = Date.now() + jitter(STREAM_ADD_INTERVAL)
-
       const rateLimited = isRateLimitError(err)
       const currentAddresses = Array.from(this.currentAddresses)
 


### PR DESCRIPTION
Follow-up to #1286 / #1287.

## Context

Moralis confirmed their [rate limit docs](https://docs.moralis.com/streams/streams-concepts/rate-limits) are **out of date**: there is no 5-requests-per-5-minutes limit on adding stream addresses. Address mutations only spend the normal account throughput budget.

That limit was the basis for pacing adds at one per minute in #1286. With it gone, the pacing is pure latency — a newly subscribed address could wait up to a minute before reaching the stream, and any transaction landing in that window is missed for that user.

## Changes

- **Adds go out immediately.** Dropped `STREAM_ADD_LIMIT` / `STREAM_ADD_WINDOW` / `STREAM_ADD_INTERVAL` and the `nextStreamAdd` deadline. `subscribeAddresses` already calls `updateStream` directly, so an address now reaches the stream in roughly one round trip instead of up to 60s.
- **Adds are issued before removals.** A failed `deleteAddress` would otherwise throw past the add in the same pass, letting cosmetic cleanup delay the addresses we actually need to catch transactions for.
- **Removals stay paced.** `STREAM_REMOVE_INTERVAL` was never about rate limits — every mutation reloads the stream before new blocks are processed for it, so pacing keeps a disconnect-heavy stretch from reloading constantly. It never blocks an add.
- **No backoff on failed address mutations.** The retry tick is 5s, already longer than Moralis's 4-second rolling throughput window, so a throughput 429 clears before the next attempt. `streamAddresses` is only updated after a request succeeds, so anything that failed stays in the diff and is retried alongside whatever arrived since.
- **Initialization keeps its backoff** (~60s jittered). Creating a stream validates the webhook URL against a limit that genuinely *is* shared across every coinstack on the account — the failure #1287 addressed. `nextStreamUpdate` now has a single setter.

## What this does not change

Local address tracking, the stream recreate on startup, and the diff-driven convergence are all untouched — those solved the request storm, which was a separate problem from the pacing.

## Testing

Typechecks clean. Not exercised against the live API. The signal to watch is `rateLimited: true` on `failed to update stream` — if account throughput does turn out to bind on address mutations, that is where it will show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)