### PR TITLE
fix(proxy): preserve upstream retry guidance on 0x errors

### DIFF
--- a/node/proxy/api/src/zrx.ts
+++ b/node/proxy/api/src/zrx.ts
@@ -74,6 +74,13 @@ export class Zrx {
       res.status(response.status).send(response.data)
     } catch (err) {
       if (isAxiosError(err)) {
+        // Preserve upstream backoff guidance and make it readable by browser clients.
+        const retryAfter = err.response?.headers['retry-after']
+        if (typeof retryAfter === 'string') {
+          res.set('Retry-After', retryAfter)
+          res.append('Access-Control-Expose-Headers', 'Retry-After')
+        }
+
         res.status(err.response?.status ?? 500).send(err.response?.data || 'Internal Server Error')
       } else if (err instanceof Error) {
         res.status(500).send(err.message || 'Internal Server Error')


### PR DESCRIPTION
The 0x proxy drops upstream error headers when forwarding failed quotes, preventing clients from receiving any `Retry-After` guidance supplied with a rate-limited response. Preserve that header and expose it through CORS so browser clients can read it; keep the existing response status and body.

This does not introduce retries, cache executable quotes, or assume a production quota. It only preserves guidance when 0x supplies it; it does not by itself resolve the observed intermittent 429s.

Validation: reviewed the success, missing-response, and absent-header paths; `git diff --check` passes. Local tests and lint were not run per `CLAUDE.md`; CI provides build/lint validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy error responses now forward the upstream `Retry-After` header when available.
  * Browser clients can read the `Retry-After` value from responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->