### PR TITLE
fix(cosmossdk): handle upstream error status codes

### DIFF
--- a/go/coinstacks/cosmos/api/api.go
+++ b/go/coinstacks/cosmos/api/api.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -268,6 +269,7 @@ func (a *API) GetValidators(w http.ResponseWriter, r *http.Request) {
 // responses:
 //
 //	200: Validator
+//	404: ApiError
 //	500: InternalServerError
 func (a *API) GetValidator(w http.ResponseWriter, r *http.Request) {
 	// pubkey validated by ValidatePubkey middleware
@@ -275,7 +277,12 @@ func (a *API) GetValidator(w http.ResponseWriter, r *http.Request) {
 
 	validator, err := a.handler.GetValidator(pubkey)
 	if err != nil {
-		api.HandleError(w, http.StatusInternalServerError, err.Error())
+		status := http.StatusInternalServerError
+		if errors.Is(err, cosmossdk.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+
+		api.HandleError(w, status, err.Error())
 		return
 	}
 

--- a/go/coinstacks/cosmos/api/swagger.json
+++ b/go/coinstacks/cosmos/api/swagger.json
@@ -367,6 +367,12 @@
               "$ref": "#/definitions/Validator"
             }
           },
+          "404": {
+            "description": "ApiError",
+            "schema": {
+              "$ref": "#/definitions/ApiError"
+            }
+          },
           "500": {
             "description": "InternalServerError",
             "schema": {

--- a/go/coinstacks/thorchain-v1/thorchainV1.go
+++ b/go/coinstacks/thorchain-v1/thorchainV1.go
@@ -46,13 +46,17 @@ func (r *ResultBlockResults) GetBlockEvents() []cosmossdk.ABCIEvent {
 func (c *HTTPClient) BlockResults(height int) (cosmossdk.BlockResults, error) {
 	res := &rpctypes.RPCResponse{}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", strconv.Itoa(height)).Get("/block_results")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", strconv.Itoa(height)).Get("/block_results")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
 	if res.Error != nil {
 		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get block results for block: %v", height)
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
 	result := &coretypes.ResultBlockResults{}

--- a/go/coinstacks/thorchain-v1/thorchainV1.go
+++ b/go/coinstacks/thorchain-v1/thorchainV1.go
@@ -61,7 +61,7 @@ func (c *HTTPClient) BlockResults(height int) (cosmossdk.BlockResults, error) {
 
 	result := &coretypes.ResultBlockResults{}
 	if err := tendermintjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal block result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal block result: %s", res.Result)
 	}
 
 	return &ResultBlockResults{result}, nil

--- a/go/pkg/cosmos/block.go
+++ b/go/pkg/cosmos/block.go
@@ -34,7 +34,7 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 
 	result := &coretypes.ResultBlock{}
 	if err := cometbftjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Errorf("failed to unmarshal block result: %v", res.Result)
+		return nil, errors.Errorf("failed to unmarshal block result: %s", res.Result)
 	}
 
 	b := &cosmossdk.ResultBlock{
@@ -74,7 +74,7 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 
 	result := &coretypes.ResultBlockSearch{}
 	if err := cometbftjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal block search result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal block search result: %s", res.Result)
 	}
 
 	return result, nil
@@ -98,7 +98,7 @@ func (c *HTTPClient) BlockResults(height int) (cosmossdk.BlockResults, error) {
 
 	result := &coretypes.ResultBlockResults{}
 	if err := cometbftjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal block result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal block result: %s", res.Result)
 	}
 
 	return &ResultBlockResults{result}, nil

--- a/go/pkg/cosmos/block.go
+++ b/go/pkg/cosmos/block.go
@@ -19,13 +19,17 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 		hs = strconv.Itoa(*height)
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %d", height)
+		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
 	}
 
 	if res.Error != nil {
 		return nil, errors.Errorf("failed to get block: %s: %s", hs, res.Error.Error())
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
 	}
 
 	result := &coretypes.ResultBlock{}
@@ -52,7 +56,7 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 		"order_by": "\"desc\"",
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/block_search")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/block_search")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to search blocks")
 	}
@@ -62,6 +66,10 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 			return &coretypes.ResultBlockSearch{Blocks: []*coretypes.ResultBlock{}, TotalCount: 0}, nil
 		}
 		return nil, errors.Wrap(errors.New(res.Error.Error()), "failed to search blocks")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrap(err, "failed to search blocks")
 	}
 
 	result := &coretypes.ResultBlockSearch{}
@@ -75,13 +83,17 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 func (c *HTTPClient) BlockResults(height int) (cosmossdk.BlockResults, error) {
 	res := &rpctypes.RPCResponse{}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", strconv.Itoa(height)).Get("/block_results")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", strconv.Itoa(height)).Get("/block_results")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
 	if res.Error != nil {
 		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get block results for block: %v", height)
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
 	result := &coretypes.ResultBlockResults{}

--- a/go/pkg/cosmos/block.go
+++ b/go/pkg/cosmos/block.go
@@ -15,21 +15,23 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 	res := &rpctypes.RPCResponse{}
 
 	hs := ""
+	label := "latest"
 	if height != nil {
 		hs = strconv.Itoa(*height)
+		label = hs
 	}
 
 	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
+		return nil, errors.Wrapf(err, "failed to get block: %s", label)
 	}
 
 	if res.Error != nil {
-		return nil, errors.Errorf("failed to get block: %s: %s", hs, res.Error.Error())
+		return nil, errors.Errorf("failed to get block: %s: %s", label, res.Error.Error())
 	}
 
 	if err := cosmossdk.CheckResponse(resp); err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
+		return nil, errors.Wrapf(err, "failed to get block: %s", label)
 	}
 
 	result := &coretypes.ResultBlock{}

--- a/go/pkg/cosmos/fees.go
+++ b/go/pkg/cosmos/fees.go
@@ -19,16 +19,14 @@ func (c *HTTPClient) GetGlobalMinimumGasPrices() (map[string]sdkmath.LegacyDec, 
 		} `json:"price"`
 	}
 
-	e := &cosmossdk.ErrorResponse{}
-
 	url := fmt.Sprintf("/feemarket/v1/gas_price/%s", c.Denom)
-	r, err := c.LCD.R().SetResult(&res).SetError(e).Get(url)
+	resp, err := c.LCD.R().SetResult(&res).Get(url)
 	if err != nil {
 		return gasPrices, errors.Wrap(err, "failed to get globalfee params")
 	}
 
-	if r.Error() != nil {
-		return gasPrices, errors.Errorf("failed to get globalfee params: %s", e.Msg)
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return gasPrices, errors.Wrap(err, "failed to get globalfee params")
 	}
 
 	amount, err := sdkmath.LegacyNewDecFromStr(res.Price.Amount)
@@ -48,15 +46,13 @@ func (c *HTTPClient) GetLocalMinimumGasPrices() (map[string]sdkmath.LegacyDec, e
 		MinimumGasPrice string `json:"minimum_gas_price"`
 	}
 
-	e := &cosmossdk.ErrorResponse{}
-
-	r, err := c.LCD.R().SetResult(&res).SetError(e).Get("/cosmos/base/node/v1beta1/config")
+	resp, err := c.LCD.R().SetResult(&res).Get("/cosmos/base/node/v1beta1/config")
 	if err != nil {
 		return gasPrices, errors.Wrap(err, "failed to get base node config")
 	}
 
-	if r.Error() != nil {
-		return gasPrices, errors.Errorf("failed to get base node config: %s", e.Msg)
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return gasPrices, errors.Wrap(err, "failed to get base node config")
 	}
 
 	coins, err := sdk.ParseDecCoins(res.MinimumGasPrice)

--- a/go/pkg/cosmos/tx.go
+++ b/go/pkg/cosmos/tx.go
@@ -49,7 +49,7 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 
 	tx := &coretypes.ResultTx{}
 	if err := cometbftjson.Unmarshal(res.Result, tx); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %s", res.Result)
 	}
 
 	return tx, nil
@@ -83,7 +83,7 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 
 	result := &coretypes.ResultTxSearch{}
 	if err := cometbftjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal tx search result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal tx search result: %s", res.Result)
 	}
 
 	return result, nil

--- a/go/pkg/cosmos/tx.go
+++ b/go/pkg/cosmos/tx.go
@@ -34,7 +34,7 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 		txid = "0x" + txid
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("hash", txid).Get("/tx")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("hash", txid).Get("/tx")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get tx: %s", txid)
 	}
@@ -43,9 +43,13 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get tx: %s", txid)
 	}
 
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get tx: %s", txid)
+	}
+
 	tx := &coretypes.ResultTx{}
 	if err := cometbftjson.Unmarshal(res.Result, tx); err != nil {
-		return nil, errors.Errorf("failed to unmarshal tx result: %v: %s", res.Result, res.Error.Error())
+		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %v", res.Result)
 	}
 
 	return tx, nil
@@ -61,7 +65,7 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 		"order_by": "\"desc\"",
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/tx_search")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/tx_search")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to search txs")
 	}
@@ -71,6 +75,10 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 			return &coretypes.ResultTxSearch{Txs: []*coretypes.ResultTx{}, TotalCount: 0}, nil
 		}
 		return nil, errors.Wrap(errors.New(res.Error.Error()), "failed to search txs")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrap(err, "failed to search txs")
 	}
 
 	result := &coretypes.ResultTxSearch{}
@@ -104,8 +112,12 @@ func (c *HTTPClient) BroadcastTx(rawTx string) (string, error) {
 		} `json:"tx_response"`
 	}
 
-	_, err = c.LCD.R().SetBody(&txtypes.BroadcastTxRequest{TxBytes: txBytes, Mode: txtypes.BroadcastMode_BROADCAST_MODE_SYNC}).SetResult(&res).Post("/cosmos/tx/v1beta1/txs")
+	resp, err := c.LCD.R().SetBody(&txtypes.BroadcastTxRequest{TxBytes: txBytes, Mode: txtypes.BroadcastMode_BROADCAST_MODE_SYNC}).SetResult(&res).Post("/cosmos/tx/v1beta1/txs")
 	if err != nil {
+		return "", errors.Wrap(err, "failed to broadcast transaction")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
 		return "", errors.Wrap(err, "failed to broadcast transaction")
 	}
 

--- a/go/pkg/mayachain/block.go
+++ b/go/pkg/mayachain/block.go
@@ -19,18 +19,22 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 		hs = strconv.Itoa(*height)
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %d", height)
+		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
 	}
 
 	if res.Error != nil {
 		return nil, errors.Errorf("failed to get block: %s: %s", hs, res.Error.Error())
 	}
 
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
+	}
+
 	result := &coretypes.ResultBlock{}
 	if err := tendermintjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Errorf("failed to unmarshal block result: %v: %s", res.Result, res.Error.Error())
+		return nil, errors.Wrapf(err, "failed to unmarshal block result: %v", res.Result)
 	}
 
 	b := &cosmossdk.ResultBlock{
@@ -52,7 +56,7 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 		"order_by": "\"desc\"",
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/block_search")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/block_search")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to search blocks")
 	}
@@ -62,6 +66,10 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 			return &coretypes.ResultBlockSearch{Blocks: []*coretypes.ResultBlock{}, TotalCount: 0}, nil
 		}
 		return nil, errors.Wrap(errors.New(res.Error.Error()), "failed to search blocks")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrap(err, "failed to search blocks")
 	}
 
 	result := &coretypes.ResultBlockSearch{}
@@ -75,13 +83,17 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 func (c *HTTPClient) BlockResults(height int) (cosmossdk.BlockResults, error) {
 	res := &rpctypes.RPCResponse{}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", strconv.Itoa(height)).Get("/block_results")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", strconv.Itoa(height)).Get("/block_results")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
 	if res.Error != nil {
 		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get block results for block: %v", height)
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
 	result := &coretypes.ResultBlockResults{}

--- a/go/pkg/mayachain/block.go
+++ b/go/pkg/mayachain/block.go
@@ -15,21 +15,23 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 	res := &rpctypes.RPCResponse{}
 
 	hs := ""
+	label := "latest"
 	if height != nil {
 		hs = strconv.Itoa(*height)
+		label = hs
 	}
 
 	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
+		return nil, errors.Wrapf(err, "failed to get block: %s", label)
 	}
 
 	if res.Error != nil {
-		return nil, errors.Errorf("failed to get block: %s: %s", hs, res.Error.Error())
+		return nil, errors.Errorf("failed to get block: %s: %s", label, res.Error.Error())
 	}
 
 	if err := cosmossdk.CheckResponse(resp); err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
+		return nil, errors.Wrapf(err, "failed to get block: %s", label)
 	}
 
 	result := &coretypes.ResultBlock{}

--- a/go/pkg/mayachain/block.go
+++ b/go/pkg/mayachain/block.go
@@ -34,7 +34,7 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 
 	result := &coretypes.ResultBlock{}
 	if err := tendermintjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal block result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal block result: %s", res.Result)
 	}
 
 	b := &cosmossdk.ResultBlock{
@@ -74,7 +74,7 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 
 	result := &coretypes.ResultBlockSearch{}
 	if err := tendermintjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal block search result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal block search result: %s", res.Result)
 	}
 
 	return result, nil
@@ -98,7 +98,7 @@ func (c *HTTPClient) BlockResults(height int) (cosmossdk.BlockResults, error) {
 
 	result := &coretypes.ResultBlockResults{}
 	if err := tendermintjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal block result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal block result: %s", res.Result)
 	}
 
 	return &ResultBlockResults{result}, nil

--- a/go/pkg/mayachain/tx.go
+++ b/go/pkg/mayachain/tx.go
@@ -31,7 +31,7 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 		txid = "0x" + txid
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("hash", txid).Get("/tx")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("hash", txid).Get("/tx")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get tx: %s", txid)
 	}
@@ -40,9 +40,13 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get tx: %s", txid)
 	}
 
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get tx: %s", txid)
+	}
+
 	tx := &coretypes.ResultTx{}
 	if err := tendermintjson.Unmarshal(res.Result, tx); err != nil {
-		return nil, errors.Errorf("failed to unmarshal tx result: %v: %s", res.Result, res.Error.Error())
+		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %v", res.Result)
 	}
 
 	return tx, nil
@@ -58,7 +62,7 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 		"order_by": "\"desc\"",
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/tx_search")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/tx_search")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to search txs")
 	}
@@ -68,6 +72,10 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 			return &coretypes.ResultTxSearch{Txs: []*coretypes.ResultTx{}, TotalCount: 0}, nil
 		}
 		return nil, errors.Wrap(errors.New(res.Error.Error()), "failed to search txs")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrap(err, "failed to search txs")
 	}
 
 	result := &coretypes.ResultTxSearch{}
@@ -101,8 +109,12 @@ func (c *HTTPClient) BroadcastTx(rawTx string) (string, error) {
 		} `json:"tx_response"`
 	}
 
-	_, err = c.LCD.R().SetBody(&txtypes.BroadcastTxRequest{TxBytes: txBytes, Mode: txtypes.BroadcastMode_BROADCAST_MODE_SYNC}).SetResult(&res).Post("/cosmos/tx/v1beta1/txs")
+	resp, err := c.LCD.R().SetBody(&txtypes.BroadcastTxRequest{TxBytes: txBytes, Mode: txtypes.BroadcastMode_BROADCAST_MODE_SYNC}).SetResult(&res).Post("/cosmos/tx/v1beta1/txs")
 	if err != nil {
+		return "", errors.Wrap(err, "failed to broadcast transaction")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
 		return "", errors.Wrap(err, "failed to broadcast transaction")
 	}
 

--- a/go/pkg/mayachain/tx.go
+++ b/go/pkg/mayachain/tx.go
@@ -46,7 +46,7 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 
 	tx := &coretypes.ResultTx{}
 	if err := tendermintjson.Unmarshal(res.Result, tx); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %s", res.Result)
 	}
 
 	return tx, nil
@@ -80,7 +80,7 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 
 	result := &coretypes.ResultTxSearch{}
 	if err := tendermintjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal tx search result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal tx search result: %s", res.Result)
 	}
 
 	return result, nil

--- a/go/pkg/thorchain/block.go
+++ b/go/pkg/thorchain/block.go
@@ -34,7 +34,7 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 
 	result := &coretypes.ResultBlock{}
 	if err := cometbftjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Errorf("failed to unmarshal block result: %v", res.Result)
+		return nil, errors.Errorf("failed to unmarshal block result: %s", res.Result)
 	}
 
 	b := &cosmossdk.ResultBlock{
@@ -74,7 +74,7 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 
 	result := &coretypes.ResultBlockSearch{}
 	if err := cometbftjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal block search result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal block search result: %s", res.Result)
 	}
 
 	return result, nil
@@ -98,7 +98,7 @@ func (c *HTTPClient) BlockResults(height int) (cosmossdk.BlockResults, error) {
 
 	result := &coretypes.ResultBlockResults{}
 	if err := cometbftjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal block result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal block result: %s", res.Result)
 	}
 
 	return &ResultBlockResults{result}, nil

--- a/go/pkg/thorchain/block.go
+++ b/go/pkg/thorchain/block.go
@@ -19,13 +19,17 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 		hs = strconv.Itoa(*height)
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %d", height)
+		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
 	}
 
 	if res.Error != nil {
 		return nil, errors.Errorf("failed to get block: %s: %s", hs, res.Error.Error())
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
 	}
 
 	result := &coretypes.ResultBlock{}
@@ -52,7 +56,7 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 		"order_by": "\"desc\"",
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/block_search")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/block_search")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to search blocks")
 	}
@@ -62,6 +66,10 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 			return &coretypes.ResultBlockSearch{Blocks: []*coretypes.ResultBlock{}, TotalCount: 0}, nil
 		}
 		return nil, errors.Wrap(errors.New(res.Error.Error()), "failed to search blocks")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrap(err, "failed to search blocks")
 	}
 
 	result := &coretypes.ResultBlockSearch{}
@@ -75,13 +83,17 @@ func (c *HTTPClient) BlockSearch(query string, page int, pageSize int) (*coretyp
 func (c *HTTPClient) BlockResults(height int) (cosmossdk.BlockResults, error) {
 	res := &rpctypes.RPCResponse{}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", strconv.Itoa(height)).Get("/block_results")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", strconv.Itoa(height)).Get("/block_results")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
 	if res.Error != nil {
 		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get block results for block: %v", height)
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get block results for block: %v", height)
 	}
 
 	result := &coretypes.ResultBlockResults{}

--- a/go/pkg/thorchain/block.go
+++ b/go/pkg/thorchain/block.go
@@ -15,21 +15,23 @@ func (c *HTTPClient) GetBlock(height *int) (*cosmossdk.ResultBlock, error) {
 	res := &rpctypes.RPCResponse{}
 
 	hs := ""
+	label := "latest"
 	if height != nil {
 		hs = strconv.Itoa(*height)
+		label = hs
 	}
 
 	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("height", hs).Get("/block")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
+		return nil, errors.Wrapf(err, "failed to get block: %s", label)
 	}
 
 	if res.Error != nil {
-		return nil, errors.Errorf("failed to get block: %s: %s", hs, res.Error.Error())
+		return nil, errors.Errorf("failed to get block: %s: %s", label, res.Error.Error())
 	}
 
 	if err := cosmossdk.CheckResponse(resp); err != nil {
-		return nil, errors.Wrapf(err, "failed to get block: %s", hs)
+		return nil, errors.Wrapf(err, "failed to get block: %s", label)
 	}
 
 	result := &coretypes.ResultBlock{}

--- a/go/pkg/thorchain/tx.go
+++ b/go/pkg/thorchain/tx.go
@@ -32,7 +32,7 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 		txid = "0x" + txid
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("hash", txid).Get("/tx")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParam("hash", txid).Get("/tx")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get tx: %s", txid)
 	}
@@ -41,9 +41,13 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 		return nil, errors.Wrapf(errors.New(res.Error.Error()), "failed to get tx: %s", txid)
 	}
 
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to get tx: %s", txid)
+	}
+
 	tx := &coretypes.ResultTx{}
 	if err := cometbftjson.Unmarshal(res.Result, tx); err != nil {
-		return nil, errors.Errorf("failed to unmarshal tx result: %v: %s", res.Result, res.Error.Error())
+		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %v", res.Result)
 	}
 
 	return tx, nil
@@ -59,7 +63,7 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 		"order_by": "\"desc\"",
 	}
 
-	_, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/tx_search")
+	resp, err := c.RPC.R().SetResult(res).SetError(res).SetQueryParams(queryParams).Get("/tx_search")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to search txs")
 	}
@@ -69,6 +73,10 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 			return &coretypes.ResultTxSearch{Txs: []*coretypes.ResultTx{}, TotalCount: 0}, nil
 		}
 		return nil, errors.Wrap(errors.New(res.Error.Error()), "failed to search txs")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
+		return nil, errors.Wrap(err, "failed to search txs")
 	}
 
 	result := &coretypes.ResultTxSearch{}
@@ -102,8 +110,12 @@ func (c *HTTPClient) BroadcastTx(rawTx string) (string, error) {
 		} `json:"tx_response"`
 	}
 
-	_, err = c.LCD.R().SetBody(&txtypes.BroadcastTxRequest{TxBytes: txBytes, Mode: txtypes.BroadcastMode_BROADCAST_MODE_SYNC}).SetResult(&res).Post("/cosmos/tx/v1beta1/txs")
+	resp, err := c.LCD.R().SetBody(&txtypes.BroadcastTxRequest{TxBytes: txBytes, Mode: txtypes.BroadcastMode_BROADCAST_MODE_SYNC}).SetResult(&res).Post("/cosmos/tx/v1beta1/txs")
 	if err != nil {
+		return "", errors.Wrap(err, "failed to broadcast transaction")
+	}
+
+	if err := cosmossdk.CheckResponse(resp); err != nil {
 		return "", errors.Wrap(err, "failed to broadcast transaction")
 	}
 

--- a/go/pkg/thorchain/tx.go
+++ b/go/pkg/thorchain/tx.go
@@ -47,7 +47,7 @@ func (c *HTTPClient) GetTx(txid string) (*coretypes.ResultTx, error) {
 
 	tx := &coretypes.ResultTx{}
 	if err := cometbftjson.Unmarshal(res.Result, tx); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal tx result: %s", res.Result)
 	}
 
 	return tx, nil
@@ -81,7 +81,7 @@ func (c *HTTPClient) TxSearch(query string, page int, pageSize int) (*coretypes.
 
 	result := &coretypes.ResultTxSearch{}
 	if err := cometbftjson.Unmarshal(res.Result, result); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal tx search result: %v", res.Result)
+		return nil, errors.Wrapf(err, "failed to unmarshal tx search result: %s", res.Result)
 	}
 
 	return result, nil

--- a/go/shared/cosmossdk/account.go
+++ b/go/shared/cosmossdk/account.go
@@ -23,8 +23,12 @@ func (c *HTTPClient) GetAccount(address string) (*AccountResponse, error) {
 		} `json:"account"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/auth/v1beta1/accounts/%s", address))
+	resp, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/auth/v1beta1/accounts/%s", address))
 	if err != nil {
+		return nil, errors.Wrap(err, "failed to get account")
+	}
+
+	if err := CheckResponse(resp); err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, errors.Wrap(err, "failed to get account")
 	}
 
@@ -48,8 +52,12 @@ func (c *HTTPClient) GetBalance(address string, baseDenom string) (*BalanceRespo
 		Pagination Pagination `json:"pagination"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/bank/v1beta1/balances/%s", address))
+	resp, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/bank/v1beta1/balances/%s", address))
 	if err != nil {
+		return nil, errors.Wrap(err, "failed to get balances")
+	}
+
+	if err := CheckResponse(resp); err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, errors.Wrap(err, "failed to get balances")
 	}
 
@@ -69,8 +77,12 @@ func (c *HTTPClient) GetDelegations(address string, apr *big.Float) ([]Delegatio
 		Pagination Pagination `json:"pagination"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/staking/v1beta1/delegations/%s", address))
+	resp, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/staking/v1beta1/delegations/%s", address))
 	if err != nil {
+		return nil, errors.Wrap(err, "failed to get delegations")
+	}
+
+	if err := CheckResponse(resp); err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, errors.Wrap(err, "failed to get delegations")
 	}
 
@@ -119,8 +131,12 @@ func (c *HTTPClient) GetRedelegations(address string, apr *big.Float) ([]Redeleg
 		Pagination Pagination `json:"pagination"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/staking/v1beta1/delegators/%s/redelegations", address))
+	resp, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/staking/v1beta1/delegators/%s/redelegations", address))
 	if err != nil {
+		return nil, errors.Wrap(err, "failed to get redelegations")
+	}
+
+	if err := CheckResponse(resp); err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, errors.Wrap(err, "failed to get redelegations")
 	}
 
@@ -173,8 +189,12 @@ func (c *HTTPClient) GetUnbondings(address string, baseDenom string, apr *big.Fl
 		Pagination Pagination `json:"pagination"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/staking/v1beta1/delegators/%s/unbonding_delegations", address))
+	resp, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/staking/v1beta1/delegators/%s/unbonding_delegations", address))
 	if err != nil {
+		return nil, errors.Wrap(err, "failed to get unbondings")
+	}
+
+	if err := CheckResponse(resp); err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, errors.Wrap(err, "failed to get unbondings")
 	}
 
@@ -219,9 +239,13 @@ func (c *HTTPClient) GetRewards(address string, apr *big.Float) ([]Reward, error
 		} `json:"total"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/distribution/v1beta1/delegators/%s/rewards", address))
+	resp, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/distribution/v1beta1/delegators/%s/rewards", address))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get unbondings")
+		return nil, errors.Wrap(err, "failed to get rewards")
+	}
+
+	if err := CheckResponse(resp); err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, errors.Wrap(err, "failed to get rewards")
 	}
 
 	rewards := []Reward{}

--- a/go/shared/cosmossdk/bank.go
+++ b/go/shared/cosmossdk/bank.go
@@ -16,8 +16,12 @@ func (c *HTTPClient) GetTotalSupply(denom string) (string, error) {
 		"denom": denom,
 	}
 
-	_, err := c.LCD.R().SetResult(&res).SetQueryParams(queryParams).Get("/cosmos/bank/v1beta1/supply/by_denom")
+	resp, err := c.LCD.R().SetResult(&res).SetQueryParams(queryParams).Get("/cosmos/bank/v1beta1/supply/by_denom")
 	if err != nil {
+		return "0", errors.Wrapf(err, "failed to get total supply of: %s", denom)
+	}
+
+	if err := CheckResponse(resp); err != nil {
 		return "0", errors.Wrapf(err, "failed to get total supply of: %s", denom)
 	}
 
@@ -29,8 +33,12 @@ func (c *HTTPClient) GetAnnualProvisions() (string, error) {
 		AnnualProvisions string `json:"annual_provisions"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get("/cosmos/mint/v1beta1/annual_provisions")
+	resp, err := c.LCD.R().SetResult(&res).Get("/cosmos/mint/v1beta1/annual_provisions")
 	if err != nil {
+		return "0", errors.Wrap(err, "failed to get annual provisions")
+	}
+
+	if err := CheckResponse(resp); err != nil {
 		return "0", errors.Wrap(err, "failed to get annual provisions")
 	}
 
@@ -44,8 +52,12 @@ func (c *HTTPClient) GetCommunityTax() (string, error) {
 		} `json:"params"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get("/cosmos/distribution/v1beta1/params")
+	resp, err := c.LCD.R().SetResult(&res).Get("/cosmos/distribution/v1beta1/params")
 	if err != nil {
+		return "0", errors.Wrap(err, "failed to get community tax")
+	}
+
+	if err := CheckResponse(resp); err != nil {
 		return "0", errors.Wrap(err, "failed to get community tax")
 	}
 
@@ -59,8 +71,12 @@ func (c *HTTPClient) GetBondedTokens() (string, error) {
 		} `json:"pool"`
 	}
 
-	_, err := c.LCD.R().SetResult(&res).Get("/cosmos/staking/v1beta1/pool")
+	resp, err := c.LCD.R().SetResult(&res).Get("/cosmos/staking/v1beta1/pool")
 	if err != nil {
+		return "0", errors.Wrap(err, "failed to get bonded tokens")
+	}
+
+	if err := CheckResponse(resp); err != nil {
 		return "0", errors.Wrap(err, "failed to get bonded tokens")
 	}
 

--- a/go/shared/cosmossdk/gas.go
+++ b/go/shared/cosmossdk/gas.go
@@ -22,15 +22,13 @@ func (c *HTTPClient) GetEstimateGas(rawTx string) (string, error) {
 		} `json:"gas_info"`
 	}{}
 
-	e := &ErrorResponse{}
-
-	r, err := c.LCD.R().SetBody(SimulateRequest{TxBytes: txBytes}).SetResult(res).SetError(e).Post("/cosmos/tx/v1beta1/simulate")
+	resp, err := c.LCD.R().SetBody(SimulateRequest{TxBytes: txBytes}).SetResult(res).Post("/cosmos/tx/v1beta1/simulate")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to estimate gas")
 	}
 
-	if r.Error() != nil {
-		return "", errors.Errorf("failed to estimate gas: %s", e.Msg)
+	if err := CheckResponse(resp); err != nil {
+		return "", errors.Wrap(err, "failed to estimate gas")
 	}
 
 	return res.GasInfo.GasUsed, nil

--- a/go/shared/cosmossdk/response.go
+++ b/go/shared/cosmossdk/response.go
@@ -15,7 +15,9 @@ func CheckResponse(r *resty.Response) error {
 		return errors.New("no response from upstream")
 	}
 
-	if !r.IsError() {
+	// mirror the condition resty uses to populate the result, rather than IsError,
+	// which ignores 3xx. an unfollowed redirect leaves the result zero valued too.
+	if r.IsSuccess() {
 		return nil
 	}
 

--- a/go/shared/cosmossdk/response.go
+++ b/go/shared/cosmossdk/response.go
@@ -8,6 +8,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// grpc-gateway writes the grpc status code into the lcd error body, 5 is codes.NotFound
+const lcdNotFoundCode = 5
+
 var ErrNotFound = errors.New("404 Not Found")
 
 func CheckResponse(r *resty.Response) error {
@@ -15,20 +18,23 @@ func CheckResponse(r *resty.Response) error {
 		return errors.New("no response from upstream")
 	}
 
-	// mirror the condition resty uses to populate the result, rather than IsError,
-	// which ignores 3xx. an unfollowed redirect leaves the result zero valued too.
+	// resty only populates the result on a 2xx with a json or xml body
 	if r.IsSuccess() {
+		ct := r.Header().Get("Content-Type")
+		if !resty.IsJSONType(ct) && !resty.IsXMLType(ct) {
+			return errors.Errorf("%s: unexpected content type: %q", r.Status(), ct)
+		}
+
 		return nil
 	}
 
-	if r.StatusCode() == http.StatusNotFound {
-		return ErrNotFound
-	}
-
-	// cosmos sdk errors use a documented shape, so surface the reason when there is
-	// one. anything else, a proxy generated html page say, is reported by status alone.
 	e := &ErrorResponse{}
 	if err := json.Unmarshal(r.Body(), e); err == nil && e.Msg != "" {
+		// a bare 404 from a proxy or unrouted path is not a missing resource
+		if r.StatusCode() == http.StatusNotFound && e.Code == lcdNotFoundCode {
+			return errors.Wrap(ErrNotFound, e.Msg)
+		}
+
 		return errors.Errorf("%s: %s", r.Status(), e.Msg)
 	}
 

--- a/go/shared/cosmossdk/response.go
+++ b/go/shared/cosmossdk/response.go
@@ -1,0 +1,34 @@
+package cosmossdk
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/pkg/errors"
+)
+
+var ErrNotFound = errors.New("404 Not Found")
+
+func CheckResponse(r *resty.Response) error {
+	if r == nil {
+		return errors.New("no response from upstream")
+	}
+
+	if !r.IsError() {
+		return nil
+	}
+
+	if r.StatusCode() == http.StatusNotFound {
+		return ErrNotFound
+	}
+
+	// cosmos sdk errors use a documented shape, so surface the reason when there is
+	// one. anything else, a proxy generated html page say, is reported by status alone.
+	e := &ErrorResponse{}
+	if err := json.Unmarshal(r.Body(), e); err == nil && e.Msg != "" {
+		return errors.Errorf("%s: %s", r.Status(), e.Msg)
+	}
+
+	return errors.New(r.Status())
+}

--- a/go/shared/cosmossdk/staking.go
+++ b/go/shared/cosmossdk/staking.go
@@ -16,8 +16,12 @@ func (c *HTTPClient) GetValidators(apr *big.Float, cursor string, pageSize int) 
 		"pagination.limit": strconv.Itoa(pageSize),
 	}
 
-	_, err := c.LCD.R().SetResult(&res).SetQueryParams(queryParams).Get("/cosmos/staking/v1beta1/validators")
+	resp, err := c.LCD.R().SetResult(&res).SetQueryParams(queryParams).Get("/cosmos/staking/v1beta1/validators")
 	if err != nil {
+		return nil, errors.Wrap(err, "failed to get validators")
+	}
+
+	if err := CheckResponse(resp); err != nil {
 		return nil, errors.Wrap(err, "failed to get validators")
 	}
 
@@ -26,19 +30,21 @@ func (c *HTTPClient) GetValidators(apr *big.Float, cursor string, pageSize int) 
 		validators = append(validators, *httpValidator(v, apr))
 	}
 
-	resp := &ValidatorsResponse{
+	return &ValidatorsResponse{
 		validators,
 		res.Pagination,
-	}
-
-	return resp, nil
+	}, nil
 }
 
 func (c *HTTPClient) GetValidator(addr string, apr *big.Float) (*Validator, error) {
 	var res QueryValidatorResponse
 
-	_, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/staking/v1beta1/validators/%s", addr))
+	resp, err := c.LCD.R().SetResult(&res).Get(fmt.Sprintf("/cosmos/staking/v1beta1/validators/%s", addr))
 	if err != nil {
+		return nil, errors.Wrap(err, "failed to get validators")
+	}
+
+	if err := CheckResponse(resp); err != nil {
 		return nil, errors.Wrap(err, "failed to get validators")
 	}
 


### PR DESCRIPTION
## Problem

`/account` was returning `{"message":"EOF"}` while upstream was returning 502s.

The EOF was ours. resty only unmarshals into the result struct on a **successful** response, and only returns an error of its own for **transport** failures. Every LCD call checked just that error:

```go
_, err := c.LCD.R().SetResult(&res).Get("/cosmos/mint/v1beta1/annual_provisions")
if err != nil { ... }   // nil on a 502
```

So a 502 gave `err == nil` and a zero-valued struct. `getAPRData()` then fed `""` into `big.Float.Parse("")`, which returns `io.EOF` — rendered to the client as `{"message":"EOF"}`, with the real 502 discarded three layers down.

Two worse cases were silent:

- **`GetAccount` / `GetBalance` returned HTTP 200 with `sequence: 0`, `balance: "0"`.** A wallet signing during an LCD outage would use sequence 0.
- **`BroadcastTx` returned `("", nil)`** — a transaction that never broadcast reported success with an empty txid.

## Change

New `CheckResponse` in `shared/cosmossdk/response.go`, wired into all 34 affected call sites across 12 files and 4 go modules. Errors report the status, plus the cosmos SDK `message` when the body has one:

```
failed to get account: 502 Bad Gateway
failed to get account: 500 Internal Server Error: node is catching up
failed to estimate gas: 400 Bad Request: account sequence mismatch, expected 42, got 41
```

Only the documented cosmos SDK error shape is parsed — proxy-generated HTML and other unpredictable bodies are reported by status alone.

On RPC calls it runs **after** the existing `res.Error` JSON-RPC check, so the more specific CometBFT error still wins and both pagination short-circuits still fire:

| upstream | result |
|---|---|
| 200 + jsonrpc error envelope | `RPC error -32603 - tx not found` |
| 500 + jsonrpc error envelope | `RPC error -32603 - internal error` |
| 200/500 + page out of range | empty result (short circuit preserved) |
| 502 proxy html, no envelope | `502 Bad Gateway` |

The two `/rpc` pass-through proxy call sites already checked status correctly and are untouched.

## Two bugs found on the same path

**Nil-pointer panic**, 4 files. `RPCError.Error()` has a *value* receiver on a `*RPCError` field, and it was called in the unmarshal-failure branch where that pointer is always nil — reachable exactly when a proxy 502 leaves no JSON-RPC envelope and an empty result:

```
502 from proxy (html body)
  before: PANIC: runtime error: invalid memory address or nil pointer dereference
  after:  failed to get tx: 502 Bad Gateway
```

**`GetBlock`** wrapped its error with `%d` on a `*int`, printing a memory address (`63191012901240`). Switched to the height string already used two lines below.

## No regressions

The LCD returns **404** for an address never seen on chain, and the old swallow-everything code was silently relying on that to return `sequence: 0`. A 404 is kept as `ErrNotFound` and tolerated by the six account-scoped lookups in `account.go`:

| upstream | before | after |
|---|---|---|
| 200 | ok | ok |
| **404** | **ok, empty** | **ok, empty** |
| 500 | ok, empty ✗ | error |
| 502 | ok, empty ✗ | error |

Every coinstack (cosmos, thorchain, mayachain) routes account requests through these via `shared/cosmossdk/handler.go`, so none bypass the tolerance.

`GetEstimateGas` and `fees.go` previously surfaced the upstream `message`; that is preserved, now with the status prepended.

**One deliberate behavior change:** `GET /api/v1/validators/{pubkey}` for a well-formed but unknown validator now errors instead of returning 200 with an empty validator object. Malformed addresses are unaffected — middleware already rejects those with a 400.

## Testing

`gofmt` clean. Behavior verified with standalone repros against `httptest` servers covering the account 404/200/500/502 matrix, RPC precedence including both pagination cases, the gas-estimate messages, and the panic. Per `CLAUDE.md` no `go build`/`vet`/tests were run locally — CI validates those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiAPuKxx6JmHDVjkhDg789


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of failed blockchain API requests across block, transaction, account, staking, banking, fee, and gas-estimation operations.
  - Non-successful server responses and unexpected successful response formats now produce actionable errors instead of empty or zero-value results.
  - Missing resources are reported distinctly from other request failures.
  - Improved error context for block, transaction, gas, and rewards-related operations.
  - Validator lookup responses now correctly distinguish missing validators from server errors.

- **Documentation**
  - Documented the validator lookup 404 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->