### PR TITLE
fix(thorchain): recover indexed transactions missing from direct lookup

### DIFF
--- a/go/pkg/thorchain/tx.go
+++ b/go/pkg/thorchain/tx.go
@@ -1,7 +1,9 @@
 package thorchain
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -38,12 +40,27 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 	}
 
 	if res.Error != nil {
+		// Some providers retain transactions in the search index after /tx stops
+		// finding them. Use the same indexed transaction data as account history.
+		hash := strings.TrimPrefix(txid, "0x")
+		decodedHash, decodeErr := hex.DecodeString(hash)
+		if decodeErr == nil && len(decodedHash) == 32 && res.Error.Code == -32603 &&
+			strings.EqualFold(res.Error.Data, fmt.Sprintf("tx (%s) not found", hash)) {
+			result, err := c.TxSearch(fmt.Sprintf(`"tx.hash='%s'"`, strings.ToUpper(hash)), 1, 1)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to search for tx: %s", txid)
+			}
+			if len(result.Txs) == 1 && result.Txs[0] != nil &&
+				bytes.Equal(result.Txs[0].Hash, decodedHash) && bytes.Equal(result.Txs[0].Tx.Hash(), decodedHash) {
+				return result.Txs[0], nil
+			}
+		}
 		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get tx: %s", txid)
 	}
 
 	tx := &coretypes.ResultTx{}
 	if err := cometbftjson.Unmarshal(res.Result, tx); err != nil {
-		return nil, errors.Errorf("failed to unmarshal tx result: %v: %s", res.Result, res.Error.Error())
+		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %s", txid)
 	}
 
 	return tx, nil


### PR DESCRIPTION
THORChain can return a transaction in account history while `/api/v1/tx/{txid}` fails with HTTP 500: the upstream `/tx` lookup says it is missing, but `/tx_search` on the same provider still returns the complete signed transaction. For example, this affects `D4C2B478C69D020386D027CB2205CFCAE60D1BD791E93E31ACDAE8ACCB32AA9F`.

Fall back to a one-result exact-hash search only for the specific transaction-not-found RPC error and a valid 32-byte hash. Accept the result only when both its reported hash and the hash of its signed bytes match the requested transaction. Other upstream failures retain their existing behavior. Also preserve the decoding error instead of dereferencing a nil RPC error on malformed success responses.

Validation: live read-only checks recovered both audited missing transactions through exact-hash search, verified their signed-byte hashes, fetched their blocks, and confirmed account history formats the same transactions. An unknown hash returned no search results. `git diff --check` passes. Local tests, Go builds/vet, and lint were not run per `CLAUDE.md`; CI provides build/lint validation.

This addresses the THORChain lookup failure. The separately observed Arbitrum/Moralis miss is not changed here.
